### PR TITLE
Extract null-skipping helpers into NullSkippingUtils and BaseAggregationFunction; tidy aggregation tests

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/RoaringBitmapUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/RoaringBitmapUtils.java
@@ -57,6 +57,8 @@ public class RoaringBitmapUtils {
   /// Iterates over the ranges of unset bits and calls the consumer for each range. This is more performant to
   /// alternatives like calling [RoaringBitmap#contains(int)] in a loop or cloning and flipping the bitmap before
   /// iterating, especially for sparse bitmaps.
+  ///
+  /// Kept deliberately parallel to [#foldUnset]; see the note there before unifying them.
   /// @param nullIndexIterator an int iterator that returns values in ascending order whose min value is 0.
   public static void forEachUnset(int length, IntIterator nullIndexIterator, BatchConsumer consumer) {
     int prev = 0;
@@ -70,6 +72,44 @@ public class RoaringBitmapUtils {
     if (prev < length) {
       consumer.consume(prev, length);
     }
+  }
+
+  /// Folds over the same ranges [#forEachUnset] walks, threading an accumulator through them.
+  ///
+  /// The walk is written out again rather than sharing one implementation with [#forEachUnset]. Expressing the void
+  /// form in terms of this one would need an adapter lambda capturing the consumer, allocated on every call, and
+  /// expressing this one in terms of the void form would need a mutable box for the accumulator. Both sit on the
+  /// aggregation path, so the two loops are kept side by side here and must be changed together.
+  ///
+  /// @param nullIndexIterator ascending iterator whose emitted indexes are the ones to skip
+  /// @param initialAcum the initial value of the accumulator
+  /// @param <A> the type of the accumulator
+  public static <A> A foldUnset(int length, IntIterator nullIndexIterator, A initialAcum, Reducer<A> reducer) {
+    A acum = initialAcum;
+    int prev = 0;
+    while (nullIndexIterator.hasNext() && prev < length) {
+      int nextNull = Math.min(nullIndexIterator.next(), length);
+      if (nextNull > prev) {
+        acum = reducer.apply(acum, prev, nextNull);
+      }
+      prev = nextNull + 1;
+    }
+    if (prev < length) {
+      acum = reducer.apply(acum, prev, length);
+    }
+    return acum;
+  }
+
+  /// A reducer that folds over consecutive index ranges. The accumulating counterpart of [BatchConsumer].
+  /// @param <A> the type of the accumulator
+  @FunctionalInterface
+  public interface Reducer<A> {
+    /// Applies the reducer to the range of indexes.
+    /// @param acum the current value of the accumulator
+    /// @param fromInclusive the start index (inclusive)
+    /// @param toExclusive the end index (exclusive)
+    /// @return the next value of the accumulator (maybe the same as the input)
+    A apply(A acum, int fromInclusive, int toExclusive);
   }
 
   /// A consumer that is being used to consume batch of indexes.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -72,7 +72,7 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.utils.ByteArray;
 
@@ -671,9 +671,9 @@ public class AggregationFunctionUtils {
   }
 
   private static Long getMinValueLong(DataSource dataSource) {
-    FieldSpec.DataType dataType = dataSource.getDataSourceMetadata().getDataType().getStoredType();
+    DataType dataType = dataSource.getDataSourceMetadata().getDataType().getStoredType();
     Preconditions.checkArgument(
-        dataType == FieldSpec.DataType.LONG || dataType == FieldSpec.DataType.INT,
+        dataType == DataType.LONG || dataType == DataType.INT,
         "MINLONG aggregation function can only be applied to columns of integer types");
     Dictionary dictionary = dataSource.getDictionary();
     if (dictionary != null) {
@@ -691,9 +691,9 @@ public class AggregationFunctionUtils {
   }
 
   private static Long getMaxValueLong(DataSource dataSource) {
-    FieldSpec.DataType dataType = dataSource.getDataSourceMetadata().getDataType().getStoredType();
+    DataType dataType = dataSource.getDataSourceMetadata().getDataType().getStoredType();
     Preconditions.checkArgument(
-        dataType == FieldSpec.DataType.LONG || dataType == FieldSpec.DataType.INT,
+        dataType == DataType.LONG || dataType == DataType.INT,
         "MAXLONG aggregation function can only be applied to columns of integer types");
     Dictionary dictionary = dataSource.getDictionary();
     if (dictionary != null) {
@@ -805,7 +805,7 @@ public class AggregationFunctionUtils {
     Dictionary dictionary = dataSource.getDictionary();
     assert dictionary != null;
     DataSourceMetadata metadata = dataSource.getDataSourceMetadata();
-    if (metadata.getDataType() == FieldSpec.DataType.BYTES) {
+    if (metadata.getDataType() == DataType.BYTES) {
       // Logical BYTES dictionary entries are serialized HyperLogLog objects.
       try {
         QueryThreadContext.checkTerminationAndSampleUsage(explainPlanName);
@@ -829,7 +829,7 @@ public class AggregationFunctionUtils {
     Dictionary dictionary = dataSource.getDictionary();
     assert dictionary != null;
     DataSourceMetadata metadata = dataSource.getDataSourceMetadata();
-    if (metadata.getDataType() == FieldSpec.DataType.BYTES) {
+    if (metadata.getDataType() == DataType.BYTES) {
       // Logical BYTES dictionary entries are serialized HyperLogLogPlus objects.
       try {
         QueryThreadContext.checkTerminationAndSampleUsage(explainPlanName);
@@ -873,7 +873,7 @@ public class AggregationFunctionUtils {
     Dictionary dictionary = dataSource.getDictionary();
     assert dictionary != null;
     DataSourceMetadata metadata = dataSource.getDataSourceMetadata();
-    if (metadata.getDataType() == FieldSpec.DataType.BYTES) {
+    if (metadata.getDataType() == DataType.BYTES) {
       // Logical BYTES dictionary entries are serialized UltraLogLog objects.
       try {
         QueryThreadContext.checkTerminationAndSampleUsage(explainPlanName);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AnyValueAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AnyValueAggregationFunction.java
@@ -35,7 +35,7 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 /// AnyValue aggregation function returns any arbitrary NON-NULL value from the column for each group.
@@ -54,8 +54,8 @@ import org.apache.pinot.spi.data.FieldSpec;
 /// FROM Orders
 /// GROUP BY CustomerID
 /// ```
-public class AnyValueAggregationFunction extends NullableSingleInputAggregationFunction<Object, Comparable<?>> {
-  private static final FieldSpec.DataType[] DATA_TYPE_VALUES = FieldSpec.DataType.values();
+public class AnyValueAggregationFunction extends BaseSingleInputAggregationFunction<Object, Comparable<?>> {
+  private static final DataType[] DATA_TYPE_VALUES = DataType.values();
   // Result type is determined at runtime based on input expression type
   private ColumnDataType _resultType;
 
@@ -208,7 +208,7 @@ public class AnyValueAggregationFunction extends NullableSingleInputAggregationF
   }
 
   /// Get value from dictionary based on data type
-  private Object getDictionaryValue(Dictionary dict, int dictId, FieldSpec.DataType storedType) {
+  private Object getDictionaryValue(Dictionary dict, int dictId, DataType storedType) {
     switch (storedType) {
       case INT:
         return dict.getIntValue(dictId);
@@ -255,26 +255,26 @@ public class AnyValueAggregationFunction extends NullableSingleInputAggregationF
   /// Note: value is never null - null is handled at the serializeIntermediateResult layer
   private byte[] serializeValue(Object value) {
     if (value instanceof Integer) {
-      return serializeFixedValue(FieldSpec.DataType.INT, 4, buffer -> buffer.putInt((Integer) value));
+      return serializeFixedValue(DataType.INT, 4, buffer -> buffer.putInt((Integer) value));
     } else if (value instanceof Long) {
-      return serializeFixedValue(FieldSpec.DataType.LONG, 8, buffer -> buffer.putLong((Long) value));
+      return serializeFixedValue(DataType.LONG, 8, buffer -> buffer.putLong((Long) value));
     } else if (value instanceof Float) {
-      return serializeFixedValue(FieldSpec.DataType.FLOAT, 4, buffer -> buffer.putFloat((Float) value));
+      return serializeFixedValue(DataType.FLOAT, 4, buffer -> buffer.putFloat((Float) value));
     } else if (value instanceof Double) {
-      return serializeFixedValue(FieldSpec.DataType.DOUBLE, 8, buffer -> buffer.putDouble((Double) value));
+      return serializeFixedValue(DataType.DOUBLE, 8, buffer -> buffer.putDouble((Double) value));
     } else if (value instanceof String) {
-      return serializeVariableValue(FieldSpec.DataType.STRING, ((String) value).getBytes(StandardCharsets.UTF_8));
+      return serializeVariableValue(DataType.STRING, ((String) value).getBytes(StandardCharsets.UTF_8));
     } else if (value instanceof BigDecimal) {
-      return serializeVariableValue(FieldSpec.DataType.BIG_DECIMAL, value.toString().getBytes(StandardCharsets.UTF_8));
+      return serializeVariableValue(DataType.BIG_DECIMAL, value.toString().getBytes(StandardCharsets.UTF_8));
     } else if (value instanceof byte[]) {
-      return serializeVariableValue(FieldSpec.DataType.BYTES, (byte[]) value);
+      return serializeVariableValue(DataType.BYTES, (byte[]) value);
     } else {
       throw new IllegalStateException("Unsupported value type for serialization: " + value.getClass().getName());
     }
   }
 
   /// Helper method for serializing fixed-length values
-  private byte[] serializeFixedValue(FieldSpec.DataType dataType, int valueSize, Consumer<ByteBuffer> valueWriter) {
+  private byte[] serializeFixedValue(DataType dataType, int valueSize, Consumer<ByteBuffer> valueWriter) {
     ByteBuffer buffer = ByteBuffer.allocate(4 + valueSize); // 4 bytes for type ordinal + value bytes
     buffer.putInt(dataType.ordinal());
     valueWriter.accept(buffer);
@@ -282,7 +282,7 @@ public class AnyValueAggregationFunction extends NullableSingleInputAggregationF
   }
 
   /// Helper method for serializing variable-length values
-  private byte[] serializeVariableValue(FieldSpec.DataType dataType, byte[] data) {
+  private byte[] serializeVariableValue(DataType dataType, byte[] data) {
     ByteBuffer buffer = ByteBuffer.allocate(8 + data.length); // 4 bytes type ordinal + 4 bytes length + data
     buffer.putInt(dataType.ordinal());
     buffer.putInt(data.length);
@@ -294,7 +294,7 @@ public class AnyValueAggregationFunction extends NullableSingleInputAggregationF
   /// Note: empty buffer (null) is handled at the deserializeIntermediateResult layer
   private Object deserializeValue(ByteBuffer buffer) {
     int typeOrdinal = buffer.getInt();
-    FieldSpec.DataType dataType = DATA_TYPE_VALUES[typeOrdinal];
+    DataType dataType = DATA_TYPE_VALUES[typeOrdinal];
     switch (dataType) {
       case INT:
         return buffer.getInt();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
@@ -35,7 +35,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
-public class AvgAggregationFunction extends NullableSingleInputAggregationFunction<AvgPair, Double> {
+public class AvgAggregationFunction extends BaseSingleInputAggregationFunction<AvgPair, Double> {
   private static final double DEFAULT_FINAL_RESULT = Double.NEGATIVE_INFINITY;
 
   public AvgAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseAggregationFunction.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import javax.annotation.Nullable;
+import org.apache.pinot.common.utils.RoaringBitmapUtils.BatchConsumer;
+import org.apache.pinot.common.utils.RoaringBitmapUtils.Reducer;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.query.aggregation.utils.NullSkippingUtils;
+import org.roaringbitmap.IntIterator;
+
+
+/// Base implementation of [AggregationFunction] carrying the query's null handling option.
+///
+/// Every user-facing aggregation receives the option, so this holds it once along with the convenience methods for
+/// reading only the rows that are not null. Functions reading a single column extend
+/// [BaseSingleInputAggregationFunction]; functions reading several extend this directly and decide for themselves
+/// which column a `null` disqualifies the row on, since that follows from what each column is for.
+///
+/// Code that is not an [AggregationFunction] at all, such as the funnel aggregation strategies, calls
+/// [NullSkippingUtils] directly instead.
+public abstract class BaseAggregationFunction<I, F extends Comparable> implements AggregationFunction<I, F> {
+  protected final boolean _nullHandlingEnabled;
+
+  public BaseAggregationFunction(boolean nullHandlingEnabled) {
+    _nullHandlingEnabled = nullHandlingEnabled;
+  }
+
+  /// Iterates over the non-null ranges of the block and calls the consumer for each range.
+  ///
+  /// Convenience over [NullSkippingUtils], which the multi-input functions call directly since they cannot inherit
+  /// from here.
+  protected void forEachNotNull(int length, BlockValSet blockValSet, BatchConsumer consumer) {
+    NullSkippingUtils.forEachNotNull(_nullHandlingEnabled, length, blockValSet, consumer);
+  }
+
+  /// Iterates over the ranges where neither block is null, for a function pairing a value from each of two columns.
+  protected void forEachNotNull(int length, BlockValSet blockValSet1, BlockValSet blockValSet2,
+      BatchConsumer consumer) {
+    NullSkippingUtils.forEachNotNull(_nullHandlingEnabled, length, blockValSet1, blockValSet2, consumer);
+  }
+
+  protected <A> A foldNotNull(int length, BlockValSet blockValSet, A initialAcum, Reducer<A> reducer) {
+    return NullSkippingUtils.foldNotNull(_nullHandlingEnabled, length, blockValSet, initialAcum, reducer);
+  }
+
+  protected <A> A foldNotNull(int length, @Nullable IntIterator nullIndexIterator, A initialAcum,
+      Reducer<A> reducer) {
+    return NullSkippingUtils.foldNotNull(_nullHandlingEnabled, length, nullIndexIterator, initialAcum, reducer);
+  }
+
+  protected IntIterator orNullIterator(BlockValSet valSet1, BlockValSet valSet2) {
+    return NullSkippingUtils.orNullIterator(_nullHandlingEnabled, valSet1, valSet2);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseBooleanAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseBooleanAggregationFunction.java
@@ -30,13 +30,13 @@ import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.IntGroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 // TODO: change this to implement BaseSingleInputAggregationFunction<Boolean, Boolean> when we get proper
 // handling of booleans in serialization - today this would fail because ColumnDataType#convert assumes
 // that the boolean is encoded as its stored type (an integer)
-public abstract class BaseBooleanAggregationFunction extends NullableSingleInputAggregationFunction<Integer, Integer> {
+public abstract class BaseBooleanAggregationFunction extends BaseSingleInputAggregationFunction<Integer, Integer> {
 
   private final BooleanMerge _merger;
 
@@ -106,7 +106,7 @@ public abstract class BaseBooleanAggregationFunction extends NullableSingleInput
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
-    if (blockValSet.getValueType() != FieldSpec.DataType.BOOLEAN) {
+    if (blockValSet.getValueType() != DataType.BOOLEAN) {
       throw new IllegalArgumentException("Unsupported data type " + getType().getName() + " for "
           + blockValSet.getValueType());
     }
@@ -150,7 +150,7 @@ public abstract class BaseBooleanAggregationFunction extends NullableSingleInput
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
-    if (blockValSet.getValueType() != FieldSpec.DataType.BOOLEAN) {
+    if (blockValSet.getValueType() != DataType.BOOLEAN) {
       throw new IllegalArgumentException("Unsupported data type " + getType().getName() + " for "
           + blockValSet.getValueType());
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctAggregateAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctAggregateAggregationFunction.java
@@ -52,7 +52,7 @@ import org.roaringbitmap.RoaringBitmap;
 /// functions.
 @SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class BaseDistinctAggregateAggregationFunction<T extends Comparable>
-    extends NullableSingleInputAggregationFunction<Set, T> {
+    extends BaseSingleInputAggregationFunction<Set, T> {
   // Use empty IntOpenHashSet as a placeholder for empty result
   private static final IntSet EMPTY_PLACEHOLDER = new IntOpenHashSet();
   private static final byte[] SERIALIZED_EMPTY_PLACEHOLDER =

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctCountSmartSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctCountSmartSketchAggregationFunction.java
@@ -48,7 +48,7 @@ import org.roaringbitmap.RoaringBitmap;
 /// Subclasses provide the sketch-specific behavior (conversion and dictionary handling).
 @SuppressWarnings({"rawtypes", "unchecked"})
 abstract class BaseDistinctCountSmartSketchAggregationFunction
-    extends NullableSingleInputAggregationFunction<Object, Integer> {
+    extends BaseSingleInputAggregationFunction<Object, Integer> {
   // Use empty IntOpenHashSet as a placeholder for empty result
   protected static final IntSet EMPTY_PLACEHOLDER = new IntOpenHashSet();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseSingleInputAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseSingleInputAggregationFunction.java
@@ -27,13 +27,16 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
 
 /// Base implementation of [AggregationFunction] with single input expression.
-public abstract class BaseSingleInputAggregationFunction<I, F extends Comparable> implements AggregationFunction<I, F> {
+public abstract class BaseSingleInputAggregationFunction<I, F extends Comparable>
+    extends BaseAggregationFunction<I, F> {
   protected final ExpressionContext _expression;
 
   /// Constructor for the class.
   ///
   /// @param expression Expression to aggregate on.
-  public BaseSingleInputAggregationFunction(ExpressionContext expression) {
+  /// @param nullHandlingEnabled the query's null handling option, which decides whether null rows are skipped.
+  public BaseSingleInputAggregationFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
+    super(nullHandlingEnabled);
     _expression = expression;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
@@ -33,7 +33,7 @@ import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair
 import org.roaringbitmap.RoaringBitmap;
 
 
-public class CountAggregationFunction extends NullableSingleInputAggregationFunction<Long, Long> {
+public class CountAggregationFunction extends BaseSingleInputAggregationFunction<Long, Long> {
   private static final String COUNT_STAR_RESULT_COLUMN_NAME = "count(*)";
   private static final double DEFAULT_INITIAL_VALUE = 0.0;
   // Special expression used by star-tree to pass in BlockValSet

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CovarianceAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CovarianceAggregationFunction.java
@@ -26,7 +26,6 @@ import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -50,31 +49,18 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 /// The calculations here are based on the second definition shown above.
 /// Sample covariance = covarPop(X, Y) \* besselCorrection
 /// @see <a href="https://en.wikipedia.org/wiki/Bessel%27s_correction">Bessel's correction</a>
-public class CovarianceAggregationFunction implements AggregationFunction<CovarianceTuple, Double> {
+public class CovarianceAggregationFunction extends BaseAggregationFunction<CovarianceTuple, Double> {
   private static final double DEFAULT_FINAL_RESULT = Double.NEGATIVE_INFINITY;
   protected final ExpressionContext _expression1;
   protected final ExpressionContext _expression2;
   protected final boolean _isSample;
-  protected final boolean _nullHandlingEnabled;
 
   public CovarianceAggregationFunction(List<ExpressionContext> arguments, boolean isSample,
       boolean nullHandlingEnabled) {
+    super(nullHandlingEnabled);
     _expression1 = arguments.get(0);
     _expression2 = arguments.get(1);
     _isSample = isSample;
-    _nullHandlingEnabled = nullHandlingEnabled;
-  }
-
-  /// Runs `consumer` over the row ranges where **both** input columns are non-null.
-  ///
-  /// A covariance pairs two values per row, so a row contributes only when neither is null. The null positions of the
-  /// two blocks are merged as a stream rather than into a new bitmap, which keeps this allocation-free on the
-  /// aggregation path.
-  private void forEachNotNull(int length, BlockValSet blockValSet1, BlockValSet blockValSet2,
-      RoaringBitmapUtils.BatchConsumer consumer) {
-    RoaringBitmapUtils.forEachUnset(length,
-        NullableSingleInputAggregationFunction.orNullIterator(_nullHandlingEnabled, blockValSet1, blockValSet2),
-        consumer);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapAggregationFunction.java
@@ -42,8 +42,7 @@ import org.roaringbitmap.RoaringBitmap;
 /// The `DistinctCountBitmapAggregationFunction` calculates the number of distinct values for a given single-value or
 /// multi-value expression using RoaringBitmap. The bitmap stores the actual values for `INT` expression, or hash code
 /// of the values for other data types (values with the same hash code will only be counted once).
-public class DistinctCountBitmapAggregationFunction
-    extends NullableSingleInputAggregationFunction<RoaringBitmap, Integer> {
+public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggregationFunction<RoaringBitmap, Integer> {
 
   public DistinctCountBitmapAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
     this(verifySingleArgument(arguments, "DISTINCT_COUNT_BITMAP"), nullHandlingEnabled);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
@@ -38,7 +38,6 @@ import org.apache.pinot.segment.local.customobject.CpcSketchAccumulator;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.Constants;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.roaringbitmap.PeekableIntIterator;
@@ -82,7 +81,7 @@ import org.roaringbitmap.RoaringBitmap;
 ///     )
 @SuppressWarnings({"rawtypes"})
 public class DistinctCountCPCSketchAggregationFunction
-    extends NullableSingleInputAggregationFunction<CpcSketchAccumulator, Comparable> {
+    extends BaseSingleInputAggregationFunction<CpcSketchAccumulator, Comparable> {
   private static final int DEFAULT_ACCUMULATOR_THRESHOLD = 2;
   protected int _accumulatorThreshold = DEFAULT_ACCUMULATOR_THRESHOLD;
   protected int _lgNominalEntries;
@@ -102,7 +101,7 @@ public class DistinctCountCPCSketchAggregationFunction
           "CPC Sketch Aggregation Function expects the second argument to be a literal (parameters)," + " but got: ",
           secondArgument.getType());
 
-      if (secondArgument.getLiteral().getType() == FieldSpec.DataType.STRING) {
+      if (secondArgument.getLiteral().getType() == DataType.STRING) {
         Parameters parameters = new Parameters(secondArgument.getLiteral().getStringValue());
         // Allows the user to trade-off memory usage for merge CPU; higher values use more memory
         _accumulatorThreshold = parameters.getAccumulatorThreshold();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
@@ -41,7 +41,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
 import org.roaringbitmap.RoaringBitmap;
 
 
-public class DistinctCountHLLAggregationFunction extends NullableSingleInputAggregationFunction<HyperLogLog, Long> {
+public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregationFunction<HyperLogLog, Long> {
   protected final int _log2m;
 
   public DistinctCountHLLAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusAggregationFunction.java
@@ -41,8 +41,7 @@ import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.RoaringBitmap;
 
 
-public class DistinctCountHLLPlusAggregationFunction
-    extends NullableSingleInputAggregationFunction<HyperLogLogPlus, Long> {
+public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggregationFunction<HyperLogLogPlus, Long> {
   // The parameter "p" determines the precision of the sparse list in HyperLogLogPlus.
   protected final int _p;
   // The "sp" parameter specifies the number of standard deviations that the sparse list's precision should be set to.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountOffHeapAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountOffHeapAggregationFunction.java
@@ -42,7 +42,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 /// Aggregation function to compute the count of distinct values for a column using off-heap memory.
 public class DistinctCountOffHeapAggregationFunction
-    extends NullableSingleInputAggregationFunction<BaseOffHeapSet, Integer> {
+    extends BaseSingleInputAggregationFunction<BaseOffHeapSet, Integer> {
   // Use empty OffHeap32BitSet as a placeholder for empty result
   // NOTE: It is okay to close it (multiple times) since we are never adding values into it
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
@@ -33,7 +33,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
 public class DistinctCountRawHLLAggregationFunction
-    extends NullableSingleInputAggregationFunction<HyperLogLog, SerializedHLL> {
+    extends BaseSingleInputAggregationFunction<HyperLogLog, SerializedHLL> {
   private final DistinctCountHLLAggregationFunction _distinctCountHLLAggregationFunction;
 
   public DistinctCountRawHLLAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLPlusAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLPlusAggregationFunction.java
@@ -33,7 +33,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
 public class DistinctCountRawHLLPlusAggregationFunction
-    extends NullableSingleInputAggregationFunction<HyperLogLogPlus, SerializedHLLPlus> {
+    extends BaseSingleInputAggregationFunction<HyperLogLogPlus, SerializedHLLPlus> {
   private final DistinctCountHLLPlusAggregationFunction _distinctCountHLLPlusAggregationFunction;
 
   public DistinctCountRawHLLPlusAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -80,7 +80,7 @@ import org.apache.pinot.sql.parsers.CalciteSqlParser;
 /// E.g. DISTINCT_COUNT_THETA_SKETCH(col, 'nominalEntries=8192')
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class DistinctCountThetaSketchAggregationFunction
-    extends NullableSingleInputAggregationFunction<List<ThetaSketchAccumulator>, Comparable> {
+    extends BaseSingleInputAggregationFunction<List<ThetaSketchAccumulator>, Comparable> {
   private static final String SET_UNION = "setunion";
   private static final String SET_INTERSECT = "setintersect";
   private static final String SET_DIFF = "setdiff";

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountULLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountULLAggregationFunction.java
@@ -42,8 +42,7 @@ import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.RoaringBitmap;
 
 
-public class DistinctCountULLAggregationFunction extends NullableSingleInputAggregationFunction<UltraLogLog,
-    Comparable> {
+public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregationFunction<UltraLogLog, Comparable> {
   protected final int _p;
 
   public DistinctCountULLAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
@@ -37,7 +37,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 /// Use [DistinctCountHLLAggregationFunction] on byte\[\] for serialized HyperLogLog.
 @Deprecated
-public class FastHLLAggregationFunction extends NullableSingleInputAggregationFunction<HyperLogLog, Long> {
+public class FastHLLAggregationFunction extends BaseSingleInputAggregationFunction<HyperLogLog, Long> {
   public static final int DEFAULT_LOG2M = 8;
   private static final int BYTE_TO_CHAR_OFFSET = 129;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstDoubleValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstDoubleValueWithTimeAggregationFunction.java
@@ -21,13 +21,11 @@ package org.apache.pinot.core.query.aggregation.function;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.local.customobject.DoubleLongPair;
 import org.apache.pinot.segment.local.customobject.ValueLongPair;
-import org.roaringbitmap.IntIterator;
 
 
 /// This function is used for FirstWithTime calculations for data column with double type.
@@ -68,8 +66,7 @@ public class FirstDoubleValueWithTimeAggregationFunction extends FirstWithTimeAg
     double[] doubleValues = blockValSet.getDoubleValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         double data = doubleValues[i];
         long time = timeValues[i];
@@ -84,8 +81,7 @@ public class FirstDoubleValueWithTimeAggregationFunction extends FirstWithTimeAg
     double[] doubleValues = blockValSet.getDoubleValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         double value = doubleValues[i];
         long time = timeValues[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstFloatValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstFloatValueWithTimeAggregationFunction.java
@@ -21,13 +21,11 @@ package org.apache.pinot.core.query.aggregation.function;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.local.customobject.FloatLongPair;
 import org.apache.pinot.segment.local.customobject.ValueLongPair;
-import org.roaringbitmap.IntIterator;
 
 
 /// This function is used for FirstWithTime calculations for data column with float type.
@@ -68,8 +66,7 @@ public class FirstFloatValueWithTimeAggregationFunction extends FirstWithTimeAgg
     float[] floatValues = blockValSet.getFloatValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         float data = floatValues[i];
         long time = timeValues[i];
@@ -84,8 +81,7 @@ public class FirstFloatValueWithTimeAggregationFunction extends FirstWithTimeAgg
     float[] floatValues = blockValSet.getFloatValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         float value = floatValues[i];
         long time = timeValues[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstIntValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstIntValueWithTimeAggregationFunction.java
@@ -21,13 +21,11 @@ package org.apache.pinot.core.query.aggregation.function;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.local.customobject.IntLongPair;
 import org.apache.pinot.segment.local.customobject.ValueLongPair;
-import org.roaringbitmap.IntIterator;
 
 
 /// This function is used for FirstWithTime calculations for data column with int/boolean type.
@@ -73,8 +71,7 @@ public class FirstIntValueWithTimeAggregationFunction extends FirstWithTimeAggre
     int[] intValues = blockValSet.getIntValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         int data = intValues[i];
         long time = timeValues[i];
@@ -89,8 +86,7 @@ public class FirstIntValueWithTimeAggregationFunction extends FirstWithTimeAggre
     int[] intValues = blockValSet.getIntValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         int value = intValues[i];
         long time = timeValues[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstLongValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstLongValueWithTimeAggregationFunction.java
@@ -21,13 +21,11 @@ package org.apache.pinot.core.query.aggregation.function;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.local.customobject.LongLongPair;
 import org.apache.pinot.segment.local.customobject.ValueLongPair;
-import org.roaringbitmap.IntIterator;
 
 
 /// This function is used for FirstWithTime calculations for data column with long type.
@@ -68,8 +66,7 @@ public class FirstLongValueWithTimeAggregationFunction extends FirstWithTimeAggr
     long[] longValues = blockValSet.getLongValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         long data = longValues[i];
         long time = timeValues[i];
@@ -84,8 +81,7 @@ public class FirstLongValueWithTimeAggregationFunction extends FirstWithTimeAggr
     long[] longValues = blockValSet.getLongValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         long value = longValues[i];
         long time = timeValues[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstStringValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstStringValueWithTimeAggregationFunction.java
@@ -21,13 +21,11 @@ package org.apache.pinot.core.query.aggregation.function;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.local.customobject.StringLongPair;
 import org.apache.pinot.segment.local.customobject.ValueLongPair;
-import org.roaringbitmap.IntIterator;
 
 
 /// This function is used for FirstWithTime calculations for data column with string type.
@@ -68,8 +66,7 @@ public class FirstStringValueWithTimeAggregationFunction extends FirstWithTimeAg
     String[] stringValues = blockValSet.getStringValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         String data = stringValues[i];
         long time = timeValues[i];
@@ -84,8 +81,7 @@ public class FirstStringValueWithTimeAggregationFunction extends FirstWithTimeAg
     String[] stringValues = blockValSet.getStringValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         String value = stringValues[i];
         long time = timeValues[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstWithTimeAggregationFunction.java
@@ -49,7 +49,7 @@ import org.roaringbitmap.IntIterator;
 /// - dataType: the data type of data column
 @SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class FirstWithTimeAggregationFunction<V extends Comparable<V>>
-    extends NullableSingleInputAggregationFunction<ValueLongPair<V>, V> {
+    extends BaseSingleInputAggregationFunction<ValueLongPair<V>, V> {
   protected final ExpressionContext _timeCol;
   private final ObjectSerDeUtils.ObjectSerDe<? extends ValueLongPair<V>> _objectSerDe;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FourthMomentAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FourthMomentAggregationFunction.java
@@ -35,8 +35,7 @@ import org.apache.pinot.segment.local.customobject.PinotFourthMoment;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
-public class FourthMomentAggregationFunction
-    extends NullableSingleInputAggregationFunction<PinotFourthMoment, Double> {
+public class FourthMomentAggregationFunction extends BaseSingleInputAggregationFunction<PinotFourthMoment, Double> {
 
   private final Type _type;
 
@@ -82,9 +81,6 @@ public class FourthMomentAggregationFunction
     // The moment is created inside the range, so a block with no non-null row leaves the holder untouched and
     // extractFinalResult sees the null that means nothing was aggregated
     forEachNotNull(length, blockValSetMap.get(_expression), (from, to) -> {
-      if (to == from) {
-        return;
-      }
       PinotFourthMoment m4 = aggregationResultHolder.getResult();
       if (m4 == null) {
         m4 = new PinotFourthMoment();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FrequentLongsSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FrequentLongsSketchAggregationFunction.java
@@ -61,7 +61,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 ///
 ///   There is a variation of the function (**FREQUENT_STRINGS_SKETCH**) which accepts STRING type input columns.
 public class FrequentLongsSketchAggregationFunction
-    extends NullableSingleInputAggregationFunction<FrequentLongsSketch, Comparable<?>> {
+    extends BaseSingleInputAggregationFunction<FrequentLongsSketch, Comparable<?>> {
   protected static final int DEFAULT_MAX_MAP_SIZE = 256;
 
   protected int _maxMapSize;
@@ -101,9 +101,6 @@ public class FrequentLongsSketchAggregationFunction
       // The sketch is created inside the range, so a block with no non-null row leaves the holder untouched and
       // extractFinalResult sees the null that means nothing was aggregated
       forEachNotNull(length, valueSet, (from, to) -> {
-        if (to == from) {
-          return;
-        }
         FrequentLongsSketch sketch = getOrCreateSketch(aggregationResultHolder);
         for (int i = from; i < to; i++) {
           sketch.merge(deserializeSketch(bytesValues[i]));
@@ -118,9 +115,6 @@ public class FrequentLongsSketchAggregationFunction
     if (singleValue) {
       long[] longValues = valueSet.getLongValuesSV();
       forEachNotNull(length, valueSet, (from, to) -> {
-        if (to == from) {
-          return;
-        }
         FrequentLongsSketch sketch = getOrCreateSketch(aggregationResultHolder);
         for (int i = from; i < to; i++) {
           sketch.update(longValues[i]);
@@ -129,9 +123,6 @@ public class FrequentLongsSketchAggregationFunction
     } else {
       long[][] longValues = valueSet.getLongValuesMV();
       forEachNotNull(length, valueSet, (from, to) -> {
-        if (to == from) {
-          return;
-        }
         FrequentLongsSketch sketch = getOrCreateSketch(aggregationResultHolder);
         for (int i = from; i < to; i++) {
           for (long value : longValues[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FrequentStringsSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FrequentStringsSketchAggregationFunction.java
@@ -62,7 +62,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 ///
 ///   There is a variation of the function (**FREQUENT_LONGS_SKETCH**) which accept INT and LONG type input columns.
 public class FrequentStringsSketchAggregationFunction
-    extends NullableSingleInputAggregationFunction<FrequentItemsSketch<String>, Comparable<?>> {
+    extends BaseSingleInputAggregationFunction<FrequentItemsSketch<String>, Comparable<?>> {
   protected static final int DEFAULT_MAX_MAP_SIZE = 256;
 
   protected int _maxMapSize;
@@ -103,9 +103,6 @@ public class FrequentStringsSketchAggregationFunction
       // The sketch is created inside the range, so a block with no non-null row leaves the holder untouched and
       // extractFinalResult sees the null that means nothing was aggregated
       forEachNotNull(length, valueSet, (from, to) -> {
-        if (to == from) {
-          return;
-        }
         FrequentItemsSketch<String> sketch = getOrCreateSketch(aggregationResultHolder);
         for (int i = from; i < to; i++) {
           sketch.merge(deserializeSketch(bytesValues[i]));
@@ -117,9 +114,6 @@ public class FrequentStringsSketchAggregationFunction
     if (singleValue) {
       String[] values = valueSet.getStringValuesSV();
       forEachNotNull(length, valueSet, (from, to) -> {
-        if (to == from) {
-          return;
-        }
         FrequentItemsSketch<String> sketch = getOrCreateSketch(aggregationResultHolder);
         for (int i = from; i < to; i++) {
           sketch.update(values[i]);
@@ -128,9 +122,6 @@ public class FrequentStringsSketchAggregationFunction
     } else {
       String[][] values = valueSet.getStringValuesMV();
       forEachNotNull(length, valueSet, (from, to) -> {
-        if (to == from) {
-          return;
-        }
         FrequentItemsSketch<String> sketch = getOrCreateSketch(aggregationResultHolder);
         for (int i = from; i < to; i++) {
           for (String value : values[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/HistogramAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/HistogramAggregationFunction.java
@@ -42,8 +42,7 @@ import org.apache.pinot.spi.utils.ArrayCopyUtils;
 /// usage example:
 /// `Histogram(columnName, ARRAY\[0,1,10,100\])` to specify bins \[0,1), \[1,10), \[10,1000\] or
 /// `Histogram(columnName, 0, 1000, 10)` to specify 10 equal-length bins \[0,100), \[100,200), ..., \[900,1000\]
-public class HistogramAggregationFunction
-    extends NullableSingleInputAggregationFunction<DoubleArrayList, DoubleArrayList> {
+public class HistogramAggregationFunction extends BaseSingleInputAggregationFunction<DoubleArrayList, DoubleArrayList> {
 
   private static final String ARRAY_CONSTRUCTOR = "arrayvalueconstructor";
   private static final int INVALID_BIN = -1;
@@ -148,10 +147,6 @@ public class HistogramAggregationFunction
     return ret;
   }
 
-  /// Find the bin id for the input value. Use division for equal-length bins, and binary search otherwise.
-  ///
-  /// @param val input value
-  /// @return bin id
   /// Counts one value into the supplied histogram, ignoring values that fall outside every bin.
   private void increment(double[] histogram, double value) {
     int binId = getBinId(value);
@@ -160,6 +155,10 @@ public class HistogramAggregationFunction
     }
   }
 
+  /// Find the bin id for the input value. Use division for equal-length bins, and binary search otherwise.
+  ///
+  /// @param val input value
+  /// @return bin id
   private int getBinId(double val) {
     if (val > _upper || val < _lower) {
       return INVALID_BIN;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IdSetAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IdSetAggregationFunction.java
@@ -55,7 +55,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 /// - fpp: Desired false positive probability for the BloomFilter, must be positive and less than 1.0. (Default 0.03)
 ///
 /// Example: IDSET(col, 'sizeThresholdInBytes=1000;expectedInsertions=10000;fpp=0.03')
-public class IdSetAggregationFunction extends NullableSingleInputAggregationFunction<IdSet, String> {
+public class IdSetAggregationFunction extends BaseSingleInputAggregationFunction<IdSet, String> {
   private static final char PARAMETER_DELIMITER = ';';
   private static final char PARAMETER_KEY_VALUE_SEPARATOR = '=';
   private static final String UPPER_CASE_SIZE_THRESHOLD_IN_BYTES = "SIZETHRESHOLDINBYTES";
@@ -140,9 +140,6 @@ public class IdSetAggregationFunction extends NullableSingleInputAggregationFunc
       case INT:
         int[] intValuesSV = blockValSet.getIntValuesSV();
         forEachNotNull(length, blockValSet, (from, to) -> {
-          if (to == from) {
-            return;
-          }
           IdSet idSet = getIdSet(aggregationResultHolder, storedType);
           for (int i = from; i < to; i++) {
             idSet.add(intValuesSV[i]);
@@ -152,9 +149,6 @@ public class IdSetAggregationFunction extends NullableSingleInputAggregationFunc
       case LONG:
         long[] longValuesSV = blockValSet.getLongValuesSV();
         forEachNotNull(length, blockValSet, (from, to) -> {
-          if (to == from) {
-            return;
-          }
           IdSet idSet = getIdSet(aggregationResultHolder, storedType);
           for (int i = from; i < to; i++) {
             idSet.add(longValuesSV[i]);
@@ -164,9 +158,6 @@ public class IdSetAggregationFunction extends NullableSingleInputAggregationFunc
       case FLOAT:
         float[] floatValuesSV = blockValSet.getFloatValuesSV();
         forEachNotNull(length, blockValSet, (from, to) -> {
-          if (to == from) {
-            return;
-          }
           IdSet idSet = getIdSet(aggregationResultHolder, storedType);
           for (int i = from; i < to; i++) {
             idSet.add(floatValuesSV[i]);
@@ -176,9 +167,6 @@ public class IdSetAggregationFunction extends NullableSingleInputAggregationFunc
       case DOUBLE:
         double[] doubleValuesSV = blockValSet.getDoubleValuesSV();
         forEachNotNull(length, blockValSet, (from, to) -> {
-          if (to == from) {
-            return;
-          }
           IdSet idSet = getIdSet(aggregationResultHolder, storedType);
           for (int i = from; i < to; i++) {
             idSet.add(doubleValuesSV[i]);
@@ -188,9 +176,6 @@ public class IdSetAggregationFunction extends NullableSingleInputAggregationFunc
       case STRING:
         String[] stringValuesSV = blockValSet.getStringValuesSV();
         forEachNotNull(length, blockValSet, (from, to) -> {
-          if (to == from) {
-            return;
-          }
           IdSet idSet = getIdSet(aggregationResultHolder, storedType);
           for (int i = from; i < to; i++) {
             idSet.add(stringValuesSV[i]);
@@ -200,9 +185,6 @@ public class IdSetAggregationFunction extends NullableSingleInputAggregationFunc
       case BYTES:
         byte[][] bytesValuesSV = blockValSet.getBytesValuesSV();
         forEachNotNull(length, blockValSet, (from, to) -> {
-          if (to == from) {
-            return;
-          }
           IdSet idSet = getIdSet(aggregationResultHolder, storedType);
           for (int i = from; i < to; i++) {
             idSet.add(bytesValuesSV[i]);
@@ -220,9 +202,6 @@ public class IdSetAggregationFunction extends NullableSingleInputAggregationFunc
       case INT:
         int[][] intValuesMV = blockValSet.getIntValuesMV();
         forEachNotNull(length, blockValSet, (from, to) -> {
-          if (to == from) {
-            return;
-          }
           IdSet idSet = getIdSet(aggregationResultHolder, storedType);
           for (int i = from; i < to; i++) {
             for (int intValue : intValuesMV[i]) {
@@ -234,9 +213,6 @@ public class IdSetAggregationFunction extends NullableSingleInputAggregationFunc
       case LONG:
         long[][] longValuesMV = blockValSet.getLongValuesMV();
         forEachNotNull(length, blockValSet, (from, to) -> {
-          if (to == from) {
-            return;
-          }
           IdSet idSet = getIdSet(aggregationResultHolder, storedType);
           for (int i = from; i < to; i++) {
             for (long longValue : longValuesMV[i]) {
@@ -248,9 +224,6 @@ public class IdSetAggregationFunction extends NullableSingleInputAggregationFunc
       case FLOAT:
         float[][] floatValuesMV = blockValSet.getFloatValuesMV();
         forEachNotNull(length, blockValSet, (from, to) -> {
-          if (to == from) {
-            return;
-          }
           IdSet idSet = getIdSet(aggregationResultHolder, storedType);
           for (int i = from; i < to; i++) {
             for (float floatValue : floatValuesMV[i]) {
@@ -262,9 +235,6 @@ public class IdSetAggregationFunction extends NullableSingleInputAggregationFunc
       case DOUBLE:
         double[][] doubleValuesMV = blockValSet.getDoubleValuesMV();
         forEachNotNull(length, blockValSet, (from, to) -> {
-          if (to == from) {
-            return;
-          }
           IdSet idSet = getIdSet(aggregationResultHolder, storedType);
           for (int i = from; i < to; i++) {
             for (double doubleValue : doubleValuesMV[i]) {
@@ -276,9 +246,6 @@ public class IdSetAggregationFunction extends NullableSingleInputAggregationFunc
       case STRING:
         String[][] stringValuesMV = blockValSet.getStringValuesMV();
         forEachNotNull(length, blockValSet, (from, to) -> {
-          if (to == from) {
-            return;
-          }
           IdSet idSet = getIdSet(aggregationResultHolder, storedType);
           for (int i = from; i < to; i++) {
             for (String stringValue : stringValuesMV[i]) {
@@ -290,9 +257,6 @@ public class IdSetAggregationFunction extends NullableSingleInputAggregationFunc
       case BYTES:
         byte[][][] bytesValuesMV = blockValSet.getBytesValuesMV();
         forEachNotNull(length, blockValSet, (from, to) -> {
-          if (to == from) {
-            return;
-          }
           IdSet idSet = getIdSet(aggregationResultHolder, storedType);
           for (int i = from; i < to; i++) {
             for (byte[] bytesValue : bytesValuesMV[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
@@ -96,7 +96,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
 ///     )
 @SuppressWarnings({"rawtypes"})
 public class IntegerTupleSketchAggregationFunction
-    extends NullableSingleInputAggregationFunction<TupleIntSketchAccumulator, Comparable> {
+    extends BaseSingleInputAggregationFunction<TupleIntSketchAccumulator, Comparable> {
   private static final int DEFAULT_ACCUMULATOR_THRESHOLD = 2;
   final ExpressionContext _expressionContext;
   final IntegerSummarySetOperations _setOps;
@@ -162,9 +162,6 @@ public class IntegerTupleSketchAggregationFunction
     forEachNotNull(length, blockValSet, (from, to) -> {
       // An empty range still reaches here, for a zero-length block. Creating the accumulator for it would mark
       // the holder as aggregated and lose the signal this whole arrangement exists to carry.
-      if (to == from) {
-        return;
-      }
       TupleIntSketchAccumulator tupleIntSketchAccumulator = getAccumulator(aggregationResultHolder);
       for (int i = from; i < to; i++) {
         tupleIntSketchAccumulator.apply(deserializeSketch(bytesValues[i]));

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastDoubleValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastDoubleValueWithTimeAggregationFunction.java
@@ -21,13 +21,11 @@ package org.apache.pinot.core.query.aggregation.function;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.local.customobject.DoubleLongPair;
 import org.apache.pinot.segment.local.customobject.ValueLongPair;
-import org.roaringbitmap.IntIterator;
 
 
 /// This function is used for LastWithTime calculations for data column with double type.
@@ -68,8 +66,7 @@ public class LastDoubleValueWithTimeAggregationFunction extends LastWithTimeAggr
     double[] doubleValues = blockValSet.getDoubleValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         double data = doubleValues[i];
         long time = timeValues[i];
@@ -84,8 +81,7 @@ public class LastDoubleValueWithTimeAggregationFunction extends LastWithTimeAggr
     double[] doubleValues = blockValSet.getDoubleValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         double value = doubleValues[i];
         long time = timeValues[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastFloatValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastFloatValueWithTimeAggregationFunction.java
@@ -21,13 +21,11 @@ package org.apache.pinot.core.query.aggregation.function;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.local.customobject.FloatLongPair;
 import org.apache.pinot.segment.local.customobject.ValueLongPair;
-import org.roaringbitmap.IntIterator;
 
 
 /// This function is used for LastWithTime calculations for data column with float type.
@@ -68,8 +66,7 @@ public class LastFloatValueWithTimeAggregationFunction extends LastWithTimeAggre
     float[] floatValues = blockValSet.getFloatValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         float data = floatValues[i];
         long time = timeValues[i];
@@ -84,8 +81,7 @@ public class LastFloatValueWithTimeAggregationFunction extends LastWithTimeAggre
     float[] floatValues = blockValSet.getFloatValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         float value = floatValues[i];
         long time = timeValues[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastIntValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastIntValueWithTimeAggregationFunction.java
@@ -21,13 +21,11 @@ package org.apache.pinot.core.query.aggregation.function;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.local.customobject.IntLongPair;
 import org.apache.pinot.segment.local.customobject.ValueLongPair;
-import org.roaringbitmap.IntIterator;
 
 
 /// This function is used for LastWithTime calculations for data column with int/boolean type.
@@ -73,8 +71,7 @@ public class LastIntValueWithTimeAggregationFunction extends LastWithTimeAggrega
     int[] intValues = blockValSet.getIntValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         int data = intValues[i];
         long time = timeValues[i];
@@ -89,8 +86,7 @@ public class LastIntValueWithTimeAggregationFunction extends LastWithTimeAggrega
     int[] intValues = blockValSet.getIntValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         int value = intValues[i];
         long time = timeValues[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastLongValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastLongValueWithTimeAggregationFunction.java
@@ -21,13 +21,11 @@ package org.apache.pinot.core.query.aggregation.function;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.local.customobject.LongLongPair;
 import org.apache.pinot.segment.local.customobject.ValueLongPair;
-import org.roaringbitmap.IntIterator;
 
 
 /// This function is used for LastWithTime calculations for data column with long type.
@@ -68,8 +66,7 @@ public class LastLongValueWithTimeAggregationFunction extends LastWithTimeAggreg
     long[] longValues = blockValSet.getLongValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         long data = longValues[i];
         long time = timeValues[i];
@@ -84,8 +81,7 @@ public class LastLongValueWithTimeAggregationFunction extends LastWithTimeAggreg
     long[] longValues = blockValSet.getLongValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         long value = longValues[i];
         long time = timeValues[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastStringValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastStringValueWithTimeAggregationFunction.java
@@ -21,13 +21,11 @@ package org.apache.pinot.core.query.aggregation.function;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.local.customobject.StringLongPair;
 import org.apache.pinot.segment.local.customobject.ValueLongPair;
-import org.roaringbitmap.IntIterator;
 
 
 /// This function is used for LastWithTime calculations for data column with string type.
@@ -68,8 +66,7 @@ public class LastStringValueWithTimeAggregationFunction extends LastWithTimeAggr
     String[] stringValues = blockValSet.getStringValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         String data = stringValues[i];
         long time = timeValues[i];
@@ -84,8 +81,7 @@ public class LastStringValueWithTimeAggregationFunction extends LastWithTimeAggr
     String[] stringValues = blockValSet.getStringValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
 
-    IntIterator nullIdxIterator = orNullIterator(blockValSet, timeValSet);
-    RoaringBitmapUtils.forEachUnset(length, nullIdxIterator, (from, to) -> {
+    forEachNotNull(length, blockValSet, timeValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         String value = stringValues[i];
         long time = timeValues[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastWithTimeAggregationFunction.java
@@ -49,7 +49,7 @@ import org.roaringbitmap.IntIterator;
 /// - dataType: the data type of data column
 @SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class LastWithTimeAggregationFunction<V extends Comparable<V>>
-    extends NullableSingleInputAggregationFunction<ValueLongPair<V>, V> {
+    extends BaseSingleInputAggregationFunction<ValueLongPair<V>, V> {
   protected final ExpressionContext _timeCol;
   private final ObjectSerDeUtils.ObjectSerDe<? extends ValueLongPair<V>> _objectSerDe;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -35,7 +35,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 
 
-public class MaxAggregationFunction extends NullableSingleInputAggregationFunction<Double, Double> {
+public class MaxAggregationFunction extends BaseSingleInputAggregationFunction<Double, Double> {
   protected static final double DEFAULT_INITIAL_VALUE = Double.NEGATIVE_INFINITY;
 
   public MaxAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxLongAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxLongAggregationFunction.java
@@ -33,7 +33,7 @@ import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
-public class MaxLongAggregationFunction extends NullableSingleInputAggregationFunction<Long, Long> {
+public class MaxLongAggregationFunction extends BaseSingleInputAggregationFunction<Long, Long> {
   protected static final long DEFAULT_INITIAL_VALUE = Long.MIN_VALUE;
 
   public MaxLongAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunction.java
@@ -32,7 +32,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 
 
-public class MaxStringAggregationFunction extends NullableSingleInputAggregationFunction<String, String> {
+public class MaxStringAggregationFunction extends BaseSingleInputAggregationFunction<String, String> {
 
   public MaxStringAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
     super(verifySingleArgument(arguments, "MAXSTRING"), nullHandlingEnabled);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
@@ -35,7 +35,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 
 
-public class MinAggregationFunction extends NullableSingleInputAggregationFunction<Double, Double> {
+public class MinAggregationFunction extends BaseSingleInputAggregationFunction<Double, Double> {
   protected static final double DEFAULT_VALUE = Double.POSITIVE_INFINITY;
 
   public MinAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinLongAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinLongAggregationFunction.java
@@ -33,7 +33,7 @@ import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
-public class MinLongAggregationFunction extends NullableSingleInputAggregationFunction<Long, Long> {
+public class MinLongAggregationFunction extends BaseSingleInputAggregationFunction<Long, Long> {
   protected static final Long DEFAULT_VALUE = Long.MAX_VALUE;
 
   public MinLongAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -35,7 +35,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
-public class MinMaxRangeAggregationFunction extends NullableSingleInputAggregationFunction<MinMaxRangePair, Double> {
+public class MinMaxRangeAggregationFunction extends BaseSingleInputAggregationFunction<MinMaxRangePair, Double> {
   private static final double DEFAULT_FINAL_RESULT = Double.NEGATIVE_INFINITY;
 
   public MinMaxRangeAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinStringAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinStringAggregationFunction.java
@@ -32,7 +32,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 
 
-public class MinStringAggregationFunction extends NullableSingleInputAggregationFunction<String, String> {
+public class MinStringAggregationFunction extends BaseSingleInputAggregationFunction<String, String> {
 
   public MinStringAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
     super(verifySingleArgument(arguments, "MINSTRING"), nullHandlingEnabled);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ModeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ModeAggregationFunction.java
@@ -57,8 +57,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 /// - Expression: expression that contains the column to be calculated mode on, can be any Numeric column
 /// - MultiModeReducerType (optional): the reducer to use in case of multiple modes present in data
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class ModeAggregationFunction
-    extends NullableSingleInputAggregationFunction<Map<? extends Number, Long>, Double> {
+public class ModeAggregationFunction extends BaseSingleInputAggregationFunction<Map<? extends Number, Long>, Double> {
 
   private static final double DEFAULT_FINAL_RESULT = Double.NEGATIVE_INFINITY;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ParentAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ParentAggregationFunction.java
@@ -29,12 +29,13 @@ import org.apache.pinot.spi.utils.CommonConstants;
 /// whose result is a nested data block containing multiple columns, each of which corresponds to a child
 /// aggregation function's result.
 public abstract class ParentAggregationFunction<I, F extends ParentAggregationFunctionResultObject>
-    implements AggregationFunction<I, F> {
+    extends BaseAggregationFunction<I, F> {
 
   protected static final int PARENT_AGGREGATION_FUNCTION_ID_OFFSET = 0;
   protected List<ExpressionContext> _arguments;
 
-  ParentAggregationFunction(List<ExpressionContext> arguments) {
+  ParentAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(nullHandlingEnabled);
     _arguments = arguments;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ParentExprMinMaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ParentExprMinMaxAggregationFunction.java
@@ -26,13 +26,14 @@ import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
+import org.apache.pinot.common.utils.RoaringBitmapUtils.BatchConsumer;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.utils.NullSkippingUtils;
 import org.apache.pinot.core.query.aggregation.utils.exprminmax.ExprMinMaxMeasuringValSetWrapper;
 import org.apache.pinot.core.query.aggregation.utils.exprminmax.ExprMinMaxObject;
 import org.apache.pinot.core.query.aggregation.utils.exprminmax.ExprMinMaxProjectionValSetWrapper;
@@ -56,7 +57,6 @@ public class ParentExprMinMaxAggregationFunction extends ParentAggregationFuncti
   private final int _numMeasuringColumns;
   // number of columns that we project based on the min/max value
   private final int _numProjectionColumns;
-  private final boolean _nullHandlingEnabled;
 
   // The following variable need to be initialized
 
@@ -74,9 +74,8 @@ public class ParentExprMinMaxAggregationFunction extends ParentAggregationFuncti
   public ParentExprMinMaxAggregationFunction(List<ExpressionContext> arguments, boolean isMax,
       boolean nullHandlingEnabled) {
 
-    super(arguments);
+    super(arguments, nullHandlingEnabled);
     _isMax = isMax;
-    _nullHandlingEnabled = nullHandlingEnabled;
     _functionIdContext = arguments.get(0);
 
     _numMeasuringColumnContext = arguments.get(1);
@@ -168,16 +167,8 @@ public class ParentExprMinMaxAggregationFunction extends ParentAggregationFuncti
   /// row, so a null there does not disqualify it. With the option disabled the whole block is one range, which is what
   /// this function did unconditionally before.
   private void forEachNotNullMeasuring(int length, Map<ExpressionContext, BlockValSet> blockValSetMap,
-      RoaringBitmapUtils.BatchConsumer consumer) {
-    RoaringBitmap nullBitmap = measuringNullBitmap(blockValSetMap);
-    if (nullBitmap == null) {
-      consumer.consume(0, length);
-      return;
-    }
-    // Skip if the entire block is null
-    if (!nullBitmap.contains(0, length)) {
-      RoaringBitmapUtils.forEachUnset(length, nullBitmap.getIntIterator(), consumer);
-    }
+      BatchConsumer consumer) {
+    NullSkippingUtils.forEachNotNull(_nullHandlingEnabled, length, measuringNullBitmap(blockValSetMap), consumer);
   }
 
   /// Returns the union of the measuring columns' null bitmaps, or `null` when no row is null.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
@@ -34,7 +34,7 @@ import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
-public class PercentileAggregationFunction extends NullableSingleInputAggregationFunction<DoubleArrayList, Double> {
+public class PercentileAggregationFunction extends BaseSingleInputAggregationFunction<DoubleArrayList, Double> {
   private static final double DEFAULT_FINAL_RESULT = Double.NEGATIVE_INFINITY;
 
   //version 0 functions specified in the of form PERCENTILE<2-digits>(column)

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
@@ -34,7 +34,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
-public class PercentileEstAggregationFunction extends NullableSingleInputAggregationFunction<QuantileDigest, Long> {
+public class PercentileEstAggregationFunction extends BaseSingleInputAggregationFunction<QuantileDigest, Long> {
   public static final double DEFAULT_MAX_ERROR = 0.05;
 
   //version 0 functions specified in the of form PERCENTILEEST<2-digits>(column)

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileKLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileKLLAggregationFunction.java
@@ -57,7 +57,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
 ///   There is a variation of the function (**PERCENTILE_RAW_KLL**) that returns the Base64 encoded
 ///   sketch object to be used externally.
 public class PercentileKLLAggregationFunction
-    extends NullableSingleInputAggregationFunction<KllDoublesSketch, Comparable<?>> {
+    extends BaseSingleInputAggregationFunction<KllDoublesSketch, Comparable<?>> {
 
   protected final double _percentile;
   protected int _kValue;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawEstAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawEstAggregationFunction.java
@@ -49,7 +49,8 @@ public class PercentileRawEstAggregationFunction
 
   protected PercentileRawEstAggregationFunction(ExpressionContext expression,
       PercentileEstAggregationFunction percentileEstAggregationFunction) {
-    super(expression);
+    // This wrapper only serializes what the delegate produced, so the delegate owns the option
+    super(expression, percentileEstAggregationFunction._nullHandlingEnabled);
     _percentileEstAggregationFunction = percentileEstAggregationFunction;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawTDigestAggregationFunction.java
@@ -58,7 +58,8 @@ public class PercentileRawTDigestAggregationFunction
 
   protected PercentileRawTDigestAggregationFunction(ExpressionContext expression,
       PercentileTDigestAggregationFunction percentileTDigestAggregationFunction) {
-    super(expression);
+    // This wrapper only serializes what the delegate produced, so the delegate owns the option
+    super(expression, percentileTDigestAggregationFunction._nullHandlingEnabled);
     _percentileTDigestAggregationFunction = percentileTDigestAggregationFunction;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunction.java
@@ -52,7 +52,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 ///              means never convert.
 /// - compression: Compression for the converted TDigest, 100 by default.
 /// Example of third argument: 'threshold=10000;compression=50'
-public class PercentileSmartTDigestAggregationFunction extends NullableSingleInputAggregationFunction<Object, Double> {
+public class PercentileSmartTDigestAggregationFunction extends BaseSingleInputAggregationFunction<Object, Double> {
   private static final double DEFAULT_FINAL_RESULT = Double.NEGATIVE_INFINITY;
 
   private final double _percentile;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
@@ -41,7 +41,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 /// TODO: Decided not to support custom compression for version 0 queries as it seems to be the older syntax and
 ///       requires extra handling for two argument PERCENTILE functions to assess if v0 or v1. This can be revisited
 ///       later if the need arises
-public class PercentileTDigestAggregationFunction extends NullableSingleInputAggregationFunction<TDigest, Double> {
+public class PercentileTDigestAggregationFunction extends BaseSingleInputAggregationFunction<TDigest, Double> {
   public static final int DEFAULT_TDIGEST_COMPRESSION = 100;
 
   // version 0 functions specified in the of form PERCENTILETDIGEST<2-digits>(column). Uses default compression of 100

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SegmentPartitionedDistinctCountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SegmentPartitionedDistinctCountAggregationFunction.java
@@ -47,8 +47,7 @@ import org.roaringbitmap.RoaringBitmap;
 ///
 /// This function calculates the exact number of distinct values within the segment, then simply sums up the results
 /// from different segments to get the final result.
-public class SegmentPartitionedDistinctCountAggregationFunction extends NullableSingleInputAggregationFunction<Long,
-    Long> {
+public class SegmentPartitionedDistinctCountAggregationFunction extends BaseSingleInputAggregationFunction<Long, Long> {
 
   public SegmentPartitionedDistinctCountAggregationFunction(List<ExpressionContext> arguments,
       boolean nullHandlingEnabled) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/StUnionAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/StUnionAggregationFunction.java
@@ -39,7 +39,7 @@ import org.locationtech.jts.geom.util.GeometryCombiner;
 import org.locationtech.jts.operation.union.UnaryUnionOp;
 
 
-public class StUnionAggregationFunction extends NullableSingleInputAggregationFunction<Geometry, ByteArray> {
+public class StUnionAggregationFunction extends BaseSingleInputAggregationFunction<Geometry, ByteArray> {
 
   public StUnionAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
     super(verifySingleArgument(arguments, "ST_UNION"), nullHandlingEnabled);
@@ -76,9 +76,6 @@ public class StUnionAggregationFunction extends NullableSingleInputAggregationFu
     // The holder is written only from inside the range, so a block with no non-null row leaves it untouched and
     // extractFinalResult sees the null that means nothing was aggregated
     forEachNotNull(length, blockValSet, (from, to) -> {
-      if (to == from) {
-        return;
-      }
       Geometry geometry = aggregationResultHolder.getResult();
       for (int i = from; i < to; i++) {
         geometry = union(geometry, GeometrySerializer.deserialize(bytesArray[i]));
@@ -91,9 +88,6 @@ public class StUnionAggregationFunction extends NullableSingleInputAggregationFu
   private void aggregateMV(int length, AggregationResultHolder aggregationResultHolder, BlockValSet blockValSet) {
     byte[][][] bytesArrays = blockValSet.getBytesValuesMV();
     forEachNotNull(length, blockValSet, (from, to) -> {
-      if (to == from) {
-        return;
-      }
       Geometry geometry = aggregationResultHolder.getResult();
       for (int i = from; i < to; i++) {
         for (byte[] bytes : bytesArrays[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -35,7 +35,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 
 
-public class SumAggregationFunction extends NullableSingleInputAggregationFunction<Double, Double> {
+public class SumAggregationFunction extends BaseSingleInputAggregationFunction<Double, Double> {
   protected static final double DEFAULT_VALUE = 0.0;
 
   public SumAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumIntAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumIntAggregationFunction.java
@@ -42,7 +42,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 /// - Minimal object allocations
 /// - Optimized for the specific case of INT column aggregation
 /// - Proper null handling support using foldNotNull and forEachNotNull
-public class SumIntAggregationFunction extends NullableSingleInputAggregationFunction<Long, Long> {
+public class SumIntAggregationFunction extends BaseSingleInputAggregationFunction<Long, Long> {
   public static final String FUNCTION_NAME = "sumInt";
   private static final long DEFAULT_VALUE = 0L;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumLongAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumLongAggregationFunction.java
@@ -42,7 +42,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 /// - Minimal object allocations
 /// - Optimized for the specific case of LONG column aggregation
 /// - Proper null handling support using foldNotNull and forEachNotNull
-public class SumLongAggregationFunction extends NullableSingleInputAggregationFunction<Long, Long> {
+public class SumLongAggregationFunction extends BaseSingleInputAggregationFunction<Long, Long> {
   public static final String FUNCTION_NAME = "SUMLONG";
   private static final long DEFAULT_VALUE = 0L;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumPrecisionAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumPrecisionAggregationFunction.java
@@ -47,7 +47,7 @@ import org.apache.pinot.spi.utils.BigDecimalUtils;
 /// - Expression: expression that contains the values to be summed up, can be serialized BigDecimal objects
 /// - Precision (optional): precision to be set to the final result
 /// - Scale (optional): scale to be set to the final result
-public class SumPrecisionAggregationFunction extends NullableSingleInputAggregationFunction<BigDecimal, BigDecimal> {
+public class SumPrecisionAggregationFunction extends BaseSingleInputAggregationFunction<BigDecimal, BigDecimal> {
   private final Integer _precision;
   private final Integer _scale;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/TimeSeriesAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/TimeSeriesAggregationFunction.java
@@ -33,7 +33,6 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
@@ -74,7 +73,11 @@ import org.apache.pinot.tsdb.spi.series.TimeSeriesBuilderFactoryProvider;
 /// ```
 /// timeReferencePointInSeconds = firstBucketValue - bucketSizeInSeconds
 /// ```
-public class TimeSeriesAggregationFunction implements AggregationFunction<BaseTimeSeriesBuilder, DoubleArrayList> {
+///
+/// Both the value and the timestamp gate a row when null handling is on. A null value has nothing to add to its
+/// bucket, and a null timestamp leaves the point with no bucket to land in, so either one makes the row
+/// uncountable rather than merely incomplete.
+public class TimeSeriesAggregationFunction extends BaseAggregationFunction<BaseTimeSeriesBuilder, DoubleArrayList> {
   private final TimeSeriesBuilderFactory _factory;
   private final AggInfo _aggInfo;
   private final ExpressionContext _valueExpression;
@@ -83,7 +86,6 @@ public class TimeSeriesAggregationFunction implements AggregationFunction<BaseTi
   private final long _timeReferencePoint;
   private final long _timeOffset;
   private final long _timeBucketDivisor;
-  private final boolean _nullHandlingEnabled;
 
   /// Arguments are as shown below:
   ///
@@ -92,6 +94,7 @@ public class TimeSeriesAggregationFunction implements AggregationFunction<BaseTi
   ///     bucketLenSeconds, numBuckets, "aggParam1=value1")
   /// ```
   public TimeSeriesAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(nullHandlingEnabled);
     // Initialize temporary variables.
     Preconditions.checkArgument(arguments.size() == 10, "Expected 10 arguments for time-series agg");
     String language = arguments.get(0).getLiteral().getStringValue();
@@ -114,7 +117,6 @@ public class TimeSeriesAggregationFunction implements AggregationFunction<BaseTi
     _timeReferencePoint = timeUnit.convert(Duration.ofSeconds(firstBucketValue - bucketWindowSeconds));
     _timeOffset = timeUnit.convert(Duration.ofSeconds(offsetSeconds));
     _timeBucketDivisor = timeUnit.convert(_timeBuckets.getBucketSize());
-    _nullHandlingEnabled = nullHandlingEnabled;
   }
 
   @Override
@@ -234,18 +236,6 @@ public class TimeSeriesAggregationFunction implements AggregationFunction<BaseTi
   @Override
   public String toExplainString() {
     return "TIME_SERIES";
-  }
-
-  /// Runs `consumer` over the row ranges where both the value and the timestamp are non-null.
-  ///
-  /// Both columns gate the row. A null value has nothing to add to its bucket, and a null timestamp leaves the point
-  /// with no bucket to land in, so either one makes the row uncountable rather than merely incomplete. With the option
-  /// disabled the whole block is one range, which is what this function did unconditionally before.
-  private void forEachNotNull(int length, BlockValSet valueBlockValSet, BlockValSet timeBlockValSet,
-      RoaringBitmapUtils.BatchConsumer consumer) {
-    RoaringBitmapUtils.forEachUnset(length,
-        NullableSingleInputAggregationFunction.orNullIterator(_nullHandlingEnabled, valueBlockValSet, timeBlockValSet),
-        consumer);
   }
 
   /// Returns the holder's series builder, creating and storing one on first use.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/VarianceAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/VarianceAggregationFunction.java
@@ -40,7 +40,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 /// The algorithm to compute variance is based on "Updating Formulae and a Pairwise Algorithm for Computing
 /// Sample Variances" by Chan et al. Please refer to the "Parallel Algorithm" section from
 /// - [this wiki](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm)
-public class VarianceAggregationFunction extends NullableSingleInputAggregationFunction<VarianceTuple, Double> {
+public class VarianceAggregationFunction extends BaseSingleInputAggregationFunction<VarianceTuple, Double> {
   private static final double DEFAULT_FINAL_RESULT = Double.NEGATIVE_INFINITY;
   protected final boolean _isSample;
   protected final boolean _isStdDev;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctIntFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctIntFunction.java
@@ -27,11 +27,11 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class ArrayAggDistinctIntFunction extends BaseArrayAggIntFunction<IntSet> {
-  public ArrayAggDistinctIntFunction(ExpressionContext expression, FieldSpec.DataType dataType,
+  public ArrayAggDistinctIntFunction(ExpressionContext expression, DataType dataType,
       boolean nullHandlingEnabled) {
     super(expression, dataType, nullHandlingEnabled);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctLongFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctLongFunction.java
@@ -27,11 +27,11 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class ArrayAggDistinctLongFunction extends BaseArrayAggLongFunction<LongSet> {
-  public ArrayAggDistinctLongFunction(ExpressionContext expression, FieldSpec.DataType dataType,
+  public ArrayAggDistinctLongFunction(ExpressionContext expression, DataType dataType,
       boolean nullHandlingEnabled) {
     super(expression, dataType, nullHandlingEnabled);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggIntFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggIntFunction.java
@@ -26,11 +26,11 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class ArrayAggIntFunction extends BaseArrayAggIntFunction<IntArrayList> {
-  public ArrayAggIntFunction(ExpressionContext expression, FieldSpec.DataType dataType, boolean nullHandlingEnabled) {
+  public ArrayAggIntFunction(ExpressionContext expression, DataType dataType, boolean nullHandlingEnabled) {
     super(expression, dataType, nullHandlingEnabled);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggLongFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggLongFunction.java
@@ -26,11 +26,11 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class ArrayAggLongFunction extends BaseArrayAggLongFunction<LongArrayList> {
-  public ArrayAggLongFunction(ExpressionContext expression, FieldSpec.DataType dataType, boolean nullHandlingEnabled) {
+  public ArrayAggLongFunction(ExpressionContext expression, DataType dataType, boolean nullHandlingEnabled) {
     super(expression, dataType, nullHandlingEnabled);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggBigDecimalFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggBigDecimalFunction.java
@@ -25,13 +25,13 @@ import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public abstract class BaseArrayAggBigDecimalFunction<I extends ObjectCollection<BigDecimal>>
     extends BaseArrayAggFunction<I, ObjectArrayList<BigDecimal>> {
   public BaseArrayAggBigDecimalFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression, FieldSpec.DataType.BIG_DECIMAL, nullHandlingEnabled);
+    super(expression, DataType.BIG_DECIMAL, nullHandlingEnabled);
   }
 
   abstract void setGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey, BigDecimal value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggDoubleFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggDoubleFunction.java
@@ -24,13 +24,13 @@ import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public abstract class BaseArrayAggDoubleFunction<I extends DoubleCollection>
     extends BaseArrayAggFunction<I, DoubleArrayList> {
   public BaseArrayAggDoubleFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression, FieldSpec.DataType.DOUBLE, nullHandlingEnabled);
+    super(expression, DataType.DOUBLE, nullHandlingEnabled);
   }
 
   abstract void setGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey, double value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggFloatFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggFloatFunction.java
@@ -24,13 +24,13 @@ import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public abstract class BaseArrayAggFloatFunction<I extends FloatCollection>
     extends BaseArrayAggFunction<I, FloatArrayList> {
   public BaseArrayAggFloatFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression, FieldSpec.DataType.FLOAT, nullHandlingEnabled);
+    super(expression, DataType.FLOAT, nullHandlingEnabled);
   }
 
   abstract void setGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey, float value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggFunction.java
@@ -23,19 +23,18 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.function.NullableSingleInputAggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.BaseSingleInputAggregationFunction;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
-public abstract class BaseArrayAggFunction<I, F extends Comparable>
-    extends NullableSingleInputAggregationFunction<I, F> {
+public abstract class BaseArrayAggFunction<I, F extends Comparable> extends BaseSingleInputAggregationFunction<I, F> {
 
   private final DataSchema.ColumnDataType _resultColumnType;
 
-  public BaseArrayAggFunction(ExpressionContext expression, FieldSpec.DataType dataType, boolean nullHandlingEnabled) {
+  public BaseArrayAggFunction(ExpressionContext expression, DataType dataType, boolean nullHandlingEnabled) {
     super(expression, nullHandlingEnabled);
     _resultColumnType = DataSchema.ColumnDataType.fromDataTypeMV(dataType);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggIntFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggIntFunction.java
@@ -24,12 +24,12 @@ import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public abstract class BaseArrayAggIntFunction<I extends IntCollection>
     extends BaseArrayAggFunction<I, IntArrayList> {
-  public BaseArrayAggIntFunction(ExpressionContext expression, FieldSpec.DataType dataType,
+  public BaseArrayAggIntFunction(ExpressionContext expression, DataType dataType,
       boolean nullHandlingEnabled) {
     super(expression, dataType, nullHandlingEnabled);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggLongFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggLongFunction.java
@@ -24,12 +24,12 @@ import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public abstract class BaseArrayAggLongFunction<I extends LongCollection>
     extends BaseArrayAggFunction<I, LongArrayList> {
-  public BaseArrayAggLongFunction(ExpressionContext expression, FieldSpec.DataType dataType,
+  public BaseArrayAggLongFunction(ExpressionContext expression, DataType dataType,
       boolean nullHandlingEnabled) {
     super(expression, dataType, nullHandlingEnabled);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggStringFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggStringFunction.java
@@ -25,13 +25,13 @@ import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public abstract class BaseArrayAggStringFunction<I extends ObjectCollection<String>>
     extends BaseArrayAggFunction<I, ObjectArrayList<String>> {
   public BaseArrayAggStringFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression, FieldSpec.DataType.STRING, nullHandlingEnabled);
+    super(expression, DataType.STRING, nullHandlingEnabled);
   }
 
   abstract void setGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey, String value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ListAggFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ListAggFunction.java
@@ -31,13 +31,13 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.function.NullableSingleInputAggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.BaseSingleInputAggregationFunction;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
-public class ListAggFunction extends NullableSingleInputAggregationFunction<ObjectCollection<String>, String> {
+public class ListAggFunction extends BaseSingleInputAggregationFunction<ObjectCollection<String>, String> {
 
   private final String _separator;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/SumArrayDoubleAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/SumArrayDoubleAggregationFunction.java
@@ -29,14 +29,14 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.function.NullableSingleInputAggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.BaseSingleInputAggregationFunction;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
 public class SumArrayDoubleAggregationFunction
-    extends NullableSingleInputAggregationFunction<DoubleArrayList, DoubleArrayList> {
+    extends BaseSingleInputAggregationFunction<DoubleArrayList, DoubleArrayList> {
 
   public SumArrayDoubleAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
     super(verifySingleArgument(arguments, "SUM_ARRAY"), nullHandlingEnabled);
@@ -65,9 +65,6 @@ public class SumArrayDoubleAggregationFunction
     // The accumulator is created inside the range, so a block with no non-null row leaves the holder untouched and
     // extractFinalResult sees the null that means nothing was aggregated
     forEachNotNull(length, blockValSet, (from, to) -> {
-      if (to == from) {
-        return;
-      }
       DoubleArrayList result = aggregationResultHolder.getResult();
       if (result == null) {
         result = new DoubleArrayList();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/SumArrayLongAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/SumArrayLongAggregationFunction.java
@@ -29,14 +29,14 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.function.NullableSingleInputAggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.BaseSingleInputAggregationFunction;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
 public class SumArrayLongAggregationFunction
-    extends NullableSingleInputAggregationFunction<LongArrayList, LongArrayList> {
+    extends BaseSingleInputAggregationFunction<LongArrayList, LongArrayList> {
 
   public SumArrayLongAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
     super(verifySingleArgument(arguments, "SUM_ARRAY"), nullHandlingEnabled);
@@ -65,9 +65,6 @@ public class SumArrayLongAggregationFunction
     // The accumulator is created inside the range, so a block with no non-null row leaves the holder untouched and
     // extractFinalResult sees the null that means nothing was aggregated
     forEachNotNull(length, blockValSet, (from, to) -> {
-      if (to == from) {
-        return;
-      }
       LongArrayList result = aggregationResultHolder.getResult();
       if (result == null) {
         result = new LongArrayList();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/AggregationStrategy.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/AggregationStrategy.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.utils.NullSkippingUtils;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -311,15 +312,7 @@ public abstract class AggregationStrategy<A> {
   /// a composite key a null in any component leaves the whole key undefined, so the row is skipped.
   private void forEachNotNullCorrelation(int length, Map<ExpressionContext, BlockValSet> blockValSetMap,
       RoaringBitmapUtils.BatchConsumer consumer) {
-    RoaringBitmap nullBitmap = correlationNullBitmap(blockValSetMap);
-    if (nullBitmap == null) {
-      consumer.consume(0, length);
-      return;
-    }
-    // Skip if the entire block is null
-    if (!nullBitmap.contains(0, length)) {
-      RoaringBitmapUtils.forEachUnset(length, nullBitmap.getIntIterator(), consumer);
-    }
+    NullSkippingUtils.forEachNotNull(_nullHandlingEnabled, length, correlationNullBitmap(blockValSetMap), consumer);
   }
 
   /// Returns the union of the correlation columns' null bitmaps, or `null` when no row is null.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/BitmapResultExtractionStrategy.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/BitmapResultExtractionStrategy.java
@@ -21,7 +21,7 @@ package org.apache.pinot.core.query.aggregation.function.funnel;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -105,7 +105,7 @@ class BitmapResultExtractionStrategy implements ResultExtractionStrategy<DictIds
   private RoaringBitmap convertToValueBitmap(Dictionary dictionary, RoaringBitmap dictIdBitmap) {
     RoaringBitmap valueBitmap = new RoaringBitmap();
     PeekableIntIterator iterator = dictIdBitmap.getIntIterator();
-    FieldSpec.DataType storedType = dictionary.getValueType();
+    DataType storedType = dictionary.getValueType();
     switch (storedType) {
       case INT:
         while (iterator.hasNext()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/SetResultExtractionStrategy.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/SetResultExtractionStrategy.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -82,7 +82,7 @@ class SetResultExtractionStrategy implements ResultExtractionStrategy<DictIdsWra
   private Set convertToValueSet(Dictionary dictionary, RoaringBitmap dictIdBitmap) {
     int numValues = dictIdBitmap.getCardinality();
     PeekableIntIterator iterator = dictIdBitmap.getIntIterator();
-    FieldSpec.DataType storedType = dictionary.getValueType();
+    DataType storedType = dictionary.getValueType();
     switch (storedType) {
       case INT:
         IntOpenHashSet intSet = new IntOpenHashSet(numValues);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelBaseAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelBaseAggregationFunction.java
@@ -30,22 +30,25 @@ import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.BaseAggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.funnel.FunnelStepEvent;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import org.apache.pinot.spi.query.QueryThreadContext;
-import org.roaringbitmap.RoaringBitmap;
 
 
+/// Only the timestamp decides whether a row is skipped when null handling is on.
+///
+/// A step expression is a predicate, and a predicate over a null operand is UNKNOWN, which SQL treats as not
+/// satisfied wherever a boolean is consumed, so a null step already means that step did not match and the row still
+/// belongs to the funnel. A null timestamp is different: the event has no position in the window, and an aggregate
+/// ignores a row whose input is null.
 public abstract class FunnelBaseAggregationFunction<F extends Comparable>
-    implements AggregationFunction<PriorityQueue<FunnelStepEvent>, F> {
-  protected final boolean _nullHandlingEnabled;
+    extends BaseAggregationFunction<PriorityQueue<FunnelStepEvent>, F> {
   protected final ExpressionContext _timestampExpression;
   protected final long _windowSize;
   protected final List<ExpressionContext> _stepExpressions;
@@ -55,7 +58,7 @@ public abstract class FunnelBaseAggregationFunction<F extends Comparable>
   protected final Map<String, String> _extraArguments = new HashMap<>();
 
   public FunnelBaseAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
-    _nullHandlingEnabled = nullHandlingEnabled;
+    super(nullHandlingEnabled);
     int numArguments = arguments.size();
     Preconditions.checkArgument(numArguments > 3,
         "FUNNEL_AGG_FUNC expects >= 4 arguments, got: %s. The function can be used as "
@@ -125,26 +128,6 @@ public abstract class FunnelBaseAggregationFunction<F extends Comparable>
     return new ObjectGroupByResultHolder(initialCapacity, maxCapacity);
   }
 
-  /// Runs the consumer over each range of rows whose timestamp is not null, or over the whole block when the
-  /// option is disabled.
-  ///
-  /// Only the timestamp is consulted. A step expression is a predicate, and a predicate over a null operand is
-  /// UNKNOWN, which SQL treats as not satisfied wherever a boolean is consumed, so a null step already means that
-  /// step did not match and the row still belongs to the funnel. A null timestamp is different: the event has no
-  /// position in the window, and an aggregate ignores a row whose input is null.
-  private void forEachNotNullTimestamp(int length, BlockValSet timestampBlockValSet,
-      RoaringBitmapUtils.BatchConsumer consumer) {
-    RoaringBitmap nullBitmap = _nullHandlingEnabled ? timestampBlockValSet.getNullBitmap() : null;
-    if (nullBitmap == null) {
-      consumer.consume(0, length);
-      return;
-    }
-    // Skip if the entire block is null
-    if (!nullBitmap.contains(0, length)) {
-      RoaringBitmapUtils.forEachUnset(length, nullBitmap.getIntIterator(), consumer);
-    }
-  }
-
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
@@ -160,7 +143,7 @@ public abstract class FunnelBaseAggregationFunction<F extends Comparable>
       aggregationResultHolder.setValue(existing);
     }
     PriorityQueue<FunnelStepEvent> stepEvents = existing;
-    forEachNotNullTimestamp(length, timestampBlockValSet, (from, to) -> {
+    forEachNotNull(length, timestampBlockValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         boolean stepFound = false;
         for (int j = 0; j < _numSteps; j++) {
@@ -187,7 +170,7 @@ public abstract class FunnelBaseAggregationFunction<F extends Comparable>
     for (ExpressionContext stepExpression : _stepExpressions) {
       stepBlocks.add(blockValSetMap.get(stepExpression).getIntValuesSV());
     }
-    forEachNotNullTimestamp(length, timestampBlockValSet, (from, to) -> {
+    forEachNotNull(length, timestampBlockValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         int groupKey = groupKeyArray[i];
         boolean stepFound = false;
@@ -217,7 +200,7 @@ public abstract class FunnelBaseAggregationFunction<F extends Comparable>
     for (ExpressionContext stepExpression : _stepExpressions) {
       stepBlocks.add(blockValSetMap.get(stepExpression).getIntValuesSV());
     }
-    forEachNotNullTimestamp(length, timestampBlockValSet, (from, to) -> {
+    forEachNotNull(length, timestampBlockValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         int[] groupKeys = groupKeysArray[i];
         boolean stepFound = false;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelEventsFunctionEvalAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelEventsFunctionEvalAggregationFunction.java
@@ -32,25 +32,33 @@ import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.BaseAggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.funnel.FunnelStepEvent;
 import org.apache.pinot.core.query.aggregation.function.funnel.FunnelStepEventWithExtraFields;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.query.QueryThreadContext;
-import org.roaringbitmap.RoaringBitmap;
 
 
+/// Only the timestamp decides whether a row is skipped when null handling is on.
+///
+/// A step expression is a predicate, and a predicate over a null operand is UNKNOWN, which SQL treats as not
+/// satisfied wherever a boolean is consumed, so a null step already means that step did not match and the row still
+/// belongs to the funnel. A null timestamp is different: the event has no position in the window, and an aggregate
+/// ignores a row whose input is null.
+///
+/// An extra field is neither. It is payload carried alongside a matched event, so a null one does not make the event
+/// invalid and dropping the row would lose an event that really happened. It is therefore not gated on, with one
+/// known limitation: the value is read positionally and a null row yields the column default, so a null extra field
+/// renders as `0` or the empty string rather than as NULL.
 public class FunnelEventsFunctionEvalAggregationFunction
-    implements AggregationFunction<PriorityQueue<FunnelStepEventWithExtraFields>, ObjectArrayList<String>> {
+    extends BaseAggregationFunction<PriorityQueue<FunnelStepEventWithExtraFields>, ObjectArrayList<String>> {
   private final static int INTERMEDIATE_RESULT_SERDE_VERSION = 0;
 
-  protected final boolean _nullHandlingEnabled;
   protected final ExpressionContext _timestampExpression;
   protected final long _windowSize;
   protected final List<ExpressionContext> _stepExpressions;
@@ -62,7 +70,7 @@ public class FunnelEventsFunctionEvalAggregationFunction
 
   public FunnelEventsFunctionEvalAggregationFunction(List<ExpressionContext> arguments,
       boolean nullHandlingEnabled) {
-    _nullHandlingEnabled = nullHandlingEnabled;
+    super(nullHandlingEnabled);
     int numArguments = arguments.size();
     Preconditions.checkArgument(numArguments > 3,
         "FUNNEL_EVENTS_FUNCTION_EVAL expects >= 4 arguments, got: %s. The function can be used as "
@@ -146,33 +154,6 @@ public class FunnelEventsFunctionEvalAggregationFunction
     return new ObjectGroupByResultHolder(initialCapacity, maxCapacity);
   }
 
-  /// Runs the consumer over each range of rows whose timestamp is not null, or over the whole block when the
-  /// option is disabled.
-  ///
-  /// Only the timestamp is consulted, of the three kinds of column this function reads.
-  ///
-  /// A step expression is a predicate, and a predicate over a null operand is UNKNOWN, which SQL treats as not
-  /// satisfied wherever a boolean is consumed, so a null step already means that step did not match and the row
-  /// still belongs to the funnel. A null timestamp is different: the event has no position in the window, and an
-  /// aggregate ignores a row whose input is null.
-  ///
-  /// An extra field is neither. It is payload carried alongside a matched event, so a null one does not make the
-  /// event invalid and dropping the row would lose an event that really happened. It is therefore not gated on,
-  /// with one known limitation: the value is read positionally and a null row yields the column default, so a null
-  /// extra field renders as `0` or the empty string rather than as NULL.
-  private void forEachNotNullTimestamp(int length, BlockValSet timestampBlockValSet,
-      RoaringBitmapUtils.BatchConsumer consumer) {
-    RoaringBitmap nullBitmap = _nullHandlingEnabled ? timestampBlockValSet.getNullBitmap() : null;
-    if (nullBitmap == null) {
-      consumer.consume(0, length);
-      return;
-    }
-    // Skip if the entire block is null
-    if (!nullBitmap.contains(0, length)) {
-      RoaringBitmapUtils.forEachUnset(length, nullBitmap.getIntIterator(), consumer);
-    }
-  }
-
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
@@ -189,7 +170,7 @@ public class FunnelEventsFunctionEvalAggregationFunction
     }
     PriorityQueue<FunnelStepEventWithExtraFields> stepEvents = existing;
     List<Object> extraFieldsBlocks = getExtraFieldsBlocks(blockValSetMap);
-    forEachNotNullTimestamp(length, timestampBlockValSet, (from, to) -> {
+    forEachNotNull(length, timestampBlockValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         boolean stepFound = false;
         for (int j = 0; j < _numSteps; j++) {
@@ -284,7 +265,7 @@ public class FunnelEventsFunctionEvalAggregationFunction
       stepBlocks.add(blockValSetMap.get(stepExpression).getIntValuesSV());
     }
     List<Object> extraFieldsBlocks = getExtraFieldsBlocks(blockValSetMap);
-    forEachNotNullTimestamp(length, timestampBlockValSet, (from, to) -> {
+    forEachNotNull(length, timestampBlockValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         int groupKey = groupKeyArray[i];
         boolean stepFound = false;
@@ -318,7 +299,7 @@ public class FunnelEventsFunctionEvalAggregationFunction
       stepBlocks.add(blockValSetMap.get(stepExpression).getIntValuesSV());
     }
     List<Object> extraFieldsBlocks = getExtraFieldsBlocks(blockValSetMap);
-    forEachNotNullTimestamp(length, timestampBlockValSet, (from, to) -> {
+    forEachNotNull(length, timestampBlockValSet, (from, to) -> {
       for (int i = from; i < to; i++) {
         int[] groupKeys = groupKeysArray[i];
         boolean stepFound = false;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/NullSkippingUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/NullSkippingUtils.java
@@ -16,57 +16,70 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.core.query.aggregation.function;
+package org.apache.pinot.core.query.aggregation.utils;
 
 import java.util.NoSuchElementException;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.RoaringBitmapUtils;
+import org.apache.pinot.common.utils.RoaringBitmapUtils.BatchConsumer;
+import org.apache.pinot.common.utils.RoaringBitmapUtils.Reducer;
 import org.apache.pinot.core.common.BlockValSet;
 import org.roaringbitmap.IntIterator;
 import org.roaringbitmap.RoaringBitmap;
 
 
-public abstract class NullableSingleInputAggregationFunction<I, F extends Comparable>
-    extends BaseSingleInputAggregationFunction<I, F> {
-  protected final boolean _nullHandlingEnabled;
-
-  public NullableSingleInputAggregationFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression);
-    _nullHandlingEnabled = nullHandlingEnabled;
-  }
-
-  /// A reducer that is being used to fold over consecutive indexes.
-  /// @param <A>
-  @FunctionalInterface
-  public interface Reducer<A> {
-    /// Applies the reducer to the range of indexes.
-    /// @param acum the initial value of the accumulator
-    /// @param fromInclusive the start index (inclusive)
-    /// @param toExclusive the end index (exclusive)
-    /// @return the next value of the accumulator (maybe the same as the input)
-    A apply(A acum, int fromInclusive, int toExclusive);
+/// Iterates the rows of a block that are not null, so that a caller can aggregate only those.
+///
+/// This is the reading half of null handling and nothing more. What a `null` *means* for a given aggregation - what
+/// the empty multiset answers, how a `null` intermediate result merges - is decided by the function itself, and is
+/// documented on [org.apache.pinot.core.query.aggregation.function.AggregationFunction].
+///
+/// Every method takes `nullHandlingEnabled` explicitly. With it disabled there are no null rows to skip, so the
+/// whole block is one range and the null bitmap is never consulted.
+///
+/// **A range handed to a consumer or reducer is never empty.** Callers therefore do not need to guard against
+/// `from == to`, and an accumulator created inside a range is created only when there is something to aggregate.
+public class NullSkippingUtils {
+  private NullSkippingUtils() {
   }
 
   /// Iterates over the non-null ranges of the blockValSet and calls the consumer for each range.
   /// @param blockValSet the blockValSet to iterate over
   /// @param consumer the consumer to call for each non-null range
-  public void forEachNotNull(int length, BlockValSet blockValSet, RoaringBitmapUtils.BatchConsumer consumer) {
-    if (!_nullHandlingEnabled) {
-      consumer.consume(0, length);
+  public static void forEachNotNull(boolean nullHandlingEnabled, int length, BlockValSet blockValSet,
+      BatchConsumer consumer) {
+    forEachNotNull(nullHandlingEnabled, length, nullHandlingEnabled ? blockValSet.getNullBitmap() : null, consumer);
+  }
+
+  /// Iterates over the ranges of rows the bitmap does not mark null, for a caller that derived the bitmap itself
+  /// rather than reading a single block - a composite key spanning several columns, for instance.
+  public static void forEachNotNull(boolean nullHandlingEnabled, int length, @Nullable RoaringBitmap nullBitmap,
+      BatchConsumer consumer) {
+    // A zero-length block has no range to hand over. The multi-stage engine reaches this with a filtered
+    // aggregation whose filter matched no row in the block, and a consumer that creates its accumulator inside the
+    // range would otherwise mark the holder as aggregated for a block it never read. Skipping is only sound while
+    // that stays the sole zero-length caller, because it always enables null handling: with null handling disabled a
+    // never-created accumulator surfaces as a null intermediate result, which that mode does not allow.
+    if (length == 0) {
       return;
     }
 
-    RoaringBitmap roaringBitmap = blockValSet.getNullBitmap();
-    if (roaringBitmap == null) {
+    if (!nullHandlingEnabled || nullBitmap == null) {
       consumer.consume(0, length);
       return;
     }
 
     // Skip if entire block is null
-    if (!roaringBitmap.contains(0, length)) {
-      RoaringBitmapUtils.forEachUnset(length, roaringBitmap.getIntIterator(), consumer);
+    if (!nullBitmap.contains(0, length)) {
+      RoaringBitmapUtils.forEachUnset(length, nullBitmap.getIntIterator(), consumer);
     }
+  }
+
+  /// Iterates over the ranges of rows where neither block is null, for functions that pair a value from each of
+  /// two columns and so must skip a row when either side is null.
+  public static void forEachNotNull(boolean nullHandlingEnabled, int length, BlockValSet blockValSet1,
+      BlockValSet blockValSet2, BatchConsumer consumer) {
+    RoaringBitmapUtils.forEachUnset(length, orNullIterator(nullHandlingEnabled, blockValSet1, blockValSet2), consumer);
   }
 
   /// Folds over the non-null ranges of the blockValSet using the reducer. Returns `initialAcum` if the entire
@@ -74,22 +87,25 @@ public abstract class NullableSingleInputAggregationFunction<I, F extends Compar
   ///
   /// @param initialAcum the initial value of the accumulator
   /// @param <A> The type of the accumulator
-  public <A> A foldNotNull(int length, BlockValSet blockValSet, A initialAcum, Reducer<A> reducer) {
-    return foldNotNull(length, _nullHandlingEnabled ? blockValSet.getNullBitmap() : null, initialAcum, reducer);
+  public static <A> A foldNotNull(boolean nullHandlingEnabled, int length, BlockValSet blockValSet, A initialAcum,
+      Reducer<A> reducer) {
+    return foldNotNull(nullHandlingEnabled, length, nullHandlingEnabled ? blockValSet.getNullBitmap() : null,
+        initialAcum, reducer);
   }
 
   /// Folds over the non-null ranges of the blockValSet using the reducer. Returns `initialAcum` if the entire
   /// block is null.
   /// @param initialAcum the initial value of the accumulator
   /// @param <A> The type of the accumulator
-  public <A> A foldNotNull(int length, @Nullable RoaringBitmap roaringBitmap, A initialAcum, Reducer<A> reducer) {
+  public static <A> A foldNotNull(boolean nullHandlingEnabled, int length, @Nullable RoaringBitmap roaringBitmap,
+      A initialAcum, Reducer<A> reducer) {
     // Exit early if entire block is null
-    if (_nullHandlingEnabled && roaringBitmap != null && roaringBitmap.contains(0, length)) {
+    if (nullHandlingEnabled && roaringBitmap != null && roaringBitmap.contains(0, length)) {
       return initialAcum;
     }
 
     IntIterator intIterator = roaringBitmap == null ? null : roaringBitmap.getIntIterator();
-    return foldNotNull(length, intIterator, initialAcum, reducer);
+    return foldNotNull(nullHandlingEnabled, length, intIterator, initialAcum, reducer);
   }
 
   /// Folds over the non-null ranges of the nullIndexIterator using the reducer.
@@ -97,33 +113,19 @@ public abstract class NullableSingleInputAggregationFunction<I, F extends Compar
   ///                          Rows are considered null if and only if their index is emitted.
   /// @param initialAcum the initial value of the accumulator
   /// @param <A> The type of the accumulator
-  public <A> A foldNotNull(int length, @Nullable IntIterator nullIndexIterator, A initialAcum, Reducer<A> reducer) {
+  public static <A> A foldNotNull(boolean nullHandlingEnabled, int length,
+      @Nullable IntIterator nullIndexIterator, A initialAcum, Reducer<A> reducer) {
     A acum = initialAcum;
 
     if (length == 0) {
       return acum;
     }
 
-    if (!_nullHandlingEnabled || nullIndexIterator == null || !nullIndexIterator.hasNext()) {
+    if (!nullHandlingEnabled || nullIndexIterator == null || !nullIndexIterator.hasNext()) {
       return reducer.apply(initialAcum, 0, length);
     }
 
-    int prev = 0;
-    while (nullIndexIterator.hasNext() && prev < length) {
-      int nextNull = Math.min(nullIndexIterator.next(), length);
-      if (nextNull > prev) {
-        acum = reducer.apply(acum, prev, nextNull);
-      }
-      prev = nextNull + 1;
-    }
-    if (prev < length) {
-      acum = reducer.apply(acum, prev, length);
-    }
-    return acum;
-  }
-
-  public IntIterator orNullIterator(BlockValSet valSet1, BlockValSet valSet2) {
-    return orNullIterator(_nullHandlingEnabled, valSet1, valSet2);
+    return RoaringBitmapUtils.foldUnset(length, nullIndexIterator, acum, reducer);
   }
 
   /// Merges the null positions of two blocks without materializing a bitmap, for functions that pair a value from

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutorTest.java
@@ -42,7 +42,7 @@ import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -231,7 +231,7 @@ public class DefaultAggregationExecutorTest {
 
     for (int i = 0; i < NUM_METRIC_COLUMNS; i++) {
       String metricName = METRIC_PREFIX + i;
-      MetricFieldSpec metricFieldSpec = new MetricFieldSpec(metricName, FieldSpec.DataType.DOUBLE);
+      MetricFieldSpec metricFieldSpec = new MetricFieldSpec(metricName, DataType.DOUBLE);
       schema.addField(metricFieldSpec);
       _columns[i] = metricName;
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AbstractAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AbstractAggregationFunctionTest.java
@@ -34,7 +34,8 @@ import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.AfterClass;
@@ -45,60 +46,44 @@ public abstract class AbstractAggregationFunctionTest {
 
   protected File _baseDir;
 
-  private static final FieldSpec.DataType[] VALID_DATA_TYPES = new FieldSpec.DataType[] {
-      FieldSpec.DataType.INT,
-      FieldSpec.DataType.LONG,
-      FieldSpec.DataType.FLOAT,
-      FieldSpec.DataType.DOUBLE,
-      FieldSpec.DataType.STRING,
-      FieldSpec.DataType.BYTES,
-      FieldSpec.DataType.BIG_DECIMAL,
-      FieldSpec.DataType.TIMESTAMP,
-      FieldSpec.DataType.BOOLEAN
+  private static final DataType[] VALID_DATA_TYPES = new DataType[]{
+      DataType.INT, DataType.LONG, DataType.FLOAT, DataType.DOUBLE, DataType.STRING, DataType.BYTES,
+      DataType.BIG_DECIMAL, DataType.TIMESTAMP, DataType.BOOLEAN
   };
 
-  private static final FieldSpec.DataType[] VALID_METRIC_DATA_TYPES = new FieldSpec.DataType[] {
-      FieldSpec.DataType.INT,
-      FieldSpec.DataType.LONG,
-      FieldSpec.DataType.FLOAT,
-      FieldSpec.DataType.DOUBLE,
-      FieldSpec.DataType.BIG_DECIMAL,
-      FieldSpec.DataType.BYTES
+  private static final DataType[] VALID_METRIC_DATA_TYPES = new DataType[]{
+      DataType.INT, DataType.LONG, DataType.FLOAT, DataType.DOUBLE, DataType.BIG_DECIMAL, DataType.BYTES
   };
 
-  protected static final Map<FieldSpec.DataType, Schema> SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS =
-      Arrays.stream(VALID_DATA_TYPES)
-          .collect(Collectors.toMap(dt -> dt, dt -> new Schema.SchemaBuilder()
-              .setSchemaName("testTable")
-              .setEnableColumnBasedNullHandling(true)
-              .addDimensionField("myField", dt, f -> f.setNullable(true))
-              .build()));
+  protected static final Map<DataType, Schema> SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS = Arrays.stream(VALID_DATA_TYPES)
+      .collect(Collectors.toMap(dt -> dt, dt -> new Schema.SchemaBuilder().setSchemaName("testTable")
+          .setEnableColumnBasedNullHandling(true)
+          .addDimensionField("myField", dt, f -> f.setNullable(true))
+          .build()));
 
-  protected static final Map<FieldSpec.DataType, Schema> SINGLE_FIELD_NULLABLE_METRIC_SCHEMAS =
+  protected static final Map<DataType, Schema> SINGLE_FIELD_NULLABLE_METRIC_SCHEMAS =
       Arrays.stream(VALID_METRIC_DATA_TYPES)
-          .collect(Collectors.toMap(dt -> dt, dt -> new Schema.SchemaBuilder()
-              .setSchemaName("testTable")
+          .collect(Collectors.toMap(dt -> dt, dt -> new Schema.SchemaBuilder().setSchemaName("testTable")
               .setEnableColumnBasedNullHandling(true)
               .addMetricField("myField", dt, f -> f.setNullable(true))
               .build()));
 
-  protected static final TableConfig SINGLE_FIELD_TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE)
-      .setTableName("testTable")
-      .build();
+  protected static final TableConfig SINGLE_FIELD_TABLE_CONFIG =
+      new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
 
-  protected FluentQueryTest.DeclaringTable givenSingleNullableFieldTable(FieldSpec.DataType dataType,
+  protected FluentQueryTest.DeclaringTable givenSingleNullableFieldTable(DataType dataType,
       boolean nullHandlingEnabled) {
     return givenSingleNullableFieldTable(dataType, nullHandlingEnabled, null);
   }
 
-  protected FluentQueryTest.DeclaringTable givenSingleNullableFieldTable(FieldSpec.DataType dataType,
-      boolean nullHandlingEnabled, @Nullable Consumer<FieldConfig.Builder> customize) {
-    return givenSingleNullableFieldTable(dataType, nullHandlingEnabled, FieldSpec.FieldType.DIMENSION, customize);
+  protected FluentQueryTest.DeclaringTable givenSingleNullableFieldTable(DataType dataType, boolean nullHandlingEnabled,
+      @Nullable Consumer<FieldConfig.Builder> customize) {
+    return givenSingleNullableFieldTable(dataType, nullHandlingEnabled, FieldType.DIMENSION, customize);
   }
 
-  protected FluentQueryTest.DeclaringTable givenSingleNullableFieldTable(FieldSpec.DataType dataType,
-      boolean nullHandlingEnabled, FieldSpec.FieldType fieldType, @Nullable Consumer<FieldConfig.Builder> customize) {
-    if (fieldType != FieldSpec.FieldType.DIMENSION && fieldType != FieldSpec.FieldType.METRIC) {
+  protected FluentQueryTest.DeclaringTable givenSingleNullableFieldTable(DataType dataType, boolean nullHandlingEnabled,
+      FieldType fieldType, @Nullable Consumer<FieldConfig.Builder> customize) {
+    if (fieldType != FieldType.DIMENSION && fieldType != FieldType.METRIC) {
       throw new IllegalArgumentException("Only METRIC and DIMENSION field types are supported");
     }
 
@@ -115,21 +100,19 @@ public abstract class AbstractAggregationFunctionTest {
       tableConfig = builder.build();
     }
 
-    Schema schema = fieldType == FieldSpec.FieldType.DIMENSION
+    Schema schema = fieldType == FieldType.DIMENSION
         ? SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(dataType)
         : SINGLE_FIELD_NULLABLE_METRIC_SCHEMAS.get(dataType);
-    return FluentQueryTest.withBaseDir(_baseDir)
-        .withNullHandling(nullHandlingEnabled)
-        .givenTable(schema, tableConfig);
+    return FluentQueryTest.withBaseDir(_baseDir).withNullHandling(nullHandlingEnabled).givenTable(schema, tableConfig);
   }
 
   protected FluentQueryTest.DeclaringTable givenSingleNullableIntFieldTable(boolean nullHandling) {
-    return givenSingleNullableFieldTable(FieldSpec.DataType.INT, nullHandling, null);
+    return givenSingleNullableFieldTable(DataType.INT, nullHandling, null);
   }
 
   protected FluentQueryTest.DeclaringTable givenSingleNullableIntFieldTable(boolean nullHandling,
       @Nullable Consumer<FieldConfig.Builder> customize) {
-    return givenSingleNullableFieldTable(FieldSpec.DataType.INT, nullHandling, customize);
+    return givenSingleNullableFieldTable(DataType.INT, nullHandling, customize);
   }
 
   @BeforeClass
@@ -150,13 +133,13 @@ public abstract class AbstractAggregationFunctionTest {
   }
 
   class DataTypeScenario {
-    private final FieldSpec.DataType _dataType;
+    private final DataType _dataType;
 
-    public DataTypeScenario(FieldSpec.DataType dataType) {
+    public DataTypeScenario(DataType dataType) {
       _dataType = dataType;
     }
 
-    public FieldSpec.DataType getDataType() {
+    public DataType getDataType() {
       return _dataType;
     }
 
@@ -164,8 +147,7 @@ public abstract class AbstractAggregationFunctionTest {
       return givenSingleNullableFieldTable(_dataType, nullHandlingEnabled);
     }
 
-    public FluentQueryTest.DeclaringTable getDeclaringTable(boolean nullHandlingEnabled,
-        FieldSpec.FieldType fieldType) {
+    public FluentQueryTest.DeclaringTable getDeclaringTable(boolean nullHandlingEnabled, FieldType fieldType) {
       return givenSingleNullableFieldTable(_dataType, nullHandlingEnabled, fieldType, null);
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AbstractPercentileAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AbstractPercentileAggregationFunctionTest.java
@@ -20,7 +20,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -29,11 +29,11 @@ public abstract class AbstractPercentileAggregationFunctionTest extends Abstract
 
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
-    return new Object[] {
-        new Scenario(FieldSpec.DataType.INT),
-        new Scenario(FieldSpec.DataType.LONG),
-        new Scenario(FieldSpec.DataType.FLOAT),
-        new Scenario(FieldSpec.DataType.DOUBLE),
+    return new Object[]{
+        new Scenario(DataType.INT),
+        new Scenario(DataType.LONG),
+        new Scenario(DataType.FLOAT),
+        new Scenario(DataType.DOUBLE),
     };
   }
 
@@ -44,13 +44,13 @@ public abstract class AbstractPercentileAggregationFunctionTest extends Abstract
   }
 
   public class Scenario {
-    private final FieldSpec.DataType _dataType;
+    private final DataType _dataType;
 
-    public Scenario(FieldSpec.DataType dataType) {
+    public Scenario(DataType dataType) {
       _dataType = dataType;
     }
 
-    public FieldSpec.DataType getDataType() {
+    public DataType getDataType() {
       return _dataType;
     }
 
@@ -66,39 +66,20 @@ public abstract class AbstractPercentileAggregationFunctionTest extends Abstract
 
   FluentQueryTest.TableWithSegments withDefaultData(Scenario scenario, boolean nullHandlingEnabled) {
     return scenario.getDeclaringTable(nullHandlingEnabled)
-        .onFirstInstance("myField",
-            "null",
-            "0",
-            "null",
-            "1",
-            "null",
-            "2",
-            "null",
-            "3",
-            "null",
-            "4",
-            "null"
-        ).andSegment("myField",
-            "null",
-            "5",
-            "null",
-            "6",
-            "null",
-            "7",
-            "null",
-            "8",
-            "null",
-            "9",
-            "null"
-        );
+        .onFirstInstance("myField", "null", "0", "null", "1", "null", "2", "null", "3", "null", "4", "null")
+        .andSegment("myField", "null", "5", "null", "6", "null", "7", "null", "8", "null", "9", "null");
   }
 
-  String minValue(FieldSpec.DataType dataType) {
+  String minValue(DataType dataType) {
     switch (dataType) {
-      case INT: return "-2.147483648E9";
-      case LONG: return "-9.223372036854776E18";
-      case FLOAT: return "-Infinity";
-      case DOUBLE: return "-Infinity";
+      case INT:
+        return "-2.147483648E9";
+      case LONG:
+        return "-9.223372036854776E18";
+      case FLOAT:
+        return "-Infinity";
+      case DOUBLE:
+        return "-Infinity";
       default:
         throw new IllegalArgumentException("Unexpected type " + dataType);
     }
@@ -146,45 +127,27 @@ public abstract class AbstractPercentileAggregationFunctionTest extends Abstract
 
   @Test(dataProvider = "scenarios")
   void aggrWithoutNull(Scenario scenario) {
-
     FluentQueryTest.TableWithSegments instance = withDefaultData(scenario, false);
 
-    instance
-        .whenQuery("select " + callStr("myField", 10) + " from testTable")
+    instance.whenQuery("select " + callStr("myField", 10) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithoutNull10(scenario));
-
-    instance
-        .whenQuery("select " + callStr("myField", 15) + " from testTable")
+    instance.whenQuery("select " + callStr("myField", 15) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithoutNull15(scenario));
-
-    instance
-        .whenQuery("select " + callStr("myField", 30) + " from testTable")
+    instance.whenQuery("select " + callStr("myField", 30) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithoutNull30(scenario));
-    instance
-        .whenQuery("select " + callStr("myField", 35) + " from testTable")
+    instance.whenQuery("select " + callStr("myField", 35) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithoutNull35(scenario));
-
-    instance
-        .whenQuery("select " + callStr("myField", 50) + " from testTable")
+    instance.whenQuery("select " + callStr("myField", 50) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithoutNull50(scenario));
-    instance
-        .whenQuery("select " + callStr("myField", 55) + " from testTable")
+    instance.whenQuery("select " + callStr("myField", 55) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithoutNull55(scenario));
-
-    instance
-        .whenQuery("select " + callStr("myField", 70) + " from testTable")
+    instance.whenQuery("select " + callStr("myField", 70) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithoutNull70(scenario));
-
-    instance
-        .whenQuery("select " + callStr("myField", 75) + " from testTable")
+    instance.whenQuery("select " + callStr("myField", 75) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithoutNull75(scenario));
-
-    instance
-        .whenQuery("select " + callStr("myField", 90) + " from testTable")
+    instance.whenQuery("select " + callStr("myField", 90) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithoutNull90(scenario));
-
-    instance
-        .whenQuery("select " + callStr("myField", 100) + " from testTable")
+    instance.whenQuery("select " + callStr("myField", 100) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithoutNull100(scenario));
   }
 
@@ -194,8 +157,7 @@ public abstract class AbstractPercentileAggregationFunctionTest extends Abstract
 
   @Test(dataProvider = "scenarios")
   void aggrWithNull10(Scenario scenario) {
-    withDefaultData(scenario, true)
-        .whenQuery("select " + callStr("myField", 10) + " from testTable")
+    withDefaultData(scenario, true).whenQuery("select " + callStr("myField", 10) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithNull10(scenario));
   }
 
@@ -205,8 +167,7 @@ public abstract class AbstractPercentileAggregationFunctionTest extends Abstract
 
   @Test(dataProvider = "scenarios")
   void aggrWithNull15(Scenario scenario) {
-    withDefaultData(scenario, true)
-        .whenQuery("select " + callStr("myField", 15) + " from testTable")
+    withDefaultData(scenario, true).whenQuery("select " + callStr("myField", 15) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithNull15(scenario));
   }
 
@@ -216,8 +177,7 @@ public abstract class AbstractPercentileAggregationFunctionTest extends Abstract
 
   @Test(dataProvider = "scenarios")
   void aggrWithNull30(Scenario scenario) {
-    withDefaultData(scenario, true)
-        .whenQuery("select " + callStr("myField", 30) + " from testTable")
+    withDefaultData(scenario, true).whenQuery("select " + callStr("myField", 30) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithNull30(scenario));
   }
 
@@ -227,8 +187,7 @@ public abstract class AbstractPercentileAggregationFunctionTest extends Abstract
 
   @Test(dataProvider = "scenarios")
   void aggrWithNull35(Scenario scenario) {
-    withDefaultData(scenario, true)
-        .whenQuery("select " + callStr("myField", 35) + " from testTable")
+    withDefaultData(scenario, true).whenQuery("select " + callStr("myField", 35) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithNull35(scenario));
   }
 
@@ -238,8 +197,7 @@ public abstract class AbstractPercentileAggregationFunctionTest extends Abstract
 
   @Test(dataProvider = "scenarios")
   void aggrWithNull50(Scenario scenario) {
-    withDefaultData(scenario, true)
-        .whenQuery("select " + callStr("myField", 50) + " from testTable")
+    withDefaultData(scenario, true).whenQuery("select " + callStr("myField", 50) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithNull50(scenario));
   }
 
@@ -249,8 +207,7 @@ public abstract class AbstractPercentileAggregationFunctionTest extends Abstract
 
   @Test(dataProvider = "scenarios")
   void aggrWithNull55(Scenario scenario) {
-    withDefaultData(scenario, true)
-        .whenQuery("select " + callStr("myField", 55) + " from testTable")
+    withDefaultData(scenario, true).whenQuery("select " + callStr("myField", 55) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithNull55(scenario));
   }
 
@@ -260,8 +217,7 @@ public abstract class AbstractPercentileAggregationFunctionTest extends Abstract
 
   @Test(dataProvider = "scenarios")
   void aggrWithNull70(Scenario scenario) {
-    withDefaultData(scenario, true)
-        .whenQuery("select " + callStr("myField", 70) + " from testTable")
+    withDefaultData(scenario, true).whenQuery("select " + callStr("myField", 70) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithNull70(scenario));
   }
 
@@ -271,8 +227,7 @@ public abstract class AbstractPercentileAggregationFunctionTest extends Abstract
 
   @Test(dataProvider = "scenarios")
   void aggrWithNull75(Scenario scenario) {
-    withDefaultData(scenario, true)
-        .whenQuery("select " + callStr("myField", 75) + " from testTable")
+    withDefaultData(scenario, true).whenQuery("select " + callStr("myField", 75) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithNull75(scenario));
   }
 
@@ -282,27 +237,20 @@ public abstract class AbstractPercentileAggregationFunctionTest extends Abstract
 
   @Test(dataProvider = "scenarios")
   void aggrWithNull100(Scenario scenario) {
-    withDefaultData(scenario, true)
-        .whenQuery("select " + callStr("myField", 100) + " from testTable")
+    withDefaultData(scenario, true).whenQuery("select " + callStr("myField", 100) + " from testTable")
         .thenResultIs(getFinalResultColumnType(), expectedAggrWithNull100(scenario));
   }
 
   @Test(dataProvider = "scenarios")
   void aggrSvWithoutNull(Scenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "null"
-        ).andSegment("myField",
-            "9"
-        ).andSegment("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select $segmentName, " + callStr("myField", 50) + " from testTable "
+        .onFirstInstance("myField", "null", "1", "null")
+        .andSegment("myField", "9")
+        .andSegment("myField", "null", "null", "null")
+        .whenQuery("select $segmentName, " + callStr("myField", 50) + " from testTable "
             + "group by $segmentName order by $segmentName")
-        .thenResultIs("STRING | " + getFinalResultColumnType(),
+        .thenResultIs(
+            "STRING | " + getFinalResultColumnType(),
             "testTable_0 | " + minValue(scenario._dataType),
             "testTable_1 |  9",
             "testTable_2 | " + minValue(scenario._dataType)
@@ -312,19 +260,13 @@ public abstract class AbstractPercentileAggregationFunctionTest extends Abstract
   @Test(dataProvider = "scenarios")
   void aggrSvWithNull(Scenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "null"
-        ).andSegment("myField",
-            "9"
-        ).andSegment("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select $segmentName, " + callStr("myField", 50) + " from testTable "
+        .onFirstInstance("myField", "null", "1", "null")
+        .andSegment("myField", "9")
+        .andSegment("myField", "null", "null", "null")
+        .whenQuery("select $segmentName, " + callStr("myField", 50) + " from testTable "
             + "group by $segmentName order by $segmentName")
-        .thenResultIs("STRING | " + getFinalResultColumnType(),
+        .thenResultIs(
+            "STRING | " + getFinalResultColumnType(),
             "testTable_0 | 1",
             "testTable_1 | 9",
             "testTable_2 | null"

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AnyValueAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AnyValueAggregationFunctionTest.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -34,12 +34,12 @@ public class AnyValueAggregationFunctionTest extends AbstractAggregationFunction
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
     return new Object[] {
-        new DataTypeScenario(FieldSpec.DataType.STRING),
-        new DataTypeScenario(FieldSpec.DataType.INT),
-        new DataTypeScenario(FieldSpec.DataType.LONG),
-        new DataTypeScenario(FieldSpec.DataType.FLOAT),
-        new DataTypeScenario(FieldSpec.DataType.DOUBLE),
-        new DataTypeScenario(FieldSpec.DataType.BOOLEAN),
+        new DataTypeScenario(DataType.STRING),
+        new DataTypeScenario(DataType.INT),
+        new DataTypeScenario(DataType.LONG),
+        new DataTypeScenario(DataType.FLOAT),
+        new DataTypeScenario(DataType.DOUBLE),
+        new DataTypeScenario(DataType.BOOLEAN),
     };
   }
 
@@ -112,8 +112,7 @@ public class AnyValueAggregationFunctionTest extends AbstractAggregationFunction
   // Test for different data types with specific values
   @Test
   void testIntegerDataType() {
-    FluentQueryTest.QueryExecuted result = new DataTypeScenario(FieldSpec.DataType.INT)
-        .getDeclaringTable(true)
+    FluentQueryTest.QueryExecuted result = new DataTypeScenario(DataType.INT).getDeclaringTable(true)
         .onFirstInstance("myField", "100", "null", "100") // Same non-null values
         .andOnSecondInstance("myField", "null", "100", "null")
         .whenQuery(STANDARD_GROUP_BY_QUERY_TEMPLATE);
@@ -123,8 +122,7 @@ public class AnyValueAggregationFunctionTest extends AbstractAggregationFunction
 
   @Test
   void testLongDataType() {
-    FluentQueryTest.QueryExecuted result = new DataTypeScenario(FieldSpec.DataType.LONG)
-        .getDeclaringTable(true)
+    FluentQueryTest.QueryExecuted result = new DataTypeScenario(DataType.LONG).getDeclaringTable(true)
         .onFirstInstance("myField", "1000", "null", "1000") // Same non-null values
         .andOnSecondInstance("myField", "null", "1000", "null")
         .whenQuery(STANDARD_GROUP_BY_QUERY_TEMPLATE);
@@ -134,8 +132,7 @@ public class AnyValueAggregationFunctionTest extends AbstractAggregationFunction
 
   @Test
   void testFloatDataType() {
-    FluentQueryTest.QueryExecuted result = new DataTypeScenario(FieldSpec.DataType.FLOAT)
-        .getDeclaringTable(true)
+    FluentQueryTest.QueryExecuted result = new DataTypeScenario(DataType.FLOAT).getDeclaringTable(true)
         .onFirstInstance("myField", "3.14", "null", "3.14") // Same non-null values
         .andOnSecondInstance("myField", "null", "3.14", "null")
         .whenQuery(STANDARD_GROUP_BY_QUERY_TEMPLATE);
@@ -145,8 +142,7 @@ public class AnyValueAggregationFunctionTest extends AbstractAggregationFunction
 
   @Test
   void testDoubleDataType() {
-    FluentQueryTest.QueryExecuted result = new DataTypeScenario(FieldSpec.DataType.DOUBLE)
-        .getDeclaringTable(true)
+    FluentQueryTest.QueryExecuted result = new DataTypeScenario(DataType.DOUBLE).getDeclaringTable(true)
         .onFirstInstance("myField", "2.718", "null", "2.718") // Same non-null values
         .andOnSecondInstance("myField", "null", "2.718", "null")
         .whenQuery(STANDARD_GROUP_BY_QUERY_TEMPLATE);
@@ -156,8 +152,7 @@ public class AnyValueAggregationFunctionTest extends AbstractAggregationFunction
 
   @Test
   void testBooleanDataType() {
-    FluentQueryTest.QueryExecuted result = new DataTypeScenario(FieldSpec.DataType.BOOLEAN)
-        .getDeclaringTable(true)
+    FluentQueryTest.QueryExecuted result = new DataTypeScenario(DataType.BOOLEAN).getDeclaringTable(true)
         .onFirstInstance("myField", "1", "null", "1") // Use 1/0 for boolean, same values
         .andOnSecondInstance("myField", "null", "1", "null")
         .whenQuery(STANDARD_GROUP_BY_QUERY_TEMPLATE);
@@ -168,8 +163,7 @@ public class AnyValueAggregationFunctionTest extends AbstractAggregationFunction
   // Edge case tests
   @Test
   void testAllNullValues() {
-    FluentQueryTest.QueryExecuted result = new DataTypeScenario(FieldSpec.DataType.STRING)
-        .getDeclaringTable(true)
+    FluentQueryTest.QueryExecuted result = new DataTypeScenario(DataType.STRING).getDeclaringTable(true)
         .onFirstInstance("myField", "null", "null", "null")
         .andOnSecondInstance("myField", "null", "null", "null")
         .whenQuery(STANDARD_GROUP_BY_QUERY_TEMPLATE);
@@ -179,8 +173,7 @@ public class AnyValueAggregationFunctionTest extends AbstractAggregationFunction
 
   @Test
   void testSingleNonNullValue() {
-    FluentQueryTest.QueryExecuted result = new DataTypeScenario(FieldSpec.DataType.STRING)
-        .getDeclaringTable(true)
+    FluentQueryTest.QueryExecuted result = new DataTypeScenario(DataType.STRING).getDeclaringTable(true)
         .onFirstInstance("myField", "null", "null", "null")
         .andOnSecondInstance("myField", "null", "unique_value", "null")
         .whenQuery(STANDARD_GROUP_BY_QUERY_TEMPLATE);
@@ -193,8 +186,7 @@ public class AnyValueAggregationFunctionTest extends AbstractAggregationFunction
   void testGroupByWithMultipleGroups() {
     // ANY_VALUE can return any of the values (value1, value2, value3)
     // This test has mixed values, so ANY_VALUE could return any of them
-    FluentQueryTest.QueryExecuted result = new DataTypeScenario(FieldSpec.DataType.STRING)
-        .getDeclaringTable(true)
+    FluentQueryTest.QueryExecuted result = new DataTypeScenario(DataType.STRING).getDeclaringTable(true)
         .onFirstInstance("myField", "value1", "value1", "value2")
         .andOnSecondInstance("myField", "value2", "value3", "value3")
         .whenQuery(STANDARD_GROUP_BY_QUERY_TEMPLATE);
@@ -206,8 +198,7 @@ public class AnyValueAggregationFunctionTest extends AbstractAggregationFunction
   void testGroupByWithNullsInGroups() {
     // ANY_VALUE can return any non-null value (100, 200, or 300)
     // This test has mixed values, so ANY_VALUE could return any of them
-    FluentQueryTest.QueryExecuted result = new DataTypeScenario(FieldSpec.DataType.INT)
-        .getDeclaringTable(true)
+    FluentQueryTest.QueryExecuted result = new DataTypeScenario(DataType.INT).getDeclaringTable(true)
         .onFirstInstance("myField", "100", "null", "200")
         .andOnSecondInstance("myField", "null", "300", "null")
         .whenQuery(STANDARD_GROUP_BY_QUERY_TEMPLATE);
@@ -220,22 +211,21 @@ public class AnyValueAggregationFunctionTest extends AbstractAggregationFunction
   void testPerformanceWithLargeDataset() {
     // ANY_VALUE can return any of the values in the dataset
     // This test has mixed values, so ANY_VALUE could return any of them
-    DataTypeScenario scenario = new DataTypeScenario(FieldSpec.DataType.STRING);
+    DataTypeScenario scenario = new DataTypeScenario(DataType.STRING);
     FluentQueryTest.DeclaringTable table = scenario.getDeclaringTable(true);
 
     // Create a large dataset where ANY_VALUE can return any value
-    FluentQueryTest.QueryExecuted result = table
-        .onFirstInstance("myField", "first_value", "value_1", "value_2", "value_3", "value_4")
-        .andOnSecondInstance("myField", "value_5", "value_6", "value_7", "value_8", "value_9")
-        .whenQuery(STANDARD_GROUP_BY_QUERY_TEMPLATE);
+    FluentQueryTest.QueryExecuted result =
+        table.onFirstInstance("myField", "first_value", "value_1", "value_2", "value_3", "value_4")
+            .andOnSecondInstance("myField", "value_5", "value_6", "value_7", "value_8", "value_9")
+            .whenQuery(STANDARD_GROUP_BY_QUERY_TEMPLATE);
     validateAnyValueBehavior(result, true); // Should return non-null (many values available)
   }
 
   // Test serialization/deserialization behavior
   @Test
   void testSerializationWithComplexValues() {
-    FluentQueryTest.QueryExecuted result = new DataTypeScenario(FieldSpec.DataType.STRING)
-        .getDeclaringTable(true)
+    FluentQueryTest.QueryExecuted result = new DataTypeScenario(DataType.STRING).getDeclaringTable(true)
         .onFirstInstance("myField", "test_value", "null", "test_value") // Same values for deterministic results
         .andOnSecondInstance("myField", "null", "test_value", "null")
         .whenQuery(STANDARD_GROUP_BY_QUERY_TEMPLATE);
@@ -246,8 +236,7 @@ public class AnyValueAggregationFunctionTest extends AbstractAggregationFunction
   // Test numeric edge cases
   @Test
   void testNumericEdgeCases() {
-    FluentQueryTest.QueryExecuted result = new DataTypeScenario(FieldSpec.DataType.DOUBLE)
-        .getDeclaringTable(true)
+    FluentQueryTest.QueryExecuted result = new DataTypeScenario(DataType.DOUBLE).getDeclaringTable(true)
         .onFirstInstance("myField", "0.0", "null", "0.0") // Same values
         .andOnSecondInstance("myField", "null", "0.0", "null")
         .whenQuery(STANDARD_GROUP_BY_QUERY_TEMPLATE);
@@ -256,7 +245,7 @@ public class AnyValueAggregationFunctionTest extends AbstractAggregationFunction
   }
 
   // Helper methods to handle different data types in parameterized tests
-  private String getTestValueForDataType(FieldSpec.DataType dataType) {
+  private String getTestValueForDataType(DataType dataType) {
     switch (dataType) {
       case STRING:
         return "test_value";
@@ -277,7 +266,7 @@ public class AnyValueAggregationFunctionTest extends AbstractAggregationFunction
     }
   }
 
-  private String getExpectedResultForDataType(FieldSpec.DataType dataType, String testValue) {
+  private String getExpectedResultForDataType(DataType dataType, String testValue) {
     switch (dataType) {
       case BOOLEAN:
         return "1"; // Boolean values are stored as integers in Pinot, so ANY_VALUE returns "1"

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ArrayAggFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ArrayAggFunctionTest.java
@@ -31,7 +31,7 @@ import org.apache.pinot.core.query.aggregation.function.array.ArrayAggDistinctLo
 import org.apache.pinot.core.query.aggregation.function.array.ArrayAggDoubleFunction;
 import org.apache.pinot.core.query.aggregation.function.array.ArrayAggLongFunction;
 import org.apache.pinot.queries.FluentQueryTest;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -42,59 +42,47 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationAllNullsWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select arrayagg(myField, 'INT') from testTable")
-        .thenResultIs(new Object[]{new int[]{Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE,
-            Integer.MIN_VALUE}});
+    new DataTypeScenario(DataType.INT).getDeclaringTable(false)
+        .onFirstInstance("myField", "null", "null", "null")
+        .andOnSecondInstance("myField", "null", "null")
+        .whenQuery("select arrayagg(myField, 'INT') from testTable")
+        .thenResultIs(new Object[]{
+            new int[]{
+                Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE
+            }
+        });
   }
 
   @Test
   void aggregationAllNullsWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select arrayagg(myField, 'LONG') from testTable")
+    new DataTypeScenario(DataType.LONG).getDeclaringTable(true)
+        .onFirstInstance("myField", "null", "null", "null")
+        .andOnSecondInstance("myField", "null", "null")
+        .whenQuery("select arrayagg(myField, 'LONG') from testTable")
         .thenResultIs(new Object[]{new long[0]});
   }
 
   @Test
   void aggregationGroupBySVAllNullsWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select 'literal', arrayagg(myField, 'FLOAT') from testTable group by 'literal'")
-        .thenResultIs(new Object[]{"literal", new float[]{Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY,
-            Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY}});
+    new DataTypeScenario(DataType.FLOAT).getDeclaringTable(false)
+        .onFirstInstance("myField", "null", "null", "null")
+        .andOnSecondInstance("myField", "null", "null")
+        .whenQuery("select 'literal', arrayagg(myField, 'FLOAT') from testTable group by 'literal'")
+        .thenResultIs(new Object[]{
+            "literal",
+            new float[]{
+                Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY,
+                Float.NEGATIVE_INFINITY
+            }
+        });
   }
 
   @Test
   void aggregationGroupBySVAllNullsWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select 'literal', arrayagg(myField, 'DOUBLE') from testTable group by 'literal'")
+    new DataTypeScenario(DataType.DOUBLE).getDeclaringTable(true)
+        .onFirstInstance("myField", "null", "null", "null")
+        .andOnSecondInstance("myField", "null", "null")
+        .whenQuery("select 'literal', arrayagg(myField, 'DOUBLE') from testTable group by 'literal'")
         .thenResultIs(new Object[]{"literal", new double[0]});
   }
 
@@ -102,31 +90,19 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
   void aggregationIntWithNullHandlingDisabled() {
     // Use repeated segment values because order of processing across segments isn't deterministic and not relevant
     // to this test
-    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "1",
-            "null",
-            "2"
-        ).andOnSecondInstance("myField",
-            "1",
-            "null",
-            "2"
-        ).whenQuery("select arrayagg(myField, 'INT') from testTable")
+    new DataTypeScenario(DataType.INT).getDeclaringTable(false)
+        .onFirstInstance("myField", "1", "null", "2")
+        .andOnSecondInstance("myField", "1", "null", "2")
+        .whenQuery("select arrayagg(myField, 'INT') from testTable")
         .thenResultIs(new Object[]{new int[]{1, Integer.MIN_VALUE, 2, 1, Integer.MIN_VALUE, 2}});
   }
 
   @Test
   void aggregationIntWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "1",
-            "null",
-            "2"
-        ).andOnSecondInstance("myField",
-            "1",
-            "null",
-            "2"
-        ).whenQuery("select arrayagg(myField, 'INT') from testTable")
+    new DataTypeScenario(DataType.INT).getDeclaringTable(true)
+        .onFirstInstance("myField", "1", "null", "2")
+        .andOnSecondInstance("myField", "1", "null", "2")
+        .whenQuery("select arrayagg(myField, 'INT') from testTable")
         .thenResultIs(new Object[]{new int[]{1, 2, 1, 2}});
   }
 
@@ -134,28 +110,23 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
   void aggregationDistinctIntWithNullHandlingDisabled() {
     // Use a single value in the segment because ordering is currently not deterministic due to the use of a hashset in
     // distinct array agg
-    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select arrayagg(myField, 'INT', true) from testTable")
+    new DataTypeScenario(DataType.INT).getDeclaringTable(false)
+        .onFirstInstance("myField", "null", "null")
+        .whenQuery("select arrayagg(myField, 'INT', true) from testTable")
         .thenResultIs(new Object[]{new int[]{Integer.MIN_VALUE}});
   }
 
   @Test
   void aggregationDistinctIntWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "1",
-            "null",
-            "1"
-        ).whenQuery("select arrayagg(myField, 'INT', true) from testTable")
+    new DataTypeScenario(DataType.INT).getDeclaringTable(true)
+        .onFirstInstance("myField", "1", "null", "1")
+        .whenQuery("select arrayagg(myField, 'INT', true) from testTable")
         .thenResultIs(new Object[]{new int[]{1}});
   }
 
   @Test
   void aggregationGroupBySVIntWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(false)
+    new DataTypeScenario(DataType.INT).getDeclaringTable(false)
         .onFirstInstance("myField", "1", "2", "null")
         .andOnSecondInstance("myField", "1", "2", "null")
         .whenQuery("select myField, arrayagg(myField, 'INT') from testTable group by myField order by myField")
@@ -168,7 +139,7 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationGroupBySVIntWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(true)
+    new DataTypeScenario(DataType.INT).getDeclaringTable(true)
         .onFirstInstance("myField", "1", "2", "null")
         .andOnSecondInstance("myField", "1", "2", "null")
         .whenQuery("select myField, arrayagg(myField, 'INT') from testTable group by myField order by myField")
@@ -181,7 +152,7 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationDistinctGroupBySVIntWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(false)
+    new DataTypeScenario(DataType.INT).getDeclaringTable(false)
         .onFirstInstance("myField", "1", "2", "null")
         .andOnSecondInstance("myField", "1", "2", "null")
         .whenQuery("select myField, arrayagg(myField, 'INT', true) from testTable group by myField order by myField")
@@ -194,7 +165,7 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationDistinctGroupBySVIntWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(true)
+    new DataTypeScenario(DataType.INT).getDeclaringTable(true)
         .onFirstInstance("myField", "1", "2", "null")
         .andOnSecondInstance("myField", "1", "2", "null")
         .whenQuery("select myField, arrayagg(myField, 'INT', true) from testTable group by myField order by myField")
@@ -207,58 +178,41 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationLongWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "1",
-            "null",
-            "2"
-        ).andOnSecondInstance("myField",
-            "1",
-            "null",
-            "2"
-        ).whenQuery("select arrayagg(myField, 'LONG') from testTable")
+    new DataTypeScenario(DataType.LONG).getDeclaringTable(false)
+        .onFirstInstance("myField", "1", "null", "2")
+        .andOnSecondInstance("myField", "1", "null", "2")
+        .whenQuery("select arrayagg(myField, 'LONG') from testTable")
         .thenResultIs(new Object[]{new long[]{1, Long.MIN_VALUE, 2, 1, Long.MIN_VALUE, 2}});
   }
 
   @Test
   void aggregationLongWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "1",
-            "null",
-            "2"
-        ).andOnSecondInstance("myField",
-            "1",
-            "null",
-            "2"
-        ).whenQuery("select arrayagg(myField, 'LONG') from testTable")
+    new DataTypeScenario(DataType.LONG).getDeclaringTable(true)
+        .onFirstInstance("myField", "1", "null", "2")
+        .andOnSecondInstance("myField", "1", "null", "2")
+        .whenQuery("select arrayagg(myField, 'LONG') from testTable")
         .thenResultIs(new Object[]{new long[]{1, 2, 1, 2}});
   }
 
   @Test
   void aggregationDistinctLongWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select arrayagg(myField, 'LONG', true) from testTable")
+    new DataTypeScenario(DataType.LONG).getDeclaringTable(false)
+        .onFirstInstance("myField", "null", "null")
+        .whenQuery("select arrayagg(myField, 'LONG', true) from testTable")
         .thenResultIs(new Object[]{new long[]{Long.MIN_VALUE}});
   }
 
   @Test
   void aggregationDistinctLongWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "1",
-            "null",
-            "1"
-        ).whenQuery("select arrayagg(myField, 'LONG', true) from testTable")
+    new DataTypeScenario(DataType.LONG).getDeclaringTable(true)
+        .onFirstInstance("myField", "1", "null", "1")
+        .whenQuery("select arrayagg(myField, 'LONG', true) from testTable")
         .thenResultIs(new Object[]{new long[]{1}});
   }
 
   @Test
   void aggregationGroupBySVLongWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(false)
+    new DataTypeScenario(DataType.LONG).getDeclaringTable(false)
         .onFirstInstance("myField", "1", "2", "null")
         .andOnSecondInstance("myField", "1", "2", "null")
         .whenQuery("select myField, arrayagg(myField, 'LONG') from testTable group by myField order by myField")
@@ -271,7 +225,7 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationGroupBySVLongWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(true)
+    new DataTypeScenario(DataType.LONG).getDeclaringTable(true)
         .onFirstInstance("myField", "1", "2", "null")
         .andOnSecondInstance("myField", "1", "2", "null")
         .whenQuery("select myField, arrayagg(myField, 'LONG') from testTable group by myField order by myField")
@@ -284,7 +238,7 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationDistinctGroupBySVLongWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(false)
+    new DataTypeScenario(DataType.LONG).getDeclaringTable(false)
         .onFirstInstance("myField", "1", "2", "null")
         .andOnSecondInstance("myField", "1", "2", "null")
         .whenQuery("select myField, arrayagg(myField, 'LONG', true) from testTable group by myField order by myField")
@@ -297,7 +251,7 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationDistinctGroupBySVLongWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(true)
+    new DataTypeScenario(DataType.LONG).getDeclaringTable(true)
         .onFirstInstance("myField", "1", "2", "null")
         .andOnSecondInstance("myField", "1", "2", "null")
         .whenQuery("select myField, arrayagg(myField, 'LONG', true) from testTable group by myField order by myField")
@@ -310,59 +264,45 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationFloatWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "1.0",
-            "null",
-            "2.0"
-        ).andOnSecondInstance("myField",
-            "1.0",
-            "null",
-            "2.0"
-        ).whenQuery("select arrayagg(myField, 'FLOAT') from testTable")
-        .thenResultIs(new Object[]{new float[]{1.0f, Float.NEGATIVE_INFINITY, 2.0f, 1.0f, Float.NEGATIVE_INFINITY,
-            2.0f}});
+    new DataTypeScenario(DataType.FLOAT).getDeclaringTable(false)
+        .onFirstInstance("myField", "1.0", "null", "2.0")
+        .andOnSecondInstance("myField", "1.0", "null", "2.0")
+        .whenQuery("select arrayagg(myField, 'FLOAT') from testTable")
+        .thenResultIs(new Object[]{
+            new float[]{
+                1.0f, Float.NEGATIVE_INFINITY, 2.0f, 1.0f, Float.NEGATIVE_INFINITY, 2.0f
+            }
+        });
   }
 
   @Test
   void aggregationFloatWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "1.0",
-            "null",
-            "2.0"
-        ).andOnSecondInstance("myField",
-            "1.0",
-            "null",
-            "2.0"
-        ).whenQuery("select arrayagg(myField, 'FLOAT') from testTable")
+    new DataTypeScenario(DataType.FLOAT).getDeclaringTable(true)
+        .onFirstInstance("myField", "1.0", "null", "2.0")
+        .andOnSecondInstance("myField", "1.0", "null", "2.0")
+        .whenQuery("select arrayagg(myField, 'FLOAT') from testTable")
         .thenResultIs(new Object[]{new float[]{1.0f, 2.0f, 1.0f, 2.0f}});
   }
 
   @Test
   void aggregationDistinctFloatWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select arrayagg(myField, 'FLOAT', true) from testTable")
+    new DataTypeScenario(DataType.FLOAT).getDeclaringTable(false)
+        .onFirstInstance("myField", "null", "null")
+        .whenQuery("select arrayagg(myField, 'FLOAT', true) from testTable")
         .thenResultIs(new Object[]{new float[]{Float.NEGATIVE_INFINITY}});
   }
 
   @Test
   void aggregationDistinctFloatWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "1.0",
-            "null",
-            "1.0"
-        ).whenQuery("select arrayagg(myField, 'FLOAT', true) from testTable")
+    new DataTypeScenario(DataType.FLOAT).getDeclaringTable(true)
+        .onFirstInstance("myField", "1.0", "null", "1.0")
+        .whenQuery("select arrayagg(myField, 'FLOAT', true) from testTable")
         .thenResultIs(new Object[]{new float[]{1.0f}});
   }
 
   @Test
   void aggregationGroupBySVFloatWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(false)
+    new DataTypeScenario(DataType.FLOAT).getDeclaringTable(false)
         .onFirstInstance("myField", "null", "1.0", "2.0")
         .andOnSecondInstance("myField", "null", "1.0", "2.0")
         .whenQuery("select myField, arrayagg(myField, 'FLOAT') from testTable group by myField order by myField")
@@ -375,7 +315,7 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationGroupBySVFloatWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(true)
+    new DataTypeScenario(DataType.FLOAT).getDeclaringTable(true)
         .onFirstInstance("myField", "null", "1.0")
         .andOnSecondInstance("myField", "null", "1.0")
         .whenQuery("select myField, arrayagg(myField, 'FLOAT') from testTable group by myField order by myField")
@@ -387,7 +327,7 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationDistinctGroupBySVFloatWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(false)
+    new DataTypeScenario(DataType.FLOAT).getDeclaringTable(false)
         .onFirstInstance("myField", "null", "1.0", "2.0")
         .andOnSecondInstance("myField", "null", "1.0", "2.0")
         .whenQuery("select myField, arrayagg(myField, 'FLOAT', true) from testTable group by myField order by myField")
@@ -400,7 +340,7 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationDistinctGroupBySVFloatWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(true)
+    new DataTypeScenario(DataType.FLOAT).getDeclaringTable(true)
         .onFirstInstance("myField", "null", "1.0")
         .andOnSecondInstance("myField", "null", "1.0")
         .whenQuery("select myField, arrayagg(myField, 'FLOAT', true) from testTable group by myField order by myField")
@@ -412,59 +352,45 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationDoubleWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "1.0",
-            "null",
-            "2.0"
-        ).andOnSecondInstance("myField",
-            "1.0",
-            "null",
-            "2.0"
-        ).whenQuery("select arrayagg(myField, 'DOUBLE') from testTable")
-        .thenResultIs(new Object[]{new double[]{1.0, Double.NEGATIVE_INFINITY, 2.0, 1.0, Double.NEGATIVE_INFINITY,
-            2.0}});
+    new DataTypeScenario(DataType.DOUBLE).getDeclaringTable(false)
+        .onFirstInstance("myField", "1.0", "null", "2.0")
+        .andOnSecondInstance("myField", "1.0", "null", "2.0")
+        .whenQuery("select arrayagg(myField, 'DOUBLE') from testTable")
+        .thenResultIs(new Object[]{
+            new double[]{
+                1.0, Double.NEGATIVE_INFINITY, 2.0, 1.0, Double.NEGATIVE_INFINITY, 2.0
+            }
+        });
   }
 
   @Test
   void aggregationDoubleWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "1.0",
-            "null",
-            "2.0"
-        ).andOnSecondInstance("myField",
-            "1.0",
-            "null",
-            "2.0"
-        ).whenQuery("select arrayagg(myField, 'DOUBLE') from testTable")
+    new DataTypeScenario(DataType.DOUBLE).getDeclaringTable(true)
+        .onFirstInstance("myField", "1.0", "null", "2.0")
+        .andOnSecondInstance("myField", "1.0", "null", "2.0")
+        .whenQuery("select arrayagg(myField, 'DOUBLE') from testTable")
         .thenResultIs(new Object[]{new double[]{1.0, 2.0, 1.0, 2.0}});
   }
 
   @Test
   void aggregationDistinctDoubleWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select arrayagg(myField, 'DOUBLE', true) from testTable")
+    new DataTypeScenario(DataType.DOUBLE).getDeclaringTable(false)
+        .onFirstInstance("myField", "null", "null")
+        .whenQuery("select arrayagg(myField, 'DOUBLE', true) from testTable")
         .thenResultIs(new Object[]{new double[]{Double.NEGATIVE_INFINITY}});
   }
 
   @Test
   void aggregationDistinctDoubleWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "1.0",
-            "null",
-            "1.0"
-        ).whenQuery("select arrayagg(myField, 'DOUBLE', true) from testTable")
+    new DataTypeScenario(DataType.DOUBLE).getDeclaringTable(true)
+        .onFirstInstance("myField", "1.0", "null", "1.0")
+        .whenQuery("select arrayagg(myField, 'DOUBLE', true) from testTable")
         .thenResultIs(new Object[]{new double[]{1.0}});
   }
 
   @Test
   void aggregationGroupBySVDoubleWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(false)
+    new DataTypeScenario(DataType.DOUBLE).getDeclaringTable(false)
         .onFirstInstance("myField", "null", "1.0", "2.0")
         .andOnSecondInstance("myField", "null", "1.0", "2.0")
         .whenQuery("select myField, arrayagg(myField, 'DOUBLE') from testTable group by myField order by myField")
@@ -477,7 +403,7 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationGroupBySVDoubleWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(true)
+    new DataTypeScenario(DataType.DOUBLE).getDeclaringTable(true)
         .onFirstInstance("myField", "null", "1.0", "2.0")
         .andOnSecondInstance("myField", "null", "1.0", "2.0")
         .whenQuery("select myField, arrayagg(myField, 'DOUBLE') from testTable group by myField order by myField")
@@ -490,7 +416,7 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationDistinctGroupBySVDoubleWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(false)
+    new DataTypeScenario(DataType.DOUBLE).getDeclaringTable(false)
         .onFirstInstance("myField", "null", "1.0", "2.0")
         .andOnSecondInstance("myField", "null", "1.0", "2.0")
         .whenQuery("select myField, arrayagg(myField, 'DOUBLE', true) from testTable group by myField order by myField")
@@ -503,7 +429,7 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationDistinctGroupBySVDoubleWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(true)
+    new DataTypeScenario(DataType.DOUBLE).getDeclaringTable(true)
         .onFirstInstance("myField", "null", "1.0", "2.0")
         .andOnSecondInstance("myField", "null", "1.0", "2.0")
         .whenQuery("select myField, arrayagg(myField, 'DOUBLE', true) from testTable group by myField order by myField")
@@ -516,84 +442,58 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationBigDecimalWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.BIG_DECIMAL).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "1.5",
-            "null",
-            "2.5"
-        ).andOnSecondInstance("myField",
-            "1.5",
-            "null",
-            "2.5"
-        ).whenQuery("select arrayagg(myField, 'BIG_DECIMAL') from testTable")
+    new DataTypeScenario(DataType.BIG_DECIMAL).getDeclaringTable(true)
+        .onFirstInstance("myField", "1.5", "null", "2.5")
+        .andOnSecondInstance("myField", "1.5", "null", "2.5")
+        .whenQuery("select arrayagg(myField, 'BIG_DECIMAL') from testTable")
         .thenResultIs(new Object[]{new String[]{"1.5", "2.5", "1.5", "2.5"}});
   }
 
   @Test
   void aggregationDistinctBigDecimalWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.BIG_DECIMAL).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "1.5",
-            "null",
-            "1.5"
-        ).whenQuery("select arrayagg(myField, 'BIG_DECIMAL', true) from testTable")
+    new DataTypeScenario(DataType.BIG_DECIMAL).getDeclaringTable(true)
+        .onFirstInstance("myField", "1.5", "null", "1.5")
+        .whenQuery("select arrayagg(myField, 'BIG_DECIMAL', true) from testTable")
         .thenResultIs(new Object[]{new String[]{"1.5"}});
   }
 
   @Test
   void aggregationStringWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.STRING).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "a",
-            "null",
-            "b"
-        ).andOnSecondInstance("myField",
-            "a",
-            "null",
-            "b"
-        ).whenQuery("select arrayagg(myField, 'STRING') from testTable")
+    new DataTypeScenario(DataType.STRING).getDeclaringTable(false)
+        .onFirstInstance("myField", "a", "null", "b")
+        .andOnSecondInstance("myField", "a", "null", "b")
+        .whenQuery("select arrayagg(myField, 'STRING') from testTable")
         .thenResultIs(new Object[]{new String[]{"a", "null", "b", "a", "null", "b"}});
   }
 
   @Test
   void aggregationStringWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.STRING).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "a",
-            "null",
-            "b"
-        ).andOnSecondInstance("myField",
-            "a",
-            "null",
-            "b"
-        ).whenQuery("select arrayagg(myField, 'STRING') from testTable")
+    new DataTypeScenario(DataType.STRING).getDeclaringTable(true)
+        .onFirstInstance("myField", "a", "null", "b")
+        .andOnSecondInstance("myField", "a", "null", "b")
+        .whenQuery("select arrayagg(myField, 'STRING') from testTable")
         .thenResultIs(new Object[]{new String[]{"a", "b", "a", "b"}});
   }
 
   @Test
   void aggregationDistinctStringWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.STRING).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select arrayagg(myField, 'STRING', true) from testTable")
+    new DataTypeScenario(DataType.STRING).getDeclaringTable(false)
+        .onFirstInstance("myField", "null", "null")
+        .whenQuery("select arrayagg(myField, 'STRING', true) from testTable")
         .thenResultIs(new Object[]{new String[]{"null"}});
   }
 
   @Test
   void aggregationDistinctStringWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.STRING).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "a",
-            "null",
-            "a"
-        ).whenQuery("select arrayagg(myField, 'STRING', true) from testTable")
+    new DataTypeScenario(DataType.STRING).getDeclaringTable(true)
+        .onFirstInstance("myField", "a", "null", "a")
+        .whenQuery("select arrayagg(myField, 'STRING', true) from testTable")
         .thenResultIs(new Object[]{new String[]{"a"}});
   }
 
   @Test
   void aggregationGroupBySVStringWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.STRING).getDeclaringTable(false)
+    new DataTypeScenario(DataType.STRING).getDeclaringTable(false)
         .onFirstInstance("myField", "a", "b", "null")
         .andOnSecondInstance("myField", "a", "b", "null")
         .whenQuery("select myField, arrayagg(myField, 'STRING') from testTable group by myField order by myField")
@@ -606,7 +506,7 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationGroupBySVStringWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.STRING).getDeclaringTable(true)
+    new DataTypeScenario(DataType.STRING).getDeclaringTable(true)
         .onFirstInstance("myField", "a", "b", "null")
         .andOnSecondInstance("myField", "a", "b", "null")
         .whenQuery("select myField, arrayagg(myField, 'STRING') from testTable group by myField order by myField")
@@ -619,7 +519,7 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationDistinctGroupBySVStringWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.STRING).getDeclaringTable(false)
+    new DataTypeScenario(DataType.STRING).getDeclaringTable(false)
         .onFirstInstance("myField", "a", "b", "null")
         .andOnSecondInstance("myField", "a", "b", "null")
         .whenQuery("select myField, arrayagg(myField, 'STRING', true) from testTable group by myField order by myField")
@@ -632,7 +532,7 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationDistinctGroupBySVStringWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.STRING).getDeclaringTable(true)
+    new DataTypeScenario(DataType.STRING).getDeclaringTable(true)
         .onFirstInstance("myField", "a", "b", "null")
         .andOnSecondInstance("myField", "a", "b", "null")
         .whenQuery("select myField, arrayagg(myField, 'STRING', true) from testTable group by myField order by myField")
@@ -645,62 +545,60 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   void aggregationGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addMetricField("value", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addMetricField("value", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", 0},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", 0},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", 0}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", 0}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, arrayagg(value, 'INT') from testTable group by tags order by tags")
-        .thenResultIs(new Object[]{"tag1", new int[]{0, 0}}, new Object[]{"tag2", new int[]{0, 0, 0, 0}},
-            new Object[]{"tag3", new int[]{0, 0}})
-        .whenQueryWithNullHandlingEnabled("select tags, arrayagg(value, 'INT') from testTable group by tags "
-            + "order by tags")
-        .thenResultIs(new Object[]{"tag1", new int[]{0, 0}}, new Object[]{"tag2", new int[]{0, 0}},
-            new Object[]{"tag3", new int[]{}});
+        .thenResultIs(
+            new Object[]{"tag1", new int[]{0, 0}},
+            new Object[]{"tag2", new int[]{0, 0, 0, 0}},
+            new Object[]{"tag3", new int[]{0, 0}}
+        )
+        .whenQueryWithNullHandlingEnabled(
+            "select tags, arrayagg(value, 'INT') from testTable group by tags " + "order by tags")
+        .thenResultIs(
+            new Object[]{"tag1", new int[]{0, 0}},
+            new Object[]{"tag2", new int[]{0, 0}},
+            new Object[]{"tag3", new int[]{}}
+        );
   }
 
   @Test
   void aggregationDistinctGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addMetricField("value", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addMetricField("value", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", 0},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", 0},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", 0}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", 0}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, arrayagg(value, 'INT', true) from testTable group by tags order by tags")
-        .thenResultIs(new Object[]{"tag1", new int[]{0}}, new Object[]{"tag2", new int[]{0}},
-            new Object[]{"tag3", new int[]{0}})
-        .whenQueryWithNullHandlingEnabled("select tags, arrayagg(value, 'INT', true) from testTable group by tags "
-            + "order by tags")
-        .thenResultIs(new Object[]{"tag1", new int[]{0}}, new Object[]{"tag2", new int[]{0}},
-            new Object[]{"tag3", new int[]{}});
+        .thenResultIs(
+            new Object[]{"tag1", new int[]{0}},
+            new Object[]{"tag2", new int[]{0}},
+            new Object[]{"tag3", new int[]{0}}
+        )
+        .whenQueryWithNullHandlingEnabled(
+            "select tags, arrayagg(value, 'INT', true) from testTable group by tags " + "order by tags")
+        .thenResultIs(
+            new Object[]{"tag1", new int[]{0}},
+            new Object[]{"tag2", new int[]{0}},
+            new Object[]{"tag3", new int[]{}}
+        );
   }
 
   @Test
   public void testDoubleArrayAggMultipleBlocks() {
-    ArrayAggDistinctDoubleFunction arrayAggDistinctDoubleFunction = new ArrayAggDistinctDoubleFunction(
-        ExpressionContext.forIdentifier("myField"), false);
+    ArrayAggDistinctDoubleFunction arrayAggDistinctDoubleFunction =
+        new ArrayAggDistinctDoubleFunction(ExpressionContext.forIdentifier("myField"), false);
     AggregationResultHolder aggregationResultHolder = arrayAggDistinctDoubleFunction.createAggregationResultHolder();
     arrayAggDistinctDoubleFunction.aggregate(2, aggregationResultHolder,
         Map.of(ExpressionContext.forIdentifier("myField"),
@@ -711,23 +609,21 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
     DoubleOpenHashSet distinctResult = aggregationResultHolder.getResult();
     assertEquals(distinctResult.size(), 3);
 
-    ArrayAggDoubleFunction arrayAggDoubleFunction = new ArrayAggDoubleFunction(
-        ExpressionContext.forIdentifier("myField"), false);
+    ArrayAggDoubleFunction arrayAggDoubleFunction =
+        new ArrayAggDoubleFunction(ExpressionContext.forIdentifier("myField"), false);
     aggregationResultHolder = arrayAggDoubleFunction.createAggregationResultHolder();
-    arrayAggDoubleFunction.aggregate(2, aggregationResultHolder,
-        Map.of(ExpressionContext.forIdentifier("myField"),
-            SyntheticBlockValSets.Double.create(null, new double[]{1.0, 2.0})));
-    arrayAggDoubleFunction.aggregate(2, aggregationResultHolder,
-        Map.of(ExpressionContext.forIdentifier("myField"),
-            SyntheticBlockValSets.Double.create(null, new double[]{2.0, 3.0})));
+    arrayAggDoubleFunction.aggregate(2, aggregationResultHolder, Map.of(ExpressionContext.forIdentifier("myField"),
+        SyntheticBlockValSets.Double.create(null, new double[]{1.0, 2.0})));
+    arrayAggDoubleFunction.aggregate(2, aggregationResultHolder, Map.of(ExpressionContext.forIdentifier("myField"),
+        SyntheticBlockValSets.Double.create(null, new double[]{2.0, 3.0})));
     DoubleArrayList result = aggregationResultHolder.getResult();
     assertEquals(result.size(), 4);
   }
 
   @Test
   public void testLongArrayAggMultipleBlocks() {
-    ArrayAggDistinctLongFunction arrayAggDistinctLongFunction = new ArrayAggDistinctLongFunction(
-        ExpressionContext.forIdentifier("myField"), FieldSpec.DataType.LONG, false);
+    ArrayAggDistinctLongFunction arrayAggDistinctLongFunction =
+        new ArrayAggDistinctLongFunction(ExpressionContext.forIdentifier("myField"), DataType.LONG, false);
     AggregationResultHolder aggregationResultHolder = arrayAggDistinctLongFunction.createAggregationResultHolder();
     arrayAggDistinctLongFunction.aggregate(2, aggregationResultHolder,
         Map.of(ExpressionContext.forIdentifier("myField"),
@@ -738,15 +634,13 @@ public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
     LongOpenHashSet distinctResult = aggregationResultHolder.getResult();
     assertEquals(distinctResult.size(), 3);
 
-    ArrayAggLongFunction arrayAggLongFunction = new ArrayAggLongFunction(
-        ExpressionContext.forIdentifier("myField"), FieldSpec.DataType.LONG, false);
+    ArrayAggLongFunction arrayAggLongFunction =
+        new ArrayAggLongFunction(ExpressionContext.forIdentifier("myField"), DataType.LONG, false);
     aggregationResultHolder = arrayAggLongFunction.createAggregationResultHolder();
-    arrayAggLongFunction.aggregate(2, aggregationResultHolder,
-        Map.of(ExpressionContext.forIdentifier("myField"),
-            SyntheticBlockValSets.Long.create(null, new long[]{1L, 2L})));
-    arrayAggLongFunction.aggregate(2, aggregationResultHolder,
-        Map.of(ExpressionContext.forIdentifier("myField"),
-            SyntheticBlockValSets.Long.create(null, new long[]{1L, 2L})));
+    arrayAggLongFunction.aggregate(2, aggregationResultHolder, Map.of(ExpressionContext.forIdentifier("myField"),
+        SyntheticBlockValSets.Long.create(null, new long[]{1L, 2L})));
+    arrayAggLongFunction.aggregate(2, aggregationResultHolder, Map.of(ExpressionContext.forIdentifier("myField"),
+        SyntheticBlockValSets.Long.create(null, new long[]{1L, 2L})));
     LongArrayList result = aggregationResultHolder.getResult();
     assertEquals(result.size(), 4);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ArrayAggMvFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ArrayAggMvFunctionTest.java
@@ -45,7 +45,7 @@ import org.apache.pinot.core.query.aggregation.function.array.ArrayAggLongFuncti
 import org.apache.pinot.core.query.aggregation.function.array.ArrayAggStringFunction;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -71,8 +71,8 @@ public class ArrayAggMvFunctionTest extends AbstractAggregationFunctionTest {
     }
 
     @Override
-    public FieldSpec.DataType getValueType() {
-      return FieldSpec.DataType.DOUBLE;
+    public DataType getValueType() {
+      return DataType.DOUBLE;
     }
   }
 
@@ -94,8 +94,8 @@ public class ArrayAggMvFunctionTest extends AbstractAggregationFunctionTest {
     }
 
     @Override
-    public FieldSpec.DataType getValueType() {
-      return FieldSpec.DataType.LONG;
+    public DataType getValueType() {
+      return DataType.LONG;
     }
   }
 
@@ -117,8 +117,8 @@ public class ArrayAggMvFunctionTest extends AbstractAggregationFunctionTest {
     }
 
     @Override
-    public FieldSpec.DataType getValueType() {
-      return FieldSpec.DataType.INT;
+    public DataType getValueType() {
+      return DataType.INT;
     }
   }
 
@@ -140,8 +140,8 @@ public class ArrayAggMvFunctionTest extends AbstractAggregationFunctionTest {
     }
 
     @Override
-    public FieldSpec.DataType getValueType() {
-      return FieldSpec.DataType.FLOAT;
+    public DataType getValueType() {
+      return DataType.FLOAT;
     }
   }
 
@@ -163,8 +163,8 @@ public class ArrayAggMvFunctionTest extends AbstractAggregationFunctionTest {
     }
 
     @Override
-    public FieldSpec.DataType getValueType() {
-      return FieldSpec.DataType.STRING;
+    public DataType getValueType() {
+      return DataType.STRING;
     }
   }
 
@@ -198,8 +198,8 @@ public class ArrayAggMvFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   public void testLongArrayAggMvMultipleBlocks() {
-    ArrayAggDistinctLongFunction distinctFn = new ArrayAggDistinctLongFunction(
-        ExpressionContext.forIdentifier("myField"), FieldSpec.DataType.LONG, false);
+    ArrayAggDistinctLongFunction distinctFn =
+        new ArrayAggDistinctLongFunction(ExpressionContext.forIdentifier("myField"), DataType.LONG, false);
     AggregationResultHolder holder = distinctFn.createAggregationResultHolder();
 
     distinctFn.aggregate(2, holder,
@@ -209,8 +209,8 @@ public class ArrayAggMvFunctionTest extends AbstractAggregationFunctionTest {
     LongOpenHashSet distinct = holder.getResult();
     assertEquals(distinct.size(), 3);
 
-    ArrayAggLongFunction fn = new ArrayAggLongFunction(ExpressionContext.forIdentifier("myField"),
-        FieldSpec.DataType.LONG, false);
+    ArrayAggLongFunction fn =
+        new ArrayAggLongFunction(ExpressionContext.forIdentifier("myField"), DataType.LONG, false);
     holder = fn.createAggregationResultHolder();
     fn.aggregate(2, holder,
         Map.of(ExpressionContext.forIdentifier("myField"), new TestLongMVBlock(new long[][]{{1L, 2L}, {2L}})));
@@ -229,8 +229,8 @@ public class ArrayAggMvFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   public void testIntArrayAggMvMultipleBlocks() {
-    ArrayAggDistinctIntFunction distinctFn = new ArrayAggDistinctIntFunction(
-        ExpressionContext.forIdentifier("myField"), FieldSpec.DataType.INT, false);
+    ArrayAggDistinctIntFunction distinctFn =
+        new ArrayAggDistinctIntFunction(ExpressionContext.forIdentifier("myField"), DataType.INT, false);
     AggregationResultHolder holder = distinctFn.createAggregationResultHolder();
 
     distinctFn.aggregate(2, holder,
@@ -240,8 +240,7 @@ public class ArrayAggMvFunctionTest extends AbstractAggregationFunctionTest {
     IntOpenHashSet distinct = holder.getResult();
     assertEquals(distinct.size(), 3);
 
-    ArrayAggIntFunction fn = new ArrayAggIntFunction(ExpressionContext.forIdentifier("myField"),
-        FieldSpec.DataType.INT, false);
+    ArrayAggIntFunction fn = new ArrayAggIntFunction(ExpressionContext.forIdentifier("myField"), DataType.INT, false);
     holder = fn.createAggregationResultHolder();
     fn.aggregate(2, holder,
         Map.of(ExpressionContext.forIdentifier("myField"), new TestIntMVBlock(new int[][]{{1, 2}, {2}})));

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunctionTest.java
@@ -22,6 +22,8 @@ import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.DataProvider;
@@ -34,139 +36,104 @@ public class AvgAggregationFunctionTest extends AbstractAggregationFunctionTest 
 
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
-    return new Object[] {
-        new DataTypeScenario(FieldSpec.DataType.INT),
-        new DataTypeScenario(FieldSpec.DataType.LONG),
-        new DataTypeScenario(FieldSpec.DataType.FLOAT),
-        new DataTypeScenario(FieldSpec.DataType.DOUBLE),
-        new DataTypeScenario(FieldSpec.DataType.BIG_DECIMAL)
+    return new Object[]{
+        new DataTypeScenario(DataType.INT),
+        new DataTypeScenario(DataType.LONG),
+        new DataTypeScenario(DataType.FLOAT),
+        new DataTypeScenario(DataType.DOUBLE),
+        new DataTypeScenario(DataType.BIG_DECIMAL)
     };
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select avg(myField) from testTable")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null)));
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select avg(myField) from testTable")
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.METRIC, scenario.getDataType(), null))
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select avg(myField) from testTable")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select avg(myField) from testTable")
         .thenResultIs("DOUBLE", "null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', avg(myField) from testTable group by 'literal'")
-        .thenResultIs("STRING | DOUBLE", "literal | "
-            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null));
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', avg(myField) from testTable group by 'literal'")
+        .thenResultIs(
+            "STRING | DOUBLE",
+            "literal | " + FieldSpec.getDefaultNullValue(FieldType.METRIC, scenario.getDataType(), null)
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', avg(myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', avg(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "7",
-            "null",
-            "5"
-        ).andOnSecondInstance("myField",
-            "null",
-            "3"
-        ).whenQuery("select avg(myField) from testTable")
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "7", "null", "5")
+        .andOnSecondInstance("myField", "null", "3")
+        .whenQuery("select avg(myField) from testTable")
         .thenResultIs("DOUBLE", "3");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "7",
-            "null",
-            "5"
-        ).andOnSecondInstance("myField",
-            "null",
-            "3"
-        ).whenQuery("select avg(myField) from testTable")
+        .onFirstInstance("myField", "7", "null", "5")
+        .andOnSecondInstance("myField", "null", "3")
+        .whenQuery("select avg(myField) from testTable")
         .thenResultIs("DOUBLE", "5");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "7",
-            "null",
-            "5"
-        ).andOnSecondInstance("myField",
-            "null",
-            "3"
-        ).whenQuery("select 'literal', avg(myField) from testTable group by 'literal'")
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "7", "null", "5")
+        .andOnSecondInstance("myField", "null", "3")
+        .whenQuery("select 'literal', avg(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | 3");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "7",
-            "null",
-            "5"
-        ).andOnSecondInstance("myField",
-            "null",
-            "3"
-        ).whenQuery("select 'literal', avg(myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "7", "null", "5")
+        .andOnSecondInstance("myField", "null", "3")
+        .whenQuery("select 'literal', avg(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | 5");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupByMV(DataTypeScenario scenario) {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addMetricField("value", scenario.getDataType())
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addMetricField("value", scenario.getDataType())
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", 2},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", 2}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, AVG(value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | DOUBLE",
@@ -185,26 +152,23 @@ public class AvgAggregationFunctionTest extends AbstractAggregationFunctionTest 
 
   @Test(dataProvider = "encodingTypes")
   void singleKeyAggregationWithSmallNumGroupsLimitDoesntThrowAIOOBE(FieldConfig.EncodingType encoding) {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMetricField("key", DataType.INT)
+        .addMetricField("value", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMetricField("key", FieldSpec.DataType.INT)
-                .addMetricField("value", FieldSpec.DataType.INT)
-                .build(),
-            new TableConfigBuilder(TableType.OFFLINE)
-                .setTableName("testTable")
-                .addFieldConfig(new FieldConfig("key", encoding, null, PASS_THROUGH, null))
-                .build())
+        .givenTable(schema, new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
+            .addFieldConfig(new FieldConfig("key", encoding, null, PASS_THROUGH, null))
+            .build())
         .onFirstInstance(new Object[]{7, 1}, new Object[]{6, 2}, new Object[]{5, 3}, new Object[]{4, 4})
         .andOnSecondInstance(new Object[]{7, 1}, new Object[]{6, 2}, new Object[]{5, 3}, new Object[]{4, 4})
-        .whenQuery(
-            "set numGroupsLimit=3; set maxInitialResultHolderCapacity=1000; "
-                + "select key, avg(value) "
-                + "from testTable "
-                + "group by key "
-                + "order by key")
+        .whenQuery("""
+            set numGroupsLimit=3; set maxInitialResultHolderCapacity=1000; \
+            select key, avg(value) \
+            from testTable \
+            group by key \
+            order by key""")
         .thenResultIs(
             "INT | DOUBLE",
             "5   |  3",
@@ -215,28 +179,25 @@ public class AvgAggregationFunctionTest extends AbstractAggregationFunctionTest 
 
   @Test(dataProvider = "encodingTypes")
   void multiKeyAggregationWithSmallNumGroupsLimitDoesntThrowAIOOBE(FieldConfig.EncodingType encoding) {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMetricField("key1", DataType.INT)
+        .addMetricField("key2", DataType.INT)
+        .addMetricField("value", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMetricField("key1", FieldSpec.DataType.INT)
-                .addMetricField("key2", FieldSpec.DataType.INT)
-                .addMetricField("value", FieldSpec.DataType.INT)
-                .build(),
-            new TableConfigBuilder(TableType.OFFLINE)
-                .setTableName("testTable")
-                .addFieldConfig(new FieldConfig("key1", encoding, null, PASS_THROUGH, null))
-                .addFieldConfig(new FieldConfig("key2", encoding, null, PASS_THROUGH, null))
-                .build())
+        .givenTable(schema, new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
+            .addFieldConfig(new FieldConfig("key1", encoding, null, PASS_THROUGH, null))
+            .addFieldConfig(new FieldConfig("key2", encoding, null, PASS_THROUGH, null))
+            .build())
         .onFirstInstance(new Object[]{7, 1}, new Object[]{6, 2}, new Object[]{5, 3}, new Object[]{4, 4})
         .andOnSecondInstance(new Object[]{7, 1}, new Object[]{6, 2}, new Object[]{5, 3}, new Object[]{4, 4})
-        .whenQuery(
-            "set numGroupsLimit=3; set maxInitialResultHolderCapacity=1000; "
-                + "select key1, key2, count(*) "
-                + "from testTable "
-                + "group by key1, key2 "
-                + "order by key1, key2")
+        .whenQuery("""
+            set numGroupsLimit=3; set maxInitialResultHolderCapacity=1000; \
+            select key1, key2, count(*) \
+            from testTable \
+            group by key1, key2 \
+            order by key1, key2""")
         .thenResultIs(
             "INT | INT | LONG",
             "5   |  3  |  2",
@@ -252,124 +213,97 @@ public class AvgAggregationFunctionTest extends AbstractAggregationFunctionTest 
 
   @Test
   public void aggregationMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select avg(mv) from testTable")
-        .thenResultIs("DOUBLE", String.valueOf(
-            (6 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
-                / 4.0))
+        .thenResultIs("DOUBLE",
+            String.valueOf((6 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)) / 4.0))
         .whenQueryWithNullHandlingEnabled("select avg(mv) from testTable")
         .thenResultIs("DOUBLE", "2");
   }
 
   @Test
   public void aggregationMVGroupBySVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"})
+        .andOnSecondInstance(new Object[]{"null", "k1"})
         .whenQuery("select avg(mv) from testTable group by sv")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs("DOUBLE", String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)))
         .whenQueryWithNullHandlingEnabled("select avg(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "null");
   }
 
   @Test
   public void aggregationMVGroupBySVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"},
-            new Object[]{"1;2;3", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k2"},
-            new Object[]{"1;2;3", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"}, new Object[]{"1;2;3", "k2"})
+        .andOnSecondInstance(new Object[]{"null", "k2"}, new Object[]{"1;2;3", "k1"})
         .whenQuery("select avg(mv) from testTable group by sv")
-        .thenResultIs("DOUBLE", String.valueOf(
-            (6 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
-                / 4.0), String.valueOf(
-            (6 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
-                / 4.0))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf((6 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)) / 4.0),
+            String.valueOf((6 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)) / 4.0)
+        )
         .whenQueryWithNullHandlingEnabled("select avg(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "2", "2");
   }
 
   @Test
   public void aggregationMVGroupByMVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select avg(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select avg(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "null", "null");
   }
 
   @Test
   public void aggregationMVGroupByMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select avg(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE", String.valueOf(
-            (3 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
-                / 3.0), String.valueOf(
-            (3 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
-                / 3.0))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf((3 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)) / 3.0),
+            String.valueOf((3 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)) / 3.0)
+        )
         .whenQueryWithNullHandlingEnabled("select avg(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "1.5", "1.5");
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunctionTest.java
@@ -20,6 +20,8 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -28,148 +30,107 @@ public class AvgMVAggregationFunctionTest extends AbstractAggregationFunctionTes
 
   @Test
   public void aggregationAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select avg_mv(mv) from testTable")
         .thenResultIs("DOUBLE",
-            String.valueOf(
-                (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
-        )
+            String.valueOf((int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)))
         .whenQueryWithNullHandlingEnabled("select avg_mv(mv) from testTable")
         .thenResultIs("DOUBLE", "null");
   }
 
   @Test
   public void aggregationWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select avg_mv(mv) from testTable")
-        .thenResultIs("DOUBLE", String.valueOf(
-            (6 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
-                / 4.0))
+        .thenResultIs("DOUBLE",
+            String.valueOf((6 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)) / 4.0))
         .whenQueryWithNullHandlingEnabled("select avg_mv(mv) from testTable")
         .thenResultIs("DOUBLE", "2");
   }
 
   @Test
   public void aggregationGroupBySVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"})
+        .andOnSecondInstance(new Object[]{"null", "k1"})
         .whenQuery("select avg_mv(mv) from testTable group by sv")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs("DOUBLE", String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)))
         .whenQueryWithNullHandlingEnabled("select avg_mv(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "null");
   }
 
   @Test
   public void aggregationGroupBySVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"},
-            new Object[]{"1;2;3", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k2"},
-            new Object[]{"1;2;3", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"}, new Object[]{"1;2;3", "k2"})
+        .andOnSecondInstance(new Object[]{"null", "k2"}, new Object[]{"1;2;3", "k1"})
         .whenQuery("select avg_mv(mv) from testTable group by sv")
-        .thenResultIs("DOUBLE", String.valueOf(
-            (6 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
-                / 4.0), String.valueOf(
-            (6 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
-                / 4.0))
+        .thenResultIs("DOUBLE",
+            String.valueOf((6 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)) / 4.0),
+            String.valueOf((6 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)) / 4.0))
         .whenQueryWithNullHandlingEnabled("select avg_mv(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "2", "2");
   }
 
   @Test
   public void aggregationGroupByMVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select avg_mv(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs("DOUBLE", String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)))
         .whenQueryWithNullHandlingEnabled("select avg_mv(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "null", "null");
   }
 
   @Test
   public void aggregationGroupByMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select avg_mv(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE", String.valueOf(
-            (3 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
-                / 3.0), String.valueOf(
-            (3 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
-                / 3.0))
+        .thenResultIs("DOUBLE",
+            String.valueOf((3 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)) / 3.0),
+            String.valueOf((3 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)) / 3.0))
         .whenQueryWithNullHandlingEnabled("select avg_mv(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "1.5", "1.5");
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/BooleanAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/BooleanAggregationFunctionTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.testng.annotations.Test;
 
 
@@ -26,153 +26,109 @@ public class BooleanAggregationFunctionTest extends AbstractAggregationFunctionT
 
   @Test
   void aggregationAllNullsWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select bool_or(myField) from testTable")
+    new DataTypeScenario(DataType.BOOLEAN).getDeclaringTable(false)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select bool_or(myField) from testTable")
         .thenResultIs("BOOLEAN", "false");
   }
 
   @Test
   void aggregationAllNullsWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select bool_and(myField) from testTable")
+    new DataTypeScenario(DataType.BOOLEAN).getDeclaringTable(true)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select bool_and(myField) from testTable")
         .thenResultIs("BOOLEAN", "null");
   }
 
   @Test
   void aggregationGroupBySVAllNullsWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', bool_and(myField) from testTable group by 'literal'")
+    new DataTypeScenario(DataType.BOOLEAN).getDeclaringTable(false)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', bool_and(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | BOOLEAN", "literal | false");
   }
 
   @Test
   void aggregationGroupBySVAllNullsWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', bool_or(myField) from testTable group by 'literal'")
+    new DataTypeScenario(DataType.BOOLEAN).getDeclaringTable(true)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', bool_or(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | BOOLEAN", "literal | null");
   }
 
   @Test
   void andAggregationWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "true"
-        ).andOnSecondInstance("myField",
-            "null",
-            "true"
-        ).whenQuery("select bool_and(myField) from testTable")
+    new DataTypeScenario(DataType.BOOLEAN).getDeclaringTable(false)
+        .onFirstInstance("myField", "null", "true")
+        .andOnSecondInstance("myField", "null", "true")
+        .whenQuery("select bool_and(myField) from testTable")
         .thenResultIs("BOOLEAN", "false");
   }
 
   @Test
   void andAggregationWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "true"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select bool_and(myField) from testTable")
+    new DataTypeScenario(DataType.BOOLEAN).getDeclaringTable(true)
+        .onFirstInstance("myField", "null", "true")
+        .andOnSecondInstance("myField", "null", "null")
+        .whenQuery("select bool_and(myField) from testTable")
         .thenResultIs("BOOLEAN", "true");
   }
 
   @Test
   void andAggregationGroupBySVWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "true"
-        ).andOnSecondInstance("myField",
-            "null",
-            "true"
-        ).whenQuery("select 'literal', bool_and(myField) from testTable group by 'literal'")
+    new DataTypeScenario(DataType.BOOLEAN).getDeclaringTable(false)
+        .onFirstInstance("myField", "null", "true")
+        .andOnSecondInstance("myField", "null", "true")
+        .whenQuery("select 'literal', bool_and(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | BOOLEAN", "literal | false");
   }
 
   @Test
   void andAggregationGroupBySVWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "true"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select 'literal', bool_and(myField) from testTable group by 'literal'")
+    new DataTypeScenario(DataType.BOOLEAN).getDeclaringTable(true)
+        .onFirstInstance("myField", "null", "true")
+        .andOnSecondInstance("myField", "null", "null")
+        .whenQuery("select 'literal', bool_and(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | BOOLEAN", "literal | true");
   }
 
   @Test
   void orAggregationWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "false"
-        ).andOnSecondInstance("myField",
-            "null",
-            "false"
-        ).whenQuery("select bool_or(myField) from testTable")
+    new DataTypeScenario(DataType.BOOLEAN).getDeclaringTable(false)
+        .onFirstInstance("myField", "null", "false")
+        .andOnSecondInstance("myField", "null", "false")
+        .whenQuery("select bool_or(myField) from testTable")
         .thenResultIs("BOOLEAN", "false");
   }
 
   @Test
   void orAggregationWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "true"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select bool_or(myField) from testTable")
+    new DataTypeScenario(DataType.BOOLEAN).getDeclaringTable(true)
+        .onFirstInstance("myField", "null", "true")
+        .andOnSecondInstance("myField", "null", "null")
+        .whenQuery("select bool_or(myField) from testTable")
         .thenResultIs("BOOLEAN", "true");
   }
 
   @Test
   void orAggregationGroupBySVWithNullHandlingDisabled() {
-    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "true"
-        ).andOnSecondInstance("myField",
-            "null",
-            "true"
-        ).whenQuery("select 'literal', bool_or(myField) from testTable group by 'literal'")
+    new DataTypeScenario(DataType.BOOLEAN).getDeclaringTable(false)
+        .onFirstInstance("myField", "null", "true")
+        .andOnSecondInstance("myField", "null", "true")
+        .whenQuery("select 'literal', bool_or(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | BOOLEAN", "literal | true");
   }
 
   @Test
   void orAggregationGroupBySVWithNullHandlingEnabled() {
-    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "false"
-        ).andOnSecondInstance("myField",
-            "null",
-            "false"
-        ).whenQuery("select 'literal', bool_or(myField) from testTable group by 'literal'")
+    new DataTypeScenario(DataType.BOOLEAN).getDeclaringTable(true)
+        .onFirstInstance("myField", "null", "false")
+        .andOnSecondInstance("myField", "null", "false")
+        .whenQuery("select 'literal', bool_or(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | BOOLEAN", "literal | false");
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunctionTest.java
@@ -22,7 +22,7 @@ package org.apache.pinot.core.query.aggregation.function;
 import java.util.List;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.queries.FluentQueryTest;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -36,79 +36,47 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
   public void list() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(false)
-        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[] {1}
-        )
-        .andOnSecondInstance(
-            new Object[] {2},
-            new Object[] {null}
-        )
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{1})
+        .andOnSecondInstance(new Object[]{2}, new Object[]{null})
         .whenQuery("select myField from testTable order by myField")
-        .thenResultIs("INT",
-            "-2147483648",
-            "1",
-            "2"
-        );
+        .thenResultIs("INT", "-2147483648", "1", "2");
   }
 
   @Test
   public void listNullHandlingEnabled() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(true)
-        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[] {1}
-        )
-        .andOnSecondInstance(
-            new Object[] {2},
-            new Object[] {null}
-        )
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{1})
+        .andOnSecondInstance(new Object[]{2}, new Object[]{null})
         .whenQuery("select myField from testTable order by myField")
-        .thenResultIs("INT",
-            "1",
-            "2",
-            "null"
-        );
+        .thenResultIs("INT", "1", "2", "null");
   }
 
   @Test
   public void countNullWhenHandlingDisabled() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(false)
-        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            "myField",
-            "1"
-        )
-        .andOnSecondInstance(
-            "myField",
-            "2",
-            "null"
-        )
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance("myField", "1")
+        .andOnSecondInstance("myField", "2", "null")
         .whenQuery("select myField, COUNT(myField) from testTable group by myField order by myField")
-        .thenResultIs("INT | LONG",
+        .thenResultIs(
+            "INT | LONG",
             "-2147483648 | 1",
             "1           | 1",
             "2           | 1"
         );
   }
 
-
   @Test
   public void countNullWhenHandlingEnabled() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(true)
-        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            "myField",
-            "1"
-        )
-        .andOnSecondInstance(
-            "myField",
-            "2",
-            "null"
-        )
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance("myField", "1")
+        .andOnSecondInstance("myField", "2", "null")
         .whenQuery("select myField, COUNT(myField) from testTable group by myField order by myField")
         .thenResultIs(
             "INT | LONG",
@@ -122,18 +90,12 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
   public void countStarNullWhenHandlingDisabled() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(false)
-        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            "myField",
-            "1"
-        )
-        .andOnSecondInstance(
-            "myField",
-            "2",
-            "null"
-        )
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance("myField", "1")
+        .andOnSecondInstance("myField", "2", "null")
         .whenQuery("select myField, COUNT(*) from testTable group by myField order by myField")
-        .thenResultIs("INT | LONG",
+        .thenResultIs(
+            "INT | LONG",
             "-2147483648 | 1",
             "1    | 1",
             "2    | 1"
@@ -144,18 +106,12 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
   public void countStarNullWhenHandlingEnabled() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(true)
-        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            "myField",
-            "1"
-        )
-        .andOnSecondInstance(
-            "myField",
-            "2",
-            "null"
-        )
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance("myField", "1")
+        .andOnSecondInstance("myField", "2", "null")
         .whenQuery("select myField, COUNT(*) from testTable group by myField order by myField")
-        .thenResultIs("INT | LONG",
+        .thenResultIs(
+            "INT | LONG",
             "1    | 1",
             "2    | 1",
             "null | 1"
@@ -166,18 +122,9 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
   public void countStarWithoutGroupBy(boolean nullHandlingEnabled) {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(nullHandlingEnabled)
-        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            "myField",
-            "1",
-            "2",
-            "null"
-        )
-        .andOnSecondInstance(
-            "myField",
-            "null",
-            "null"
-        )
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance("myField", "1", "2", "null")
+        .andOnSecondInstance("myField", "null", "null")
         .whenQuery("select COUNT(*) from testTable")
         // COUNT(*) result should be the same regardless of whether null handling is enabled or not
         .thenResultIs("LONG", "5");
@@ -187,18 +134,9 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
   public void countLiteralWithoutGroupBy(boolean nullHandlingEnabled) {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(nullHandlingEnabled)
-        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            "myField",
-            "1",
-            "2",
-            "null"
-        )
-        .andOnSecondInstance(
-            "myField",
-            "null",
-            "null"
-        )
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance("myField", "1", "2", "null")
+        .andOnSecondInstance("myField", "null", "null")
         .whenQuery("select COUNT('literal') from testTable")
         // COUNT(*) result should be the same regardless of whether null handling is enabled or not
         .thenResultIs("LONG", "5");
@@ -206,22 +144,15 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
 
   @Test
   public void countGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addMetricField("value", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addMetricField("value", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, COUNT(value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | LONG",

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunctionTest.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -28,41 +28,28 @@ public class CountMVAggregationFunctionTest extends AbstractAggregationFunctionT
 
   @Test
   public void basicCountMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3"},
-            new Object[]{"4;5;6"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"7;8;9"},
-            new Object[]{"10;11;12"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3"}, new Object[]{"4;5;6"})
+        .andOnSecondInstance(new Object[]{"7;8;9"}, new Object[]{"10;11;12"})
         .whenQuery("select count_mv(mv) from testTable")
         .thenResultIs("LONG", String.valueOf(12));
   }
 
   @Test
   public void countMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"},
-            new Object[]{"1;2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null"})
+        .andOnSecondInstance(new Object[]{"null"}, new Object[]{"1;2"})
         .whenQuery("select count_mv(mv) from testTable")
         .thenResultIs("LONG", "4")
         .whenQueryWithNullHandlingEnabled("select count_mv(mv) from testTable")
@@ -71,21 +58,15 @@ public class CountMVAggregationFunctionTest extends AbstractAggregationFunctionT
 
   @Test
   public void countMVGroupBySVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1"},
-            new Object[]{"1;2", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"})
+        .andOnSecondInstance(new Object[]{"null", "k1"}, new Object[]{"1;2", "k1"})
         .whenQuery("select count_mv(mv) from testTable group by sv")
         .thenResultIs("LONG", "4")
         .whenQueryWithNullHandlingEnabled("select count_mv(mv) from testTable group by sv")
@@ -94,21 +75,15 @@ public class CountMVAggregationFunctionTest extends AbstractAggregationFunctionT
 
   @Test
   public void countMVGroupByMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"},
-            new Object[]{"1;2", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"}, new Object[]{"1;2", "k1;k2"})
         .whenQuery("select count_mv(mv1) from testTable group by mv2")
         .thenResultIs("LONG", "4", "4")
         .whenQueryWithNullHandlingEnabled("select count_mv(mv1) from testTable group by mv2")

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunctionTest.java
@@ -20,6 +20,8 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,146 +32,96 @@ public class DistinctAggregationFunctionTest extends AbstractAggregationFunction
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
     return new Object[] {
-        new DataTypeScenario(FieldSpec.DataType.INT),
-        new DataTypeScenario(FieldSpec.DataType.LONG),
-        new DataTypeScenario(FieldSpec.DataType.FLOAT),
-        new DataTypeScenario(FieldSpec.DataType.DOUBLE)
+        new DataTypeScenario(DataType.INT),
+        new DataTypeScenario(DataType.LONG),
+        new DataTypeScenario(DataType.FLOAT),
+        new DataTypeScenario(DataType.DOUBLE)
     };
   }
 
   @Test(dataProvider = "scenarios")
   void distinctCountAggregationAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select count(distinct myField) from testTable")
+        .onFirstInstance("myField", "null", "null", "null")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select count(distinct myField) from testTable")
         .thenResultIs("INT", "1");
   }
 
   @Test(dataProvider = "scenarios")
   void distinctCountAggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select count(distinct myField) from testTable")
+        .onFirstInstance("myField", "null", "null", "null")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select count(distinct myField) from testTable")
         .thenResultIs("INT", "0");
   }
 
   @Test(dataProvider = "scenarios")
   void distinctCountAggregationGroupBySVAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select 'literal', count(distinct myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "null", "null", "null")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select 'literal', count(distinct myField) from testTable group by 'literal'")
         .thenResultIs("STRING | INT", "literal | 1");
   }
 
   @Test(dataProvider = "scenarios")
   void distinctCountAggregationGroupBySVAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select 'literal', count(distinct myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "null", "null", "null")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select 'literal', count(distinct myField) from testTable group by 'literal'")
         .thenResultIs("STRING | INT", "literal | 0");
   }
 
   @Test(dataProvider = "scenarios")
   void distinctCountAggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "2",
-            "2"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select count(distinct myField) from testTable")
+        .onFirstInstance("myField", "null", "1", "2", "2")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select count(distinct myField) from testTable")
         .thenResultIs("INT", "3");
   }
 
   @Test(dataProvider = "scenarios")
   void distinctCountAggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "2",
-            "2"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select count(distinct myField) from testTable")
+        .onFirstInstance("myField", "null", "1", "2", "2")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select count(distinct myField) from testTable")
         .thenResultIs("INT", "2");
   }
 
   @Test(dataProvider = "scenarios")
   void distinctCountAggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "2"
-        ).andOnSecondInstance("myField",
-            "2",
-            "3",
-            "2"
-        ).whenQuery("select 'literal', count(distinct myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "null", "1", "2")
+        .andOnSecondInstance("myField", "2", "3", "2")
+        .whenQuery("select 'literal', count(distinct myField) from testTable group by 'literal'")
         .thenResultIs("STRING | INT", "literal | 3");
   }
 
   @Test(dataProvider = "scenarios")
   void distinctCountAggregationGroupByMV(DataTypeScenario scenario) {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addMetricField("value", scenario.getDataType())
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addMetricField("value", scenario.getDataType())
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", 2},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", 2}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, count(distinct value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | INT",
             "tag1    | 2",
             "tag2    | 3",
-            "tag3    | 1")
-        .whenQueryWithNullHandlingEnabled("select tags, count(distinct value) from testTable group by tags "
-            + "order by tags")
+            "tag3    | 1"
+        )
+        .whenQueryWithNullHandlingEnabled(
+            "select tags, count(distinct value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | INT",
             "tag1    | 2",
@@ -181,98 +133,59 @@ public class DistinctAggregationFunctionTest extends AbstractAggregationFunction
   @Test(dataProvider = "scenarios")
   void distinctSumAggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select sum(distinct myField) from testTable")
+        .onFirstInstance("myField", "null", "null", "null")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select sum(distinct myField) from testTable")
         .thenResultIs("INT", "null");
   }
 
   @Test(dataProvider = "scenarios")
   void distinctSumAggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "2",
-            "2"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select sum(distinct myField) from testTable")
+        .onFirstInstance("myField", "null", "1", "2", "2")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select sum(distinct myField) from testTable")
         .thenResultIs("DOUBLE", addToDefaultNullValue(scenario.getDataType(), 3));
   }
 
   @Test(dataProvider = "scenarios")
   void distinctSumAggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "2",
-            "2"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select sum(distinct myField) from testTable")
+        .onFirstInstance("myField", "null", "1", "2", "2")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select sum(distinct myField) from testTable")
         .thenResultIs("DOUBLE", "3");
   }
 
   @Test(dataProvider = "scenarios")
   void distinctSumAggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "2"
-        ).andOnSecondInstance("myField",
-            "2",
-            "3",
-            "2"
-        ).whenQuery("select 'literal', sum(distinct myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "null", "1", "2")
+        .andOnSecondInstance("myField", "2", "3", "2")
+        .whenQuery("select 'literal', sum(distinct myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | " + addToDefaultNullValue(scenario.getDataType(), 6));
   }
 
   @Test(dataProvider = "scenarios")
   void distinctSumAggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "2"
-        ).andOnSecondInstance("myField",
-            "2",
-            "3",
-            "2"
-        ).whenQuery("select 'literal', sum(distinct myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "null", "1", "2")
+        .andOnSecondInstance("myField", "2", "3", "2")
+        .whenQuery("select 'literal', sum(distinct myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | 6");
   }
 
   @Test
   void distinctSumAggregationGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addSingleValueDimension("value", DataType.INT, -1)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addSingleValueDimension("value", FieldSpec.DataType.INT, -1)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", 2},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", 2}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, sum(distinct value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | DOUBLE",
@@ -292,96 +205,59 @@ public class DistinctAggregationFunctionTest extends AbstractAggregationFunction
   @Test(dataProvider = "scenarios")
   void distinctAvgAggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select avg(distinct myField) from testTable")
+        .onFirstInstance("myField", "null", "null", "null")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select avg(distinct myField) from testTable")
         .thenResultIs("DOUBLE", "null");
   }
 
   @Test(dataProvider = "scenarios")
   void distinctAvgAggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "2"
-        ).andOnSecondInstance("myField",
-            "2",
-            "null",
-            "null"
-        ).whenQuery("select avg(distinct myField) from testTable")
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "1", "2")
+        .andOnSecondInstance("myField", "2", "null", "null")
+        .whenQuery("select avg(distinct myField) from testTable")
         .thenResultIs("DOUBLE", "1.0");
   }
 
   @Test(dataProvider = "scenarios")
   void distinctAvgAggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "2"
-        ).andOnSecondInstance("myField",
-            "2",
-            "null",
-            "null"
-        ).whenQuery("select avg(distinct myField) from testTable")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "1", "2")
+        .andOnSecondInstance("myField", "2", "null", "null")
+        .whenQuery("select avg(distinct myField) from testTable")
         .thenResultIs("DOUBLE", "1.5");
   }
 
   @Test(dataProvider = "scenarios")
   void distinctAvgAggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "2"
-        ).andOnSecondInstance("myField",
-            "2",
-            "3",
-            "2"
-        ).whenQuery("select 'literal', avg(distinct myField) from testTable group by 'literal'")
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "1", "2")
+        .andOnSecondInstance("myField", "2", "3", "2")
+        .whenQuery("select 'literal', avg(distinct myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | 1.5");
   }
 
   @Test(dataProvider = "scenarios")
   void distinctAvgAggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "2"
-        ).andOnSecondInstance("myField",
-            "2",
-            "3",
-            "2"
-        ).whenQuery("select 'literal', avg(distinct myField) from testTable group by 'literal'")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "1", "2")
+        .andOnSecondInstance("myField", "2", "3", "2")
+        .whenQuery("select 'literal', avg(distinct myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | 2.0");
   }
 
   @Test
   void distinctAvgAggregationGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addMetricField("value", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addMetricField("value", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", 2},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", 2}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, avg(distinct value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | DOUBLE",
@@ -398,7 +274,7 @@ public class DistinctAggregationFunctionTest extends AbstractAggregationFunction
         );
   }
 
-  private String addToDefaultNullValue(FieldSpec.DataType dataType, int addend) {
+  private String addToDefaultNullValue(DataType dataType, int addend) {
     switch (dataType) {
       case INT:
         return String.valueOf(FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT + addend);

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctAvgAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctAvgAggregationFunctionTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -31,51 +32,33 @@ public class DistinctAvgAggregationFunctionTest extends AbstractAggregationFunct
   public void distinctAvgWithNulls() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(false)
-        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            "myField",
-            "1",
-            "2"
-        )
-        .andOnSecondInstance(
-            "myField",
-            "2",
-            "null"
-        )
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance("myField", "1", "2")
+        .andOnSecondInstance("myField", "2", "null")
         .whenQuery("select DISTINCT_AVG(myField) from testTable")
-        .thenResultIs("DOUBLE",
-            String.valueOf((3 + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT) / 3.0)
-        ).whenQueryWithNullHandlingEnabled("select DISTINCT_AVG(myField) from testTable")
-        .thenResultIs("DOUBLE",
-            "1.5"
-        );
+        .thenResultIs("DOUBLE", String.valueOf((3 + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT) / 3.0))
+        .whenQueryWithNullHandlingEnabled("select DISTINCT_AVG(myField) from testTable")
+        .thenResultIs("DOUBLE", "1.5");
   }
 
   @Test
   public void distinctAvgWithGroupBy() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(false)
-        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            "myField",
-            "1",
-            "2",
-            "null"
-        )
-        .andOnSecondInstance(
-            "myField",
-            "2",
-            "null"
-        )
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance("myField", "1", "2", "null")
+        .andOnSecondInstance("myField", "2", "null")
         .whenQuery("select myField, DISTINCT_AVG(myField) from testTable group by myField order by myField")
-        .thenResultIs("INT | DOUBLE",
+        .thenResultIs(
+            "INT | DOUBLE",
             "-2147483648 | " + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT,
             "1           | 1",
             "2           | 2"
         )
         .whenQueryWithNullHandlingEnabled(
-            "select myField, DISTINCT_AVG(myField) from testTable  group by myField order by myField")
-        .thenResultIs("INT | DOUBLE",
+            "select myField, DISTINCT_AVG(myField) from testTable group by myField order by myField")
+        .thenResultIs(
+            "INT | DOUBLE",
             "1    | 1",
             "2    | 2",
             "null | null"
@@ -84,22 +67,15 @@ public class DistinctAvgAggregationFunctionTest extends AbstractAggregationFunct
 
   @Test
   public void distinctAvgGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addMetricField("value", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addMetricField("value", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, DISTINCT_AVG(value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | DOUBLE",
@@ -107,8 +83,7 @@ public class DistinctAvgAggregationFunctionTest extends AbstractAggregationFunct
             "tag2    | 0.5",
             "tag3    | 0"
         )
-        .whenQueryWithNullHandlingEnabled(
-            "select tags, DISTINCT_AVG(value) from testTable group by tags order by tags")
+        .whenQueryWithNullHandlingEnabled("select tags, DISTINCT_AVG(value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | DOUBLE",
             "tag1    | 1",
@@ -119,42 +94,28 @@ public class DistinctAvgAggregationFunctionTest extends AbstractAggregationFunct
 
   @Test
   public void distinctAvgMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3;4"},
-            new Object[]{"3;4;5;6"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"6;7;8;9"},
-            new Object[]{"9;10;11;12"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3;4"}, new Object[]{"3;4;5;6"})
+        .andOnSecondInstance(new Object[]{"6;7;8;9"}, new Object[]{"9;10;11;12"})
         .whenQuery("select DISTINCT_AVG(mv) from testTable")
         .thenResultIs("DOUBLE", "6.5");
   }
 
   @Test
   public void distinctAvgMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null"},
-            new Object[]{"1;2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"},
-            new Object[]{"1;2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null"}, new Object[]{"1;2"})
+        .andOnSecondInstance(new Object[]{"null"}, new Object[]{"1;2"})
         .whenQuery("select DISTINCT_AVG(mv) from testTable")
         .thenResultIs("DOUBLE", String.valueOf((3 + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT) / 3.0))
         .whenQueryWithNullHandlingEnabled("select DISTINCT_AVG(mv) from testTable")
@@ -163,21 +124,15 @@ public class DistinctAvgAggregationFunctionTest extends AbstractAggregationFunct
 
   @Test
   public void distinctAvgMVGroupBySVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1"},
-            new Object[]{"1;2", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"})
+        .andOnSecondInstance(new Object[]{"null", "k1"}, new Object[]{"1;2", "k1"})
         .whenQuery("select DISTINCT_AVG(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", String.valueOf((3 + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT) / 3.0))
         .whenQueryWithNullHandlingEnabled("select DISTINCT_AVG(mv) from testTable group by sv")
@@ -186,25 +141,21 @@ public class DistinctAvgAggregationFunctionTest extends AbstractAggregationFunct
 
   @Test
   public void distinctAvgMVGroupByMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1;k2"},
-            new Object[]{"1;2", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"},
-            new Object[]{"1;2", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1;k2"}, new Object[]{"1;2", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"}, new Object[]{"1;2", "k1;k2"})
         .whenQuery("select DISTINCT_AVG(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE", String.valueOf((3 + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT) / 3.0),
-            String.valueOf((3 + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT) / 3.0))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf((3 + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT) / 3.0),
+            String.valueOf((3 + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT) / 3.0)
+        )
         .whenQueryWithNullHandlingEnabled("select DISTINCT_AVG(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "1.5", "1.5");
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunctionTest.java
@@ -20,7 +20,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -31,51 +31,33 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
   public void distinctCountWithNulls() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(false)
-        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            "myField",
-            "1",
-            "2"
-        )
-        .andOnSecondInstance(
-            "myField",
-            "2",
-            "null"
-        )
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance("myField", "1", "2")
+        .andOnSecondInstance("myField", "2", "null")
         .whenQuery("select DISTINCT_COUNT(myField) from testTable")
-        .thenResultIs("INT",
-            "3"
-        ).whenQueryWithNullHandlingEnabled("select DISTINCT_COUNT(myField) from testTable")
-        .thenResultIs("INT",
-            "2"
-        );
+        .thenResultIs("INT", "3")
+        .whenQueryWithNullHandlingEnabled("select DISTINCT_COUNT(myField) from testTable")
+        .thenResultIs("INT", "2");
   }
 
   @Test
   public void distinctCountWithGroupBy() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(false)
-        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            "myField",
-            "1",
-            "2",
-            "null"
-        )
-        .andOnSecondInstance(
-            "myField",
-            "2",
-            "null"
-        )
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance("myField", "1", "2", "null")
+        .andOnSecondInstance("myField", "2", "null")
         .whenQuery("select myField, DISTINCT_COUNT(myField) from testTable group by myField order by myField")
-        .thenResultIs("INT | INT",
+        .thenResultIs(
+            "INT | INT",
             "-2147483648 | 1",
             "1           | 1",
             "2           | 1"
         )
         .whenQueryWithNullHandlingEnabled(
             "select myField, DISTINCT_COUNT(myField) from testTable  group by myField order by myField")
-        .thenResultIs("INT | INT",
+        .thenResultIs(
+            "INT | INT",
             "1    | 1",
             "2    | 1",
             "null | 0"
@@ -84,22 +66,15 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
 
   @Test
   public void distinctCountGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addMetricField("value", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addMetricField("value", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, DISTINCT_COUNT(value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | INT",
@@ -119,42 +94,28 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
 
   @Test
   public void distinctCountMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3;4"},
-            new Object[]{"3;4;5;6"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"6;7;8;9"},
-            new Object[]{"9;10;11;12"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3;4"}, new Object[]{"3;4;5;6"})
+        .andOnSecondInstance(new Object[]{"6;7;8;9"}, new Object[]{"9;10;11;12"})
         .whenQuery("select DISTINCT_COUNT(mv) from testTable")
         .thenResultIs("INT", "12");
   }
 
   @Test
   public void distinctCountMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null"},
-            new Object[]{"1;2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"},
-            new Object[]{"1;2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null"}, new Object[]{"1;2"})
+        .andOnSecondInstance(new Object[]{"null"}, new Object[]{"1;2"})
         .whenQuery("select DISTINCT_COUNT(mv) from testTable")
         .thenResultIs("INT", "3")
         .whenQueryWithNullHandlingEnabled("select DISTINCT_COUNT(mv) from testTable")
@@ -163,21 +124,15 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
 
   @Test
   public void distinctCountMVGroupBySVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1"},
-            new Object[]{"1;2", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"})
+        .andOnSecondInstance(new Object[]{"null", "k1"}, new Object[]{"1;2", "k1"})
         .whenQuery("select DISTINCT_COUNT(mv) from testTable group by sv")
         .thenResultIs("INT", "3")
         .whenQueryWithNullHandlingEnabled("select DISTINCT_COUNT(mv) from testTable group by sv")
@@ -187,18 +142,9 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
   @Test
   public void distinctCountBigDecimal() {
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.BIG_DECIMAL),
-            SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            "myField",
-            "1.5",
-            "2.5"
-        )
-        .andOnSecondInstance(
-            "myField",
-            "2.5",
-            "3.5"
-        )
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(DataType.BIG_DECIMAL), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance("myField", "1.5", "2.5")
+        .andOnSecondInstance("myField", "2.5", "3.5")
         .whenQuery("select DISTINCT_COUNT(myField) from testTable")
         .thenResultIs("INT", "3");
   }
@@ -206,23 +152,17 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
   @Test
   public void distinctCountBigDecimalGroupBy() {
     // Schema column order is alphabetical via TreeSet, so row values must be in {grp, value} order.
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .addSingleValueDimension("value", DataType.BIG_DECIMAL)
+        .addSingleValueDimension("grp", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .addSingleValueDimension("value", FieldSpec.DataType.BIG_DECIMAL)
-                .addSingleValueDimension("grp", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"a", "1.5"},
-            new Object[]{"a", "2.5"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"a", "2.5"},
-            new Object[]{"b", "3.5"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"a", "1.5"}, new Object[]{"a", "2.5"})
+        .andOnSecondInstance(new Object[]{"a", "2.5"}, new Object[]{"b", "3.5"})
         .whenQuery("select grp, DISTINCT_COUNT(value) from testTable group by grp order by grp")
-        .thenResultIs("STRING | INT",
+        .thenResultIs(
+            "STRING | INT",
             "a | 2",
             "b | 1"
         );
@@ -230,19 +170,13 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
 
   @Test
   public void distinctCountBigDecimalMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .addMultiValueDimension("mv", DataType.BIG_DECIMAL)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .addMultiValueDimension("mv", FieldSpec.DataType.BIG_DECIMAL)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1.5;2.5"},
-            new Object[]{"2.5;3.5"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"3.5;4.5"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1.5;2.5"}, new Object[]{"2.5;3.5"})
+        .andOnSecondInstance(new Object[]{"3.5;4.5"})
         .whenQuery("select DISTINCT_COUNT(mv) from testTable")
         .thenResultIs("INT", "4");
   }
@@ -250,22 +184,17 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
   @Test
   public void distinctCountBigDecimalMVGroupBySV() {
     // Schema column order is alphabetical via TreeSet, so row values must be in {grp, mv} order.
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .addMultiValueDimension("mv", DataType.BIG_DECIMAL)
+        .addSingleValueDimension("grp", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .addMultiValueDimension("mv", FieldSpec.DataType.BIG_DECIMAL)
-                .addSingleValueDimension("grp", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"a", "1.5;2.5"},
-            new Object[]{"a", "2.5;3.5"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"b", "3.5;4.5"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"a", "1.5;2.5"}, new Object[]{"a", "2.5;3.5"})
+        .andOnSecondInstance(new Object[]{"b", "3.5;4.5"})
         .whenQuery("select grp, DISTINCT_COUNT(mv) from testTable group by grp order by grp")
-        .thenResultIs("STRING | INT",
+        .thenResultIs(
+            "STRING | INT",
             "a | 3",
             "b | 2"
         );
@@ -274,19 +203,16 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
   @Test
   public void distinctCountBigDecimalMVGroupByMV() {
     // Schema column order is alphabetical via TreeSet, so row values must be in {grp, mv} order.
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .addMultiValueDimension("mv", DataType.BIG_DECIMAL)
+        .addMultiValueDimension("grp", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .addMultiValueDimension("mv", FieldSpec.DataType.BIG_DECIMAL)
-                .addMultiValueDimension("grp", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"a;b", "1.5;2.5"},
-            new Object[]{"b;c", "2.5;3.5"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"a;b", "1.5;2.5"}, new Object[]{"b;c", "2.5;3.5"})
         .whenQuery("select grp, DISTINCT_COUNT(mv) from testTable group by grp order by grp")
-        .thenResultIs("STRING | INT",
+        .thenResultIs(
+            "STRING | INT",
             "a | 2",
             "b | 3",
             "c | 2"
@@ -295,22 +221,15 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
 
   @Test
   public void distinctCountMVGroupByMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1;k2"},
-            new Object[]{"1;2", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"},
-            new Object[]{"1;2", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1;k2"}, new Object[]{"1;2", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"}, new Object[]{"1;2", "k1;k2"})
         .whenQuery("select DISTINCT_COUNT(mv1) from testTable group by mv2")
         .thenResultIs("INT", "3", "3")
         .whenQueryWithNullHandlingEnabled("select DISTINCT_COUNT(mv1) from testTable group by mv2")

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapMVAggregationFunctionTest.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -28,19 +28,14 @@ public class DistinctCountBitmapMVAggregationFunctionTest extends AbstractAggreg
 
   @Test
   public void testAggregationMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"2;3;4"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3"})
+        .andOnSecondInstance(new Object[]{"2;3;4"})
         // Distinct values: 1, 2, 3, 4 = 4 distinct
         .whenQuery("select distinctcountbitmap(mv) from testTable")
         .thenResultIs("INT", "4");
@@ -48,48 +43,41 @@ public class DistinctCountBitmapMVAggregationFunctionTest extends AbstractAggreg
 
   @Test
   public void testAggregationMVGroupBySV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3", "k1"},
-            new Object[]{"4;5", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"2;3", "k1"},
-            new Object[]{"5;6", "k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3", "k1"}, new Object[]{"4;5", "k2"})
+        .andOnSecondInstance(new Object[]{"2;3", "k1"}, new Object[]{"5;6", "k2"})
         .whenQuery("select sv, distinctcountbitmap(mv) from testTable group by sv order by sv")
-        .thenResultIs("STRING | INT",
+        .thenResultIs(
+            "STRING | INT",
             "k1 | 3",   // distinct: 1, 2, 3
-            "k2 | 3");  // distinct: 4, 5, 6
+            "k2 | 3"    // distinct: 4, 5, 6
+        );
   }
 
   @Test
   public void testAggregationMVGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("nums", DataType.INT)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("nums", FieldSpec.DataType.INT)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
         .onFirstInstance(
             // Column order is alphabetical: nums, tags
-            new Object[]{"1;2", "tag1;tag2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"2;3", "tag1;tag2"}
-        )
+            new Object[]{"1;2", "tag1;tag2"})
+        .andOnSecondInstance(new Object[]{"2;3", "tag1;tag2"})
         .whenQuery("select tags, distinctcountbitmap(nums) from testTable group by tags order by tags")
-        .thenResultIs("STRING | INT",
+        .thenResultIs(
+            "STRING | INT",
             "tag1 | 3",   // distinct: 1, 2, 3
-            "tag2 | 3");  // distinct: 1, 2, 3
+            "tag2 | 3"    // distinct: 1, 2, 3
+        );
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunctionTest.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -28,19 +28,14 @@ public class DistinctCountHLLMVAggregationFunctionTest extends AbstractAggregati
 
   @Test
   public void testAggregationMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"2;3;4"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3"})
+        .andOnSecondInstance(new Object[]{"2;3;4"})
         // Distinct values: 1, 2, 3, 4 = 4 distinct
         .whenQuery("select distinctcounthll(mv) from testTable")
         .thenResultIs("LONG", "4");
@@ -48,48 +43,41 @@ public class DistinctCountHLLMVAggregationFunctionTest extends AbstractAggregati
 
   @Test
   public void testAggregationMVGroupBySV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3", "k1"},
-            new Object[]{"4;5", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"2;3", "k1"},
-            new Object[]{"5;6", "k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3", "k1"}, new Object[]{"4;5", "k2"})
+        .andOnSecondInstance(new Object[]{"2;3", "k1"}, new Object[]{"5;6", "k2"})
         .whenQuery("select sv, distinctcounthll(mv) from testTable group by sv order by sv")
-        .thenResultIs("STRING | LONG",
+        .thenResultIs(
+            "STRING | LONG",
             "k1 | 3",   // distinct: 1, 2, 3
-            "k2 | 3");  // distinct: 4, 5, 6
+            "k2 | 3"    // distinct: 4, 5, 6
+        );
   }
 
   @Test
   public void testAggregationMVGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("nums", DataType.INT)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("nums", FieldSpec.DataType.INT)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
         .onFirstInstance(
             // Column order is alphabetical: nums, tags
-            new Object[]{"1;2", "tag1;tag2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"2;3", "tag1;tag2"}
-        )
+            new Object[]{"1;2", "tag1;tag2"})
+        .andOnSecondInstance(new Object[]{"2;3", "tag1;tag2"})
         .whenQuery("select tags, distinctcounthll(nums) from testTable group by tags order by tags")
-        .thenResultIs("STRING | LONG",
+        .thenResultIs(
+            "STRING | LONG",
             "tag1 | 3",   // distinct: 1, 2, 3
-            "tag2 | 3");  // distinct: 1, 2, 3
+            "tag2 | 3"    // distinct: 1, 2, 3
+        );
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusMVAggregationFunctionTest.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -28,19 +28,14 @@ public class DistinctCountHLLPlusMVAggregationFunctionTest extends AbstractAggre
 
   @Test
   public void testAggregationMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"2;3;4"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3"})
+        .andOnSecondInstance(new Object[]{"2;3;4"})
         // Distinct values: 1, 2, 3, 4 = 4 distinct
         .whenQuery("select distinctcounthllplus(mv) from testTable")
         .thenResultIs("LONG", "4");
@@ -48,48 +43,41 @@ public class DistinctCountHLLPlusMVAggregationFunctionTest extends AbstractAggre
 
   @Test
   public void testAggregationMVGroupBySV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3", "k1"},
-            new Object[]{"4;5", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"2;3", "k1"},
-            new Object[]{"5;6", "k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3", "k1"}, new Object[]{"4;5", "k2"})
+        .andOnSecondInstance(new Object[]{"2;3", "k1"}, new Object[]{"5;6", "k2"})
         .whenQuery("select sv, distinctcounthllplus(mv) from testTable group by sv order by sv")
-        .thenResultIs("STRING | LONG",
+        .thenResultIs(
+            "STRING | LONG",
             "k1 | 3",   // distinct: 1, 2, 3
-            "k2 | 3");  // distinct: 4, 5, 6
+            "k2 | 3"    // distinct: 4, 5, 6
+        );
   }
 
   @Test
   public void testAggregationMVGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("nums", DataType.INT)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("nums", FieldSpec.DataType.INT)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
         .onFirstInstance(
             // Column order is alphabetical: nums, tags
-            new Object[]{"1;2", "tag1;tag2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"2;3", "tag1;tag2"}
-        )
+            new Object[]{"1;2", "tag1;tag2"})
+        .andOnSecondInstance(new Object[]{"2;3", "tag1;tag2"})
         .whenQuery("select tags, distinctcounthllplus(nums) from testTable group by tags order by tags")
-        .thenResultIs("STRING | LONG",
+        .thenResultIs(
+            "STRING | LONG",
             "tag1 | 3",   // distinct: 1, 2, 3
-            "tag2 | 3");  // distinct: 1, 2, 3
+            "tag2 | 3"    // distinct: 1, 2, 3
+        );
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLAggregationFunctionTest.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -38,81 +38,69 @@ public class DistinctCountSmartHLLAggregationFunctionTest {
   @Test
   public void testParameterParsing() {
     // Test default values
-    DistinctCountSmartHLLAggregationFunction function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col")), false);
+    DistinctCountSmartHLLAggregationFunction function =
+        new DistinctCountSmartHLLAggregationFunction(List.of(ExpressionContext.forIdentifier("col")), false);
     assertEquals(function.getThreshold(), 100_000);
     assertEquals(function.getDictIdCardinalityThreshold(), 100_000);
 
     // Test individual parameters
-    function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "threshold=50000")), false);
+    function = new DistinctCountSmartHLLAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
+        ExpressionContext.forLiteral(DataType.STRING, "threshold=50000")), false);
     assertEquals(function.getThreshold(), 50_000);
     assertEquals(function.getDictIdCardinalityThreshold(), 100_000);
 
     function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "log2m=8")), false);
+        List.of(ExpressionContext.forIdentifier("col"), ExpressionContext.forLiteral(DataType.STRING, "log2m=8")),
+        false);
     assertEquals(function.getThreshold(), 100_000);
     assertEquals(function.getDictIdCardinalityThreshold(), 100_000);
 
-    function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=50000")), false);
+    function = new DistinctCountSmartHLLAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
+        ExpressionContext.forLiteral(DataType.STRING, "dictThreshold=50000")), false);
     assertEquals(function.getThreshold(), 100_000);
     assertEquals(function.getDictIdCardinalityThreshold(), 50_000);
 
     // Test disabled dictThreshold (non-positive values)
-    function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=-1")), false);
+    function = new DistinctCountSmartHLLAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
+        ExpressionContext.forLiteral(DataType.STRING, "dictThreshold=-1")), false);
     assertEquals(function.getDictIdCardinalityThreshold(), Integer.MAX_VALUE);
 
-    function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=0")), false);
+    function = new DistinctCountSmartHLLAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
+        ExpressionContext.forLiteral(DataType.STRING, "dictThreshold=0")), false);
     assertEquals(function.getDictIdCardinalityThreshold(), Integer.MAX_VALUE);
 
     // Test multiple parameters together
-    function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING,
-                "threshold=200000;log2m=10;dictThreshold=150000")), false);
+    function = new DistinctCountSmartHLLAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
+        ExpressionContext.forLiteral(DataType.STRING, "threshold=200000;log2m=10;dictThreshold=150000")), false);
     assertEquals(function.getThreshold(), 200_000);
     assertEquals(function.getDictIdCardinalityThreshold(), 150_000);
 
     // Test parameter order independence
     DistinctCountSmartHLLAggregationFunction function1 = new DistinctCountSmartHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=50000;threshold=100000;log2m=8")),
-                false);
+            ExpressionContext.forLiteral(DataType.STRING, "dictThreshold=50000;threshold=100000;log2m=8")), false);
     DistinctCountSmartHLLAggregationFunction function2 = new DistinctCountSmartHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "log2m=8;dictThreshold=50000;threshold=100000")),
-                false);
+            ExpressionContext.forLiteral(DataType.STRING, "log2m=8;dictThreshold=50000;threshold=100000")), false);
     assertEquals(function1.getThreshold(), function2.getThreshold());
     assertEquals(function1.getDictIdCardinalityThreshold(), function2.getDictIdCardinalityThreshold());
 
     // Test legacy parameter names
-    function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "hllConversionThreshold=50000;hllLog2m=10")),
-                false);
+    function = new DistinctCountSmartHLLAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
+        ExpressionContext.forLiteral(DataType.STRING, "hllConversionThreshold=50000;hllLog2m=10")), false);
     assertEquals(function.getThreshold(), 50_000);
 
     // Test case-insensitive parameters
-    function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "THRESHOLD=50000;LOG2M=8;DICTTHRESHOLD=100000")),
-                false);
+    function = new DistinctCountSmartHLLAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
+        ExpressionContext.forLiteral(DataType.STRING, "THRESHOLD=50000;LOG2M=8;DICTTHRESHOLD=100000")), false);
     assertEquals(function.getThreshold(), 50_000);
     assertEquals(function.getDictIdCardinalityThreshold(), 100_000);
   }
 
   @Test
   public void testFunctionMetadata() {
-    DistinctCountSmartHLLAggregationFunction function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col")), false);
+    DistinctCountSmartHLLAggregationFunction function =
+        new DistinctCountSmartHLLAggregationFunction(List.of(ExpressionContext.forIdentifier("col")), false);
 
     // Test function type
     assertEquals(function.getType().getName(), "distinctCountSmartHLL");
@@ -128,8 +116,8 @@ public class DistinctCountSmartHLLAggregationFunctionTest {
 
   @Test
   public void testHLLOperations() {
-    DistinctCountSmartHLLAggregationFunction function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col")), false);
+    DistinctCountSmartHLLAggregationFunction function =
+        new DistinctCountSmartHLLAggregationFunction(List.of(ExpressionContext.forIdentifier("col")), false);
 
     // Test merge final results (should sum)
     Integer finalResult = function.mergeFinalResult(100, 200);
@@ -163,7 +151,7 @@ public class DistinctCountSmartHLLAggregationFunctionTest {
   public void itExtractsHLLFromGroupByResultHolderWhenSketchConverted() {
     DistinctCountSmartHLLAggregationFunction function = new DistinctCountSmartHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "threshold=5;dictThreshold=5")), false);
+            ExpressionContext.forLiteral(DataType.STRING, "threshold=5;dictThreshold=5")), false);
 
     ObjectGroupByResultHolder holder = new ObjectGroupByResultHolder(10, 10);
 
@@ -185,26 +173,23 @@ public class DistinctCountSmartHLLAggregationFunctionTest {
   @Test
   public void testAdaptiveConversion() {
     // Test adaptive conversion enabled by default (100K threshold)
-    DistinctCountSmartHLLAggregationFunction function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col")), false);
+    DistinctCountSmartHLLAggregationFunction function =
+        new DistinctCountSmartHLLAggregationFunction(List.of(ExpressionContext.forIdentifier("col")), false);
     assertEquals(function.getDictIdCardinalityThreshold(), 100_000);
 
     // Test adaptive conversion with custom threshold
-    function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=50000")), false);
+    function = new DistinctCountSmartHLLAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
+        ExpressionContext.forLiteral(DataType.STRING, "dictThreshold=50000")), false);
     assertEquals(function.getDictIdCardinalityThreshold(), 50_000);
 
     // Test adaptive conversion disabled (Integer.MAX_VALUE)
-    function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=" + Integer.MAX_VALUE)), false);
+    function = new DistinctCountSmartHLLAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
+        ExpressionContext.forLiteral(DataType.STRING, "dictThreshold=" + Integer.MAX_VALUE)), false);
     assertEquals(function.getDictIdCardinalityThreshold(), Integer.MAX_VALUE);
 
     // Test non-positive threshold converted to Integer.MAX_VALUE (disabled)
-    function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=-1")), false);
+    function = new DistinctCountSmartHLLAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
+        ExpressionContext.forLiteral(DataType.STRING, "dictThreshold=-1")), false);
     assertEquals(function.getDictIdCardinalityThreshold(), Integer.MAX_VALUE);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctSumAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctSumAggregationFunctionTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -31,51 +32,33 @@ public class DistinctSumAggregationFunctionTest extends AbstractAggregationFunct
   public void distinctSumWithNulls() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(false)
-        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            "myField",
-            "1",
-            "2"
-        )
-        .andOnSecondInstance(
-            "myField",
-            "2",
-            "null"
-        )
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance("myField", "1", "2")
+        .andOnSecondInstance("myField", "2", "null")
         .whenQuery("select DISTINCT_SUM(myField) from testTable")
-        .thenResultIs("DOUBLE",
-            String.valueOf(3 + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT)
-        ).whenQueryWithNullHandlingEnabled("select DISTINCT_SUM(myField) from testTable")
-        .thenResultIs("DOUBLE",
-            "3"
-        );
+        .thenResultIs("DOUBLE", String.valueOf(3 + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT))
+        .whenQueryWithNullHandlingEnabled("select DISTINCT_SUM(myField) from testTable")
+        .thenResultIs("DOUBLE", "3");
   }
 
   @Test
   public void distinctSumWithGroupBy() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(false)
-        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            "myField",
-            "1",
-            "2",
-            "null"
-        )
-        .andOnSecondInstance(
-            "myField",
-            "2",
-            "null"
-        )
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance("myField", "1", "2", "null")
+        .andOnSecondInstance("myField", "2", "null")
         .whenQuery("select myField, DISTINCT_SUM(myField) from testTable group by myField order by myField")
-        .thenResultIs("INT | DOUBLE",
+        .thenResultIs(
+            "INT | DOUBLE",
             "-2147483648 | " + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT,
             "1           | 1",
             "2           | 2"
         )
         .whenQueryWithNullHandlingEnabled(
             "select myField, DISTINCT_SUM(myField) from testTable  group by myField order by myField")
-        .thenResultIs("INT | DOUBLE",
+        .thenResultIs(
+            "INT | DOUBLE",
             "1    | 1",
             "2    | 2",
             "null | null"
@@ -84,22 +67,15 @@ public class DistinctSumAggregationFunctionTest extends AbstractAggregationFunct
 
   @Test
   public void distinctSumGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addMetricField("value", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addMetricField("value", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, DISTINCT_SUM(value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | DOUBLE",
@@ -107,8 +83,7 @@ public class DistinctSumAggregationFunctionTest extends AbstractAggregationFunct
             "tag2    | 1",
             "tag3    | 0"
         )
-        .whenQueryWithNullHandlingEnabled(
-            "select tags, DISTINCT_SUM(value) from testTable group by tags order by tags")
+        .whenQueryWithNullHandlingEnabled("select tags, DISTINCT_SUM(value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | DOUBLE",
             "tag1    | 1",
@@ -119,42 +94,28 @@ public class DistinctSumAggregationFunctionTest extends AbstractAggregationFunct
 
   @Test
   public void distinctSumMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3;4"},
-            new Object[]{"3;4;5;6"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"6;7;8;9"},
-            new Object[]{"9;10;11;12"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3;4"}, new Object[]{"3;4;5;6"})
+        .andOnSecondInstance(new Object[]{"6;7;8;9"}, new Object[]{"9;10;11;12"})
         .whenQuery("select DISTINCT_SUM(mv) from testTable")
         .thenResultIs("DOUBLE", "78");
   }
 
   @Test
   public void distinctSumMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null"},
-            new Object[]{"1;2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"},
-            new Object[]{"1;2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null"}, new Object[]{"1;2"})
+        .andOnSecondInstance(new Object[]{"null"}, new Object[]{"1;2"})
         .whenQuery("select DISTINCT_SUM(mv) from testTable")
         .thenResultIs("DOUBLE", String.valueOf(3 + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT))
         .whenQueryWithNullHandlingEnabled("select DISTINCT_SUM(mv) from testTable")
@@ -163,21 +124,15 @@ public class DistinctSumAggregationFunctionTest extends AbstractAggregationFunct
 
   @Test
   public void distinctSumMVGroupBySVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1"},
-            new Object[]{"1;2", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"})
+        .andOnSecondInstance(new Object[]{"null", "k1"}, new Object[]{"1;2", "k1"})
         .whenQuery("select DISTINCT_SUM(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", String.valueOf(3 + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT))
         .whenQueryWithNullHandlingEnabled("select DISTINCT_SUM(mv) from testTable group by sv")
@@ -186,25 +141,21 @@ public class DistinctSumAggregationFunctionTest extends AbstractAggregationFunct
 
   @Test
   public void distinctSumMVGroupByMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1;k2"},
-            new Object[]{"1;2", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"},
-            new Object[]{"1;2", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1;k2"}, new Object[]{"1;2", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"}, new Object[]{"1;2", "k1;k2"})
         .whenQuery("select DISTINCT_SUM(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE", String.valueOf(3 + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT),
-            String.valueOf(3 + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(3 + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT),
+            String.valueOf(3 + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT)
+        )
         .whenQueryWithNullHandlingEnabled("select DISTINCT_SUM(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "3", "3");
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/FirstWithTimeAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/FirstWithTimeAggregationFunctionTest.java
@@ -20,8 +20,9 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.PinotDataType;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
@@ -34,22 +35,22 @@ public class FirstWithTimeAggregationFunctionTest extends AbstractAggregationFun
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
     return new Object[] {
-        new Scenario(FieldSpec.DataType.INT, "1", "2", "-2147483648"),
-        new Scenario(FieldSpec.DataType.LONG, "1", "2", "-9223372036854775808"),
-        new Scenario(FieldSpec.DataType.FLOAT, "1", "2", "-Infinity"),
-        new Scenario(FieldSpec.DataType.DOUBLE, "1", "2", "-Infinity"),
-        new Scenario(FieldSpec.DataType.STRING, "a", "b", "\"null\""),
+        new Scenario(DataType.INT, "1", "2", "-2147483648"),
+        new Scenario(DataType.LONG, "1", "2", "-9223372036854775808"),
+        new Scenario(DataType.FLOAT, "1", "2", "-Infinity"),
+        new Scenario(DataType.DOUBLE, "1", "2", "-Infinity"),
+        new Scenario(DataType.STRING, "a", "b", "\"null\""),
     };
   }
 
   public class Scenario {
     private final PinotDataType _pinotDataType;
-    private final FieldSpec.DataType _dataType;
+    private final DataType _dataType;
     private final String _valAsStr1;
     private final String _valAsStr2;
     private final String _defaultNullValue;
 
-    public Scenario(FieldSpec.DataType dataType, String valAsStr1, String valAsStr2, String defaultNullValue) {
+    public Scenario(DataType dataType, String valAsStr1, String valAsStr2, String defaultNullValue) {
       _dataType = dataType;
       _valAsStr1 = valAsStr1;
       _valAsStr2 = valAsStr2;
@@ -58,35 +59,39 @@ public class FirstWithTimeAggregationFunctionTest extends AbstractAggregationFun
     }
 
     public FluentQueryTest.DeclaringTable getDeclaringTable(boolean nullHandlingEnabled) {
-      Schema schema = new Schema.SchemaBuilder()
-          .setSchemaName("testTable")
+      Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
           .setEnableColumnBasedNullHandling(true)
           .addDimensionField("myField", _dataType, f -> f.setNullable(true))
-          .addDimensionField("timeField", FieldSpec.DataType.TIMESTAMP)
+          .addDimensionField("timeField", DataType.TIMESTAMP)
           .build();
-      TableConfigBuilder tableConfigBuilder = new TableConfigBuilder(TableType.OFFLINE)
-          .setTableName("testTable");
+      TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
 
       return FluentQueryTest.withBaseDir(_baseDir)
           .withNullHandling(nullHandlingEnabled)
-          .givenTable(schema, tableConfigBuilder.build());
+          .givenTable(schema, tableConfig);
     }
 
     @Override
     public String toString() {
-      return "Scenario{" + "dt=" + _dataType + ", val1='" + _valAsStr1 + '\'' + ", val2='"
-          + _valAsStr2 + '\'' + '}';
+      return "Scenario{"
+          + "dt=" + _dataType
+          + ", val1='" + _valAsStr1 + '\''
+          + ", val2='" + _valAsStr2 + '\''
+          + '}';
     }
   }
 
   @Test(dataProvider = "scenarios")
   void aggrWithoutNull(Scenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField | timeField",
+        .onFirstInstance(
+            "myField | timeField",
             "null                   | 1",
             scenario._valAsStr1 + " | 2",
             "null                   | 3"
-        ).andOnSecondInstance("myField | timeField",
+        )
+        .andOnSecondInstance(
+            "myField | timeField",
             "null                   | 4",
             scenario._valAsStr2 + " | 5",
             "null                   | 6"
@@ -98,11 +103,14 @@ public class FirstWithTimeAggregationFunctionTest extends AbstractAggregationFun
   @Test(dataProvider = "scenarios")
   void aggrWithNull(Scenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField | timeField",
+        .onFirstInstance(
+            "myField | timeField",
             "null                   | 1",
             scenario._valAsStr1 + " | 2",
             "null                   | 3"
-        ).andOnSecondInstance("myField | timeField",
+        )
+        .andOnSecondInstance(
+            "myField | timeField",
             "null                   | 4",
             scenario._valAsStr2 + " | 5",
             "null                   | 6"
@@ -114,52 +122,67 @@ public class FirstWithTimeAggregationFunctionTest extends AbstractAggregationFun
   @Test(dataProvider = "scenarios")
   void aggrSvWithoutNull(Scenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField | timeField",
+        .onFirstInstance(
+            "myField | timeField",
             "null                   | 1",
             scenario._valAsStr1 + " | 2",
             "null                   | 3"
-        ).andOnSecondInstance("myField | timeField",
+        )
+        .andOnSecondInstance(
+            "myField | timeField",
             "null                   | 4",
             scenario._valAsStr2 + " | 5",
             "null                   | 6"
-        ).whenQuery("select 'cte', FIRST_WITH_TIME(myField, timeField, '" + scenario._dataType + "') as mode "
-            + "from testTable "
-            + "group by 'cte'")
+        )
+        .whenQuery("""
+            select 'cte', FIRST_WITH_TIME(myField, timeField, '%s') as mode \
+            from testTable \
+            group by 'cte'""".formatted(scenario._dataType))
         .thenResultIs("STRING | " + scenario._pinotDataType.name(), "cte | " + scenario._defaultNullValue);
   }
 
   @Test(dataProvider = "scenarios")
   void aggrSvWithNull(Scenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField | timeField",
+        .onFirstInstance(
+            "myField | timeField",
             "null                   | 1",
             scenario._valAsStr1 + " | 2",
             "null                   | 3"
-        ).andOnSecondInstance("myField | timeField",
+        )
+        .andOnSecondInstance(
+            "myField | timeField",
             "null                   | 4",
             scenario._valAsStr2 + " | 5",
             "null                   | 6"
-        ).whenQuery("select 'cte', FIRST_WITH_TIME(myField, timeField, '" + scenario._dataType + "') as mode "
-            + "from testTable "
-            + "group by 'cte'")
+        )
+        .whenQuery("""
+            select 'cte', FIRST_WITH_TIME(myField, timeField, '%s') as mode \
+            from testTable \
+            group by 'cte'""".formatted(scenario._dataType))
         .thenResultIs("STRING | " + scenario._pinotDataType.name(), "cte | " + scenario._valAsStr1);
   }
 
   @Test(dataProvider = "scenarios")
   void aggrMvWithoutNull(Scenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField | timeField",
+        .onFirstInstance(
+            "myField | timeField",
             "null                   | 1",
             scenario._valAsStr1 + " | 2",
             "null                   | 3"
-        ).andOnSecondInstance("myField | timeField",
+        )
+        .andOnSecondInstance(
+            "myField | timeField",
             "null                   | 4",
             scenario._valAsStr2 + " | 5",
             "null                   | 6"
-        ).whenQuery("select 'cte1' as cte1, 'cte2' as cte2, "
-            + "FIRST_WITH_TIME(myField, timeField, '" + scenario._dataType + "') as mode "
-            + "from testTable "
-            + "group by 'cte'")
+        )
+        .whenQuery("""
+            select 'cte1' as cte1, 'cte2' as cte2, \
+            FIRST_WITH_TIME(myField, timeField, '%s') as mode \
+            from testTable \
+            group by 'cte'""".formatted(scenario._dataType))
         .thenResultIs("STRING | STRING | " + scenario._pinotDataType.name(),
             "cte1 | cte2 | " + scenario._defaultNullValue);
   }
@@ -167,19 +190,26 @@ public class FirstWithTimeAggregationFunctionTest extends AbstractAggregationFun
   @Test(dataProvider = "scenarios")
   void aggrMvWithNull(Scenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField | timeField",
+        .onFirstInstance(
+            "myField | timeField",
             "null                   | 1",
             scenario._valAsStr1 + " | 2",
             "null                   | 3"
-        ).andOnSecondInstance("myField | timeField",
+        )
+        .andOnSecondInstance(
+            "myField | timeField",
             "null                   | 4",
             scenario._valAsStr2 + " | 5",
             "null                   | 6"
-        ).whenQuery("select 'cte1' as cte1, 'cte2' as cte2, "
-            + "FIRST_WITH_TIME(myField, timeField, '" + scenario._dataType + "') as mode "
-            + "from testTable "
-            + "group by 'cte'")
-        .thenResultIs("STRING | STRING | " + scenario._pinotDataType.name(),
-            "cte1 | cte2 | " + scenario._valAsStr1);
+        )
+        .whenQuery("""
+            select 'cte1' as cte1, 'cte2' as cte2, \
+            FIRST_WITH_TIME(myField, timeField, '%s') as mode \
+            from testTable \
+            group by 'cte'""".formatted(scenario._dataType))
+        .thenResultIs(
+            "STRING | STRING | " + scenario._pinotDataType.name(),
+            "cte1 | cte2 | " + scenario._valAsStr1
+        );
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/LastWithTimeAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/LastWithTimeAggregationFunctionTest.java
@@ -20,8 +20,9 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.PinotDataType;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
@@ -33,23 +34,23 @@ public class LastWithTimeAggregationFunctionTest extends AbstractAggregationFunc
 
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
-    return new Object[] {
-        new Scenario(FieldSpec.DataType.INT, "1", "2", "-2147483648"),
-        new Scenario(FieldSpec.DataType.LONG, "1", "2", "-9223372036854775808"),
-        new Scenario(FieldSpec.DataType.FLOAT, "1", "2", "-Infinity"),
-        new Scenario(FieldSpec.DataType.DOUBLE, "1", "2", "-Infinity"),
-        new Scenario(FieldSpec.DataType.STRING, "a", "b", "\"null\""),
+    return new Object[]{
+        new Scenario(DataType.INT, "1", "2", "-2147483648"),
+        new Scenario(DataType.LONG, "1", "2", "-9223372036854775808"),
+        new Scenario(DataType.FLOAT, "1", "2", "-Infinity"),
+        new Scenario(DataType.DOUBLE, "1", "2", "-Infinity"),
+        new Scenario(DataType.STRING, "a", "b", "\"null\""),
     };
   }
 
   public class Scenario {
     private final PinotDataType _pinotDataType;
-    private final FieldSpec.DataType _dataType;
+    private final DataType _dataType;
     private final String _valAsStr1;
     private final String _valAsStr2;
     private final String _defaultNullValue;
 
-    public Scenario(FieldSpec.DataType dataType, String valAsStr1, String valAsStr2, String defaultNullValue) {
+    public Scenario(DataType dataType, String valAsStr1, String valAsStr2, String defaultNullValue) {
       _dataType = dataType;
       _valAsStr1 = valAsStr1;
       _valAsStr2 = valAsStr2;
@@ -58,34 +59,38 @@ public class LastWithTimeAggregationFunctionTest extends AbstractAggregationFunc
     }
 
     public FluentQueryTest.DeclaringTable getDeclaringTable(boolean nullHandlingEnabled) {
-      Schema schema = new Schema.SchemaBuilder()
-          .setSchemaName("testTable")
+      Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
           .setEnableColumnBasedNullHandling(true)
           .addDimensionField("myField", _dataType, f -> f.setNullable(true))
-          .addDimensionField("timeField", FieldSpec.DataType.TIMESTAMP)
+          .addDimensionField("timeField", DataType.TIMESTAMP)
           .build();
-      TableConfigBuilder tableConfigBuilder = new TableConfigBuilder(TableType.OFFLINE)
-          .setTableName("testTable");
+      TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
 
       return FluentQueryTest.withBaseDir(_baseDir)
           .withNullHandling(nullHandlingEnabled)
-          .givenTable(schema, tableConfigBuilder.build());
+          .givenTable(schema, tableConfig);
     }
 
     @Override
     public String toString() {
-      return "Scenario{" + "dt=" + _dataType + ", val1='" + _valAsStr1 + '\'' + ", val2='"
-          + _valAsStr2 + '\'' + '}';
+      return "Scenario{"
+          + "dt=" + _dataType
+          + ", val1='" + _valAsStr1 + '\''
+          + ", val2='" + _valAsStr2 + '\''
+          + '}';
     }
   }
 
   @Test(dataProvider = "scenarios")
   void aggrWithoutNull(Scenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField | timeField",
+        .onFirstInstance(
+            "myField | timeField",
             scenario._valAsStr1 + " | 2",
             "null                   | 3"
-        ).andOnSecondInstance("myField | timeField",
+        )
+        .andOnSecondInstance(
+            "myField | timeField",
             scenario._valAsStr2 + " | 5",
             "null                   | 6"
         )
@@ -96,10 +101,13 @@ public class LastWithTimeAggregationFunctionTest extends AbstractAggregationFunc
   @Test(dataProvider = "scenarios")
   void aggrWithNull(Scenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField | timeField",
+        .onFirstInstance(
+            "myField | timeField",
             scenario._valAsStr1 + " | 2",
             "null                   | 3"
-        ).andOnSecondInstance("myField | timeField",
+        )
+        .andOnSecondInstance(
+            "myField | timeField",
             scenario._valAsStr2 + " | 5",
             "null                   | 6"
         )
@@ -110,64 +118,87 @@ public class LastWithTimeAggregationFunctionTest extends AbstractAggregationFunc
   @Test(dataProvider = "scenarios")
   void aggrSvWithoutNull(Scenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField | timeField",
+        .onFirstInstance(
+            "myField | timeField",
             scenario._valAsStr1 + " | 2",
             "null                   | 3"
-        ).andOnSecondInstance("myField | timeField",
+        )
+        .andOnSecondInstance(
+            "myField | timeField",
             scenario._valAsStr2 + " | 5",
             "null                   | 6"
-        ).whenQuery("select 'cte', LAST_WITH_TIME(myField, timeField, '" + scenario._dataType + "') as mode "
-            + "from testTable "
-            + "group by 'cte'")
+        ).whenQuery("""
+            select 'cte', LAST_WITH_TIME(myField, timeField, '%s') as mode \
+            from testTable \
+            group by 'cte'""".formatted(scenario._dataType))
         .thenResultIs("STRING | " + scenario._pinotDataType.name(), "cte | " + scenario._defaultNullValue);
   }
 
   @Test(dataProvider = "scenarios")
   void aggrSvWithNull(Scenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField | timeField",
+        .onFirstInstance(
+            "myField | timeField",
             scenario._valAsStr1 + " | 2",
             "null                   | 3"
-        ).andOnSecondInstance("myField | timeField",
+        )
+        .andOnSecondInstance(
+            "myField | timeField",
             scenario._valAsStr2 + " | 5",
             "null                   | 6"
-        ).whenQuery("select 'cte', LAST_WITH_TIME(myField, timeField, '" + scenario._dataType + "') as mode "
-            + "from testTable "
-            + "group by 'cte'")
+        )
+        .whenQuery("""
+            select 'cte', LAST_WITH_TIME(myField, timeField, '%s') as mode \
+            from testTable \
+            group by 'cte'""".formatted(scenario._dataType))
         .thenResultIs("STRING | " + scenario._pinotDataType.name(), "cte | " + scenario._valAsStr2);
   }
 
   @Test(dataProvider = "scenarios")
   void aggrMvWithoutNull(Scenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField | timeField",
+        .onFirstInstance(
+            "myField | timeField",
             scenario._valAsStr1 + " | 2",
             "null                   | 3"
-        ).andOnSecondInstance("myField | timeField",
+        )
+        .andOnSecondInstance(
+            "myField | timeField",
             scenario._valAsStr2 + " | 5",
             "null                   | 6"
-        ).whenQuery("select 'cte1' as cte1, 'cte2' as cte2, "
-            + "LAST_WITH_TIME(myField, timeField, '" + scenario._dataType + "') as mode "
-            + "from testTable "
-            + "group by 'cte'")
-        .thenResultIs("STRING | STRING | " + scenario._pinotDataType.name(),
-            "cte1 | cte2 | " + scenario._defaultNullValue);
+        )
+        .whenQuery("""
+            select 'cte1' as cte1, 'cte2' as cte2, \
+            LAST_WITH_TIME(myField, timeField, '%s') as mode \
+            from testTable \
+            group by 'cte'""".formatted(scenario._dataType))
+        .thenResultIs(
+            "STRING | STRING | " + scenario._pinotDataType.name(),
+            "cte1 | cte2 | " + scenario._defaultNullValue
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggrMvWithNull(Scenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField | timeField",
+        .onFirstInstance(
+            "myField | timeField",
             scenario._valAsStr1 + " | 2",
             "null                   | 3"
-        ).andOnSecondInstance("myField | timeField",
+        )
+        .andOnSecondInstance(
+            "myField | timeField",
             scenario._valAsStr2 + " | 5",
             "null                   | 6"
-        ).whenQuery("select 'cte1' as cte1, 'cte2' as cte2, "
-            + "LAST_WITH_TIME(myField, timeField, '" + scenario._dataType + "') as mode "
-            + "from testTable "
-            + "group by 'cte'")
-        .thenResultIs("STRING | STRING | " + scenario._pinotDataType.name(),
-            "cte1 | cte2 | " + scenario._valAsStr2);
+        )
+        .whenQuery("""
+            select 'cte1' as cte1, 'cte2' as cte2, \
+            LAST_WITH_TIME(myField, timeField, '%s') as mode \
+            from testTable \
+            group by 'cte'""".formatted(scenario._dataType))
+        .thenResultIs(
+            "STRING | STRING | " + scenario._pinotDataType.name(),
+            "cte1 | cte2 | " + scenario._valAsStr2
+        );
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ListAggFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ListAggFunctionTest.java
@@ -26,7 +26,7 @@ import org.apache.pinot.core.query.aggregation.function.array.ListAggDistinctFun
 import org.apache.pinot.core.query.aggregation.function.array.ListAggFunction;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -52,8 +52,8 @@ public class ListAggFunctionTest extends AbstractAggregationFunctionTest {
     }
 
     @Override
-    public FieldSpec.DataType getValueType() {
-      return FieldSpec.DataType.STRING;
+    public DataType getValueType() {
+      return DataType.STRING;
     }
   }
 
@@ -75,8 +75,8 @@ public class ListAggFunctionTest extends AbstractAggregationFunctionTest {
     }
 
     @Override
-    public FieldSpec.DataType getValueType() {
-      return FieldSpec.DataType.STRING;
+    public DataType getValueType() {
+      return DataType.STRING;
     }
   }
 
@@ -106,8 +106,7 @@ public class ListAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   public void testListAggDistinctAggregate() {
-    ListAggDistinctFunction fn =
-        new ListAggDistinctFunction(ExpressionContext.forIdentifier("myField"), ",", false);
+    ListAggDistinctFunction fn = new ListAggDistinctFunction(ExpressionContext.forIdentifier("myField"), ",", false);
     AggregationResultHolder holder = fn.createAggregationResultHolder();
     fn.aggregate(2, holder,
         Map.of(ExpressionContext.forIdentifier("myField"), new TestStringMVBlock(new String[][]{{"A", "B"}, {"C"}})));
@@ -119,8 +118,7 @@ public class ListAggFunctionTest extends AbstractAggregationFunctionTest {
 
   @Test
   public void testListAggDistinctAggregateSV() {
-    ListAggDistinctFunction fn =
-        new ListAggDistinctFunction(ExpressionContext.forIdentifier("svField"), ",", false);
+    ListAggDistinctFunction fn = new ListAggDistinctFunction(ExpressionContext.forIdentifier("svField"), ",", false);
     AggregationResultHolder holder = fn.createAggregationResultHolder();
     fn.aggregate(3, holder,
         Map.of(ExpressionContext.forIdentifier("svField"), new TestStringSVBlock(new String[]{"A", "B", "C"})));

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunctionTest.java
@@ -20,6 +20,8 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,177 +32,121 @@ public class MaxAggregationFunctionTest extends AbstractAggregationFunctionTest 
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
     return new Object[] {
-        new DataTypeScenario(FieldSpec.DataType.INT),
-        new DataTypeScenario(FieldSpec.DataType.LONG),
-        new DataTypeScenario(FieldSpec.DataType.FLOAT),
-        new DataTypeScenario(FieldSpec.DataType.DOUBLE),
-        new DataTypeScenario(FieldSpec.DataType.BIG_DECIMAL)
+        new DataTypeScenario(DataType.INT),
+        new DataTypeScenario(DataType.LONG),
+        new DataTypeScenario(DataType.FLOAT),
+        new DataTypeScenario(DataType.DOUBLE),
+        new DataTypeScenario(DataType.BIG_DECIMAL)
     };
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select max(myField) from testTable")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select max(myField) from testTable")
         .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null)));
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, scenario.getDataType(), null)));
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select max(myField) from testTable")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select max(myField) from testTable")
         .thenResultIs("DOUBLE", "null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', max(myField) from testTable group by 'literal'")
-        .thenResultIs("STRING | DOUBLE", "literal | "
-            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null));
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', max(myField) from testTable group by 'literal'")
+        .thenResultIs(
+            "STRING | DOUBLE",
+            "literal | " + FieldSpec.getDefaultNullValue(FieldType.DIMENSION, scenario.getDataType(), null)
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', max(myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', max(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "2",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "5",
-            "null"
-        ).whenQuery("select max(myField) from testTable")
+        .onFirstInstance("myField", "2", "null", "3")
+        .andOnSecondInstance("myField", "null", "5", "null")
+        .whenQuery("select max(myField) from testTable")
         .thenResultIs("DOUBLE", "5");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "2",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "5",
-            "null"
-        ).whenQuery("select max(myField) from testTable")
+        .onFirstInstance("myField", "2", "null", "3")
+        .andOnSecondInstance("myField", "null", "5", "null")
+        .whenQuery("select max(myField) from testTable")
         .thenResultIs("DOUBLE", "5");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "2",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "5",
-            "null"
-        ).whenQuery("select 'literal', max(myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "2", "null", "3")
+        .andOnSecondInstance("myField", "null", "5", "null")
+        .whenQuery("select 'literal', max(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | 5");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "3",
-            "null",
-            "5"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select 'literal', max(myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "3", "null", "5")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select 'literal', max(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | 5");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupByMV(DataTypeScenario scenario) {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addMetricField("value", scenario.getDataType())
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addMetricField("value", scenario.getDataType())
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", -1},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", -2},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", -1}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", -2}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, MAX(value) from testTable group by tags order by tags")
-        .thenResultIs(
-            "STRING | DOUBLE",
-            "tag1    | -1.0",
-            "tag2    | 0.0",
-            "tag3    | 0.0"
-        )
+        .thenResultIs("STRING | DOUBLE", "tag1    | -1.0", "tag2    | 0.0", "tag3    | 0.0")
         .whenQueryWithNullHandlingEnabled("select tags, MAX(value) from testTable group by tags order by tags")
-        .thenResultIs(
-            "STRING | DOUBLE",
-            "tag1    | -1.0",
-            "tag2    | -1.0",
-            "tag3    | null"
-        );
+        .thenResultIs("STRING | DOUBLE", "tag1    | -1.0", "tag2    | -1.0", "tag3    | null");
   }
 
   @Test
   public void aggregationMVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select max(mv) from testTable")
-        .thenResultIs("DOUBLE",
-            String.valueOf(
-                (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf((int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
         )
         .whenQueryWithNullHandlingEnabled("select max(mv) from testTable")
         .thenResultIs("DOUBLE", "null");
@@ -208,19 +154,14 @@ public class MaxAggregationFunctionTest extends AbstractAggregationFunctionTest 
 
   @Test
   public void aggregationMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select max(mv) from testTable")
         .thenResultIs("DOUBLE", "3")
         .whenQueryWithNullHandlingEnabled("select max(mv) from testTable")
@@ -229,45 +170,32 @@ public class MaxAggregationFunctionTest extends AbstractAggregationFunctionTest 
 
   @Test
   public void aggregationMVGroupBySVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"})
+        .andOnSecondInstance(new Object[]{"null", "k1"})
         .whenQuery("select max(mv) from testTable group by sv")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs("DOUBLE", String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)))
         .whenQueryWithNullHandlingEnabled("select max(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "null");
   }
 
   @Test
   public void aggregationGroupBySVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"},
-            new Object[]{"1;2;3", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k2"},
-            new Object[]{"1;2;3", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"}, new Object[]{"1;2;3", "k2"})
+        .andOnSecondInstance(new Object[]{"null", "k2"}, new Object[]{"1;2;3", "k1"})
         .whenQuery("select max(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "3", "3")
         .whenQueryWithNullHandlingEnabled("select max(mv) from testTable group by sv")
@@ -276,44 +204,36 @@ public class MaxAggregationFunctionTest extends AbstractAggregationFunctionTest 
 
   @Test
   public void aggregationMVGroupByMVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select max(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select max(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "null", "null");
   }
 
   @Test
   public void aggregationMVGroupByMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select max(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "2", "2")
         .whenQueryWithNullHandlingEnabled("select max(mv1) from testTable group by mv2")

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MaxLongAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MaxLongAggregationFunctionTest.java
@@ -20,6 +20,8 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,139 +32,100 @@ public class MaxLongAggregationFunctionTest extends AbstractAggregationFunctionT
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
     return new Object[] {
-        new DataTypeScenario(FieldSpec.DataType.INT),
-        new DataTypeScenario(FieldSpec.DataType.LONG)
+        new DataTypeScenario(DataType.INT),
+        new DataTypeScenario(DataType.LONG)
     };
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select maxlong(myField) from testTable")
-        .thenResultIs("LONG",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null)));
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select maxlong(myField) from testTable")
+        .thenResultIs(
+            "LONG",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, scenario.getDataType(), null))
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select maxlong(myField) from testTable")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select maxlong(myField) from testTable")
         .thenResultIs("LONG", "null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', maxlong(myField) from testTable group by 'literal'")
-        .thenResultIs("STRING | LONG", "literal | "
-            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null));
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', maxlong(myField) from testTable group by 'literal'")
+        .thenResultIs(
+            "STRING | LONG",
+            "literal | " + FieldSpec.getDefaultNullValue(FieldType.DIMENSION, scenario.getDataType(), null)
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', maxlong(myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', maxlong(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | LONG", "literal | null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "2",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "5",
-            "null"
-        ).whenQuery("select maxlong(myField) from testTable")
+        .onFirstInstance("myField", "2", "null", "3")
+        .andOnSecondInstance("myField", "null", "5", "null")
+        .whenQuery("select maxlong(myField) from testTable")
         .thenResultIs("LONG", "5");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "2",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "5",
-            "null"
-        ).whenQuery("select maxlong(myField) from testTable")
+        .onFirstInstance("myField", "2", "null", "3")
+        .andOnSecondInstance("myField", "null", "5", "null")
+        .whenQuery("select maxlong(myField) from testTable")
         .thenResultIs("LONG", "5");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "2",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "5",
-            "null"
-        ).whenQuery("select 'literal', maxlong(myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "2", "null", "3")
+        .andOnSecondInstance("myField", "null", "5", "null")
+        .whenQuery("select 'literal', maxlong(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | LONG", "literal | 5");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "3",
-            "null",
-            "5"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select 'literal', maxlong(myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "3", "null", "5")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select 'literal', maxlong(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | LONG", "literal | 5");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupByMV(DataTypeScenario scenario) {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addMetricField("value", scenario.getDataType())
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addMetricField("value", scenario.getDataType())
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", -1},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", -2},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", -1}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", -2}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, maxlong(value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | LONG",
@@ -181,34 +144,23 @@ public class MaxLongAggregationFunctionTest extends AbstractAggregationFunctionT
 
   @Test
   public void aggregationOnLargeLongValues() {
-    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "" + (Long.MAX_VALUE - 6),
-            "" + (Long.MAX_VALUE - 5),
-            "" + (Long.MAX_VALUE - 4)
-        ).andOnSecondInstance("myField",
-            "" + (Long.MAX_VALUE - 3),
-            "" + (Long.MAX_VALUE - 2),
-            "" + (Long.MAX_VALUE - 1)
-        ).whenQuery("select maxlong(myField) from testTable")
-        .thenResultIs("LONG", "" + (Long.MAX_VALUE - 1));
+    new DataTypeScenario(DataType.LONG).getDeclaringTable(true)
+        .onFirstInstance("myField", "" + (Long.MAX_VALUE - 6), "" + (Long.MAX_VALUE - 5), "" + (Long.MAX_VALUE - 4))
+        .andOnSecondInstance("myField", "" + (Long.MAX_VALUE - 3), "" + (Long.MAX_VALUE - 2), "" + (Long.MAX_VALUE - 1))
+        .whenQuery("select maxlong(myField) from testTable")
+        .thenResultIs("LONG", String.valueOf(Long.MAX_VALUE - 1));
   }
 
   @Test
   public void aggregationMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.LONG)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.LONG)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select maxlong(mv) from testTable")
         .thenResultIs("LONG", "3")
         .whenQueryWithNullHandlingEnabled("select maxlong(mv) from testTable")
@@ -217,22 +169,15 @@ public class MaxLongAggregationFunctionTest extends AbstractAggregationFunctionT
 
   @Test
   public void aggregationMVGroupBySV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.LONG)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.LONG)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"},
-            new Object[]{"1;2;3", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k2"},
-            new Object[]{"1;2;3", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"}, new Object[]{"1;2;3", "k2"})
+        .andOnSecondInstance(new Object[]{"null", "k2"}, new Object[]{"1;2;3", "k1"})
         .whenQuery("select maxlong(mv) from testTable group by sv")
         .thenResultIs("LONG", "3", "3")
         .whenQueryWithNullHandlingEnabled("select maxlong(mv) from testTable group by sv")
@@ -241,20 +186,15 @@ public class MaxLongAggregationFunctionTest extends AbstractAggregationFunctionT
 
   @Test
   public void aggregationMVGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.LONG)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.LONG)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select maxlong(mv1) from testTable group by mv2")
         .thenResultIs("LONG", "2", "2")
         .whenQueryWithNullHandlingEnabled("select maxlong(mv1) from testTable group by mv2")

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunctionTest.java
@@ -20,6 +20,8 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -28,23 +30,18 @@ public class MaxMVAggregationFunctionTest extends AbstractAggregationFunctionTes
 
   @Test
   public void aggregationAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select max_mv(mv) from testTable")
-        .thenResultIs("DOUBLE",
-            String.valueOf(
-                (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf((int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
         )
         .whenQueryWithNullHandlingEnabled("select max_mv(mv) from testTable")
         .thenResultIs("DOUBLE", "null");
@@ -52,19 +49,14 @@ public class MaxMVAggregationFunctionTest extends AbstractAggregationFunctionTes
 
   @Test
   public void aggregationWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select max_mv(mv) from testTable")
         .thenResultIs("DOUBLE", "3")
         .whenQueryWithNullHandlingEnabled("select max_mv(mv) from testTable")
@@ -73,45 +65,32 @@ public class MaxMVAggregationFunctionTest extends AbstractAggregationFunctionTes
 
   @Test
   public void aggregationGroupBySVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"})
+        .andOnSecondInstance(new Object[]{"null", "k1"})
         .whenQuery("select max_mv(mv) from testTable group by sv")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs("DOUBLE", String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)))
         .whenQueryWithNullHandlingEnabled("select max_mv(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "null");
   }
 
   @Test
   public void aggregationGroupBySVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"},
-            new Object[]{"1;2;3", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k2"},
-            new Object[]{"1;2;3", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"}, new Object[]{"1;2;3", "k2"})
+        .andOnSecondInstance(new Object[]{"null", "k2"}, new Object[]{"1;2;3", "k1"})
         .whenQuery("select max_mv(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "3", "3")
         .whenQueryWithNullHandlingEnabled("select max_mv(mv) from testTable group by sv")
@@ -120,44 +99,36 @@ public class MaxMVAggregationFunctionTest extends AbstractAggregationFunctionTes
 
   @Test
   public void aggregationGroupByMVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select max_mv(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select max_mv(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "null", "null");
   }
 
   @Test
   public void aggregationGroupByMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select max_mv(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "2", "2")
         .whenQueryWithNullHandlingEnabled("select max_mv(mv1) from testTable group by mv2")

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunctionTest.java
@@ -28,7 +28,7 @@ import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
@@ -52,26 +52,24 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
 
   protected FluentQueryTest.DeclaringTable getDeclaringTable(boolean enableColumnBasedNullHandling,
       Map<String, String> extraQueryOptions) {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(enableColumnBasedNullHandling)
+        .addSingleValueDimension("myField", DataType.STRING)
+        .build();
     return FluentQueryTest.withBaseDir(_baseDir)
         .withExtraQueryOptions(extraQueryOptions)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(enableColumnBasedNullHandling)
-                .addSingleValueDimension("myField", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG);
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG);
   }
 
   @Test
   public void testNumericColumnExceptioninAggregateMethod() {
     ExpressionContext expression = RequestContextUtils.getExpression("column");
-    MaxStringAggregationFunction function = new MaxStringAggregationFunction(List.of(expression),
-        false);
+    MaxStringAggregationFunction function = new MaxStringAggregationFunction(List.of(expression), false);
 
     AggregationResultHolder resultHolder = function.createAggregationResultHolder();
     Map<ExpressionContext, BlockValSet> blockValSetMap = new HashMap<>();
     BlockValSet mockBlockValSet = mock(BlockValSet.class);
-    when(mockBlockValSet.getValueType()).thenReturn(FieldSpec.DataType.INT);
+    when(mockBlockValSet.getValueType()).thenReturn(DataType.INT);
     blockValSetMap.put(expression, mockBlockValSet);
 
     try {
@@ -85,13 +83,12 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
   @Test
   public void testNumericColumnExceptioninAggregateGroupBySVMethod() {
     ExpressionContext expression = RequestContextUtils.getExpression("column");
-    MaxStringAggregationFunction function = new MaxStringAggregationFunction(List.of(expression),
-        false);
+    MaxStringAggregationFunction function = new MaxStringAggregationFunction(List.of(expression), false);
 
     GroupByResultHolder groupByResultHolder = function.createGroupByResultHolder(10, 20);
     Map<ExpressionContext, BlockValSet> blockValSetMap = new HashMap<>();
     BlockValSet mockBlockValSet = mock(BlockValSet.class);
-    when(mockBlockValSet.getValueType()).thenReturn(FieldSpec.DataType.INT);
+    when(mockBlockValSet.getValueType()).thenReturn(DataType.INT);
     blockValSetMap.put(expression, mockBlockValSet);
 
     try {
@@ -105,13 +102,12 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
   @Test
   public void testNumericColumnExceptioninAggregateGroupByMVMethod() {
     ExpressionContext expression = RequestContextUtils.getExpression("column");
-    MaxStringAggregationFunction function = new MaxStringAggregationFunction(List.of(expression),
-        false);
+    MaxStringAggregationFunction function = new MaxStringAggregationFunction(List.of(expression), false);
 
     GroupByResultHolder groupByResultHolder = function.createGroupByResultHolder(10, 20);
     Map<ExpressionContext, BlockValSet> blockValSetMap = new HashMap<>();
     BlockValSet mockBlockValSet = mock(BlockValSet.class);
-    when(mockBlockValSet.getValueType()).thenReturn(FieldSpec.DataType.INT);
+    when(mockBlockValSet.getValueType()).thenReturn(DataType.INT);
     blockValSetMap.put(expression, mockBlockValSet);
 
     try {
@@ -125,8 +121,7 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
   @Test
   public void testFunctionBasics() {
     ExpressionContext expression = RequestContextUtils.getExpression("column");
-    MaxStringAggregationFunction function = new MaxStringAggregationFunction(List.of(expression),
-        false);
+    MaxStringAggregationFunction function = new MaxStringAggregationFunction(List.of(expression), false);
 
     // Test function type
     assertEquals(function.getType(), AggregationFunctionType.MAXSTRING);
@@ -148,12 +143,9 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
     // the result should be 'null' as there's no valid string to compare.
     // This differs from numeric MAX/MIN which might return an initial default value.
     getDeclaringTable(false) // nullHandlingEnabled = false
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select maxstring(myField) from testTable")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select maxstring(myField) from testTable")
         .thenResultIs("STRING", "\"null\""); // Asserting "null" as a string literal for the result
   }
 
@@ -161,12 +153,9 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
   void aggregationAllNullsWithNullHandlingEnabled() {
     // When null handling is enabled, and all values are null, the result should also be 'null'.
     getDeclaringTable(true) // nullHandlingEnabled = true
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select maxstring(myField) from testTable")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select maxstring(myField) from testTable")
         .thenResultIs("STRING", "\"null\""); // Asserting "null" as a string literal for the result
   }
 
@@ -175,12 +164,9 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
     // For group by, if all values in a group are null and null handling is disabled,
     // the group's result for MAXSTRING should be 'null'.
     getDeclaringTable(false) // nullHandlingEnabled = false
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', maxstring(myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', maxstring(myField) from testTable group by 'literal'")
         // Expected "null" as a string literal for the aggregated column
         .thenResultIs("STRING | STRING", "literal | \"null\"");
   }
@@ -190,12 +176,9 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
     // For group by, if all values in a group are null and null handling is enabled,
     // the group's result for MAXSTRING should be 'null'.
     getDeclaringTable(true) // nullHandlingEnabled = true
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', maxstring(myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', maxstring(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | STRING", "literal | \"null\"");
   }
 
@@ -204,15 +187,9 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
     // With null handling disabled, null values are effectively skipped, and the maximum non-null
     // string should be found. The updated function handles this correctly.
     getDeclaringTable(false) // nullHandlingEnabled = false
-        .onFirstInstance("myField",
-            "cat",
-            "null",
-            "apple"
-        ).andOnSecondInstance("myField",
-            "null",
-            "zebra",
-            "null"
-        ).whenQuery("select maxstring(myField) from testTable")
+        .onFirstInstance("myField", "cat", "null", "apple")
+        .andOnSecondInstance("myField", "null", "zebra", "null")
+        .whenQuery("select maxstring(myField) from testTable")
         .thenResultIs("STRING", "zebra"); // Max of {"cat", "apple", "zebra"} is "zebra"
   }
 
@@ -221,15 +198,9 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
     // With null handling enabled, null values are explicitly ignored, and the maximum non-null
     // string should be found. The updated function handles this correctly.
     getDeclaringTable(true) // nullHandlingEnabled = true
-        .onFirstInstance("myField",
-            "cat",
-            "null",
-            "apple"
-        ).andOnSecondInstance("myField",
-            "null",
-            "zebra",
-            "null"
-        ).whenQuery("select maxstring(myField) from testTable")
+        .onFirstInstance("myField", "cat", "null", "apple")
+        .andOnSecondInstance("myField", "null", "zebra", "null")
+        .whenQuery("select maxstring(myField) from testTable")
         .thenResultIs("STRING", "zebra"); // Max of {"cat", "apple", "zebra"} is "zebra"
   }
 
@@ -239,17 +210,21 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
     // Null handling disabled: nulls are ignored if there's at least one non-null value in the group.
     // The updated function should now correctly find the max among non-nulls.
     getDeclaringTable(false) // nullHandlingEnabled = false
-        .onFirstInstance("myField",
-            "alpha", // Grouped with 'literal'
+        .onFirstInstance(
+            "myField", "alpha", // Grouped with 'literal'
             "null",  // Grouped with 'literal'
             "gamma"  // Grouped with 'literal'
-        ).andOnSecondInstance("myField",
-            "null",  // Grouped with 'literal'
+        )
+        .andOnSecondInstance(
+            "myField", "null",  // Grouped with 'literal'
             "beta",  // Grouped with 'literal'
             "null"   // Grouped with 'literal'
-        ).whenQuery("select 'literal', maxstring(myField) from testTable group by 'literal'")
-        .thenResultIs("STRING | STRING",
-            "literal | \"null\""); // Max of {"alpha", null, "gamma", "beta"} is "null" when null handling is disabled
+        )
+        .whenQuery("select 'literal', maxstring(myField) from testTable group by 'literal'")
+        .thenResultIs(
+            "STRING | STRING",
+            "literal | \"null\"" // Max of {"alpha", null, "gamma", "beta"} is "null" when null handling is disabled
+        );
   }
 
   @Test
@@ -258,28 +233,31 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
     // Null handling enabled: nulls are ignored.
     // The updated function should now correctly find the max among non-nulls.
     getDeclaringTable(true) // nullHandlingEnabled = true
-        .onFirstInstance("myField",
+        .onFirstInstance(
+            "myField",
             "alpha", // Grouped with 'literal'
             "null",  // Grouped with 'literal'
             "gamma"  // Grouped with 'literal'
-        ).andOnSecondInstance("myField",
+        )
+        .andOnSecondInstance(
+            "myField",
             "null",  // Grouped with 'literal'
             "beta",  // Grouped with 'literal'
             "null"   // Grouped with 'literal'
-        ).whenQueryWithNullHandlingEnabled("select 'literal', maxstring(myField) from testTable group by 'literal'")
+        )
+        .whenQueryWithNullHandlingEnabled("select 'literal', maxstring(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | STRING", "literal | gamma"); // Max of {"alpha", "gamma", "beta"} is "gamma"
   }
 
   @Test
   void aggregationGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true) // Set at schema level for general behavior
+        .addMultiValueDimension("tags", DataType.STRING) // Dimension for tags
+        .addDimensionField("value", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true) // Set at schema level for general behavior
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING) // Dimension for tags
-                .addDimensionField("value", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
         .onFirstInstance(
             new Object[]{"tag1;tag2", "banana"}, // Row 1: tag1 -> "banana", tag2 -> "banana"
             new Object[]{"tag2;tag3", null}      // Row 2: tag2 -> null, tag3 -> null
@@ -299,8 +277,7 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
             "tag3    | \"null\""  // Values for tag3: null, "cherry". Max is "null".
         )
         // Query with explicit null handling enabled via query option
-        .whenQueryWithNullHandlingEnabled("select tags, MAXSTRING(value) from testTable "
-            + "group by tags order by tags")
+        .whenQueryWithNullHandlingEnabled("select tags, MAXSTRING(value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | STRING",
             "tag1    | banana", // Values for tag1: "banana", "apple". Max is "banana".
@@ -314,23 +291,17 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
   /// the custom-object null encoding, so this only round-trips if the builder writes the null through a bitmap.
   @Test
   void aggregationNoMatchingRowsWithNullHandlingDisabled() {
-    getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "alpha"
-        ).andOnSecondInstance("myField",
-            "beta"
-        ).whenQuery("select maxstring(myField) from testTable where myField = 'nomatch'")
+    getDeclaringTable(false).onFirstInstance("myField", "alpha")
+        .andOnSecondInstance("myField", "beta")
+        .whenQuery("select maxstring(myField) from testTable where myField = 'nomatch'")
         .thenResultIs("STRING", "null");
   }
 
   @Test
   void aggregationNoMatchingRowsWithNullHandlingEnabled() {
-    getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "alpha"
-        ).andOnSecondInstance("myField",
-            "beta"
-        ).whenQueryWithNullHandlingEnabled("select maxstring(myField) from testTable where myField = 'nomatch'")
+    getDeclaringTable(true).onFirstInstance("myField", "alpha")
+        .andOnSecondInstance("myField", "beta")
+        .whenQueryWithNullHandlingEnabled("select maxstring(myField) from testTable where myField = 'nomatch'")
         .thenResultIs("STRING", "null");
   }
 
@@ -338,12 +309,9 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
   /// 4-byte slot, so an over-wide null encoding would corrupt the column that follows it.
   @Test
   void aggregationNoMatchingRowsWithFollowingAggregateColumn() {
-    getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "alpha"
-        ).andOnSecondInstance("myField",
-            "beta"
-        ).whenQuery("select maxstring(myField), count(*) from testTable where myField = 'nomatch'")
+    getDeclaringTable(false).onFirstInstance("myField", "alpha")
+        .andOnSecondInstance("myField", "beta")
+        .whenQuery("select maxstring(myField), count(*) from testTable where myField = 'nomatch'")
         .thenResultIs("STRING | LONG", "null | 0");
   }
 
@@ -352,23 +320,19 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
   /// broker sets this option on its own for any single-server query, so this is a routine path, not an edge case.
   @Test
   void aggregationNoMatchingRowsReturningFinalResultWithNullHandlingDisabled() {
-    getDeclaringTable(false, Map.of(QueryOptionKey.SERVER_RETURN_FINAL_RESULT, "true"))
-        .onFirstInstance("myField",
-            "alpha"
-        ).andOnSecondInstance("myField",
-            "beta"
-        ).whenQuery("select maxstring(myField) from testTable where myField = 'nomatch'")
+    getDeclaringTable(false, Map.of(QueryOptionKey.SERVER_RETURN_FINAL_RESULT, "true")).onFirstInstance("myField",
+            "alpha")
+        .andOnSecondInstance("myField", "beta")
+        .whenQuery("select maxstring(myField) from testTable where myField = 'nomatch'")
         .thenResultIs("STRING", "null");
   }
 
   @Test
   void aggregationNoMatchingRowsReturningFinalResultWithNullHandlingEnabled() {
-    getDeclaringTable(true, Map.of(QueryOptionKey.SERVER_RETURN_FINAL_RESULT, "true"))
-        .onFirstInstance("myField",
-            "alpha"
-        ).andOnSecondInstance("myField",
-            "beta"
-        ).whenQueryWithNullHandlingEnabled("select maxstring(myField) from testTable where myField = 'nomatch'")
+    getDeclaringTable(true, Map.of(QueryOptionKey.SERVER_RETURN_FINAL_RESULT, "true")).onFirstInstance("myField",
+            "alpha")
+        .andOnSecondInstance("myField", "beta")
+        .whenQueryWithNullHandlingEnabled("select maxstring(myField) from testTable where myField = 'nomatch'")
         .thenResultIs("STRING", "null");
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunctionTest.java
@@ -20,6 +20,8 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,144 +32,109 @@ public class MinAggregationFunctionTest extends AbstractAggregationFunctionTest 
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
     return new Object[] {
-        new DataTypeScenario(FieldSpec.DataType.INT),
-        new DataTypeScenario(FieldSpec.DataType.LONG),
-        new DataTypeScenario(FieldSpec.DataType.FLOAT),
-        new DataTypeScenario(FieldSpec.DataType.DOUBLE),
-        new DataTypeScenario(FieldSpec.DataType.BIG_DECIMAL)
+        new DataTypeScenario(DataType.INT),
+        new DataTypeScenario(DataType.LONG),
+        new DataTypeScenario(DataType.FLOAT),
+        new DataTypeScenario(DataType.DOUBLE),
+        new DataTypeScenario(DataType.BIG_DECIMAL)
     };
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select min(myField) from testTable")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null)));
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select min(myField) from testTable")
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, scenario.getDataType(), null))
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select min(myField) from testTable")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select min(myField) from testTable")
         .thenResultIs("DOUBLE", "null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', min(myField) from testTable group by 'literal'")
-        .thenResultIs("STRING | DOUBLE", "literal | "
-            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null));
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', min(myField) from testTable group by 'literal'")
+        .thenResultIs(
+            "STRING | DOUBLE",
+            "literal | " + FieldSpec.getDefaultNullValue(FieldType.DIMENSION, scenario.getDataType(), null)
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', min(myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', min(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "5",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "2",
-            "null"
-        ).whenQuery("select min(myField) from testTable")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null)));
+        .onFirstInstance("myField", "5", "null", "3")
+        .andOnSecondInstance("myField", "null", "2", "null")
+        .whenQuery("select min(myField) from testTable")
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, scenario.getDataType(), null))
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "5",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "2",
-            "null"
-        ).whenQuery("select min(myField) from testTable")
+        .onFirstInstance("myField", "5", "null", "3")
+        .andOnSecondInstance("myField", "null", "2", "null")
+        .whenQuery("select min(myField) from testTable")
         .thenResultIs("DOUBLE", "2");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "5",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "2",
-            "null"
-        ).whenQuery("select 'literal', min(myField) from testTable group by 'literal'")
-        .thenResultIs("STRING | DOUBLE", "literal | "
-            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null));
+        .onFirstInstance("myField", "5", "null", "3")
+        .andOnSecondInstance("myField", "null", "2", "null")
+        .whenQuery("select 'literal', min(myField) from testTable group by 'literal'")
+        .thenResultIs(
+            "STRING | DOUBLE",
+            "literal | " + FieldSpec.getDefaultNullValue(FieldType.DIMENSION, scenario.getDataType(), null)
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "5",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select 'literal', min(myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "5", "null", "3")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select 'literal', min(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | 3");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupByMV(DataTypeScenario scenario) {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addMetricField("value", scenario.getDataType())
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addMetricField("value", scenario.getDataType())
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", 2},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", 2}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, MIN(value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | DOUBLE",
@@ -186,23 +153,18 @@ public class MinAggregationFunctionTest extends AbstractAggregationFunctionTest 
 
   @Test
   public void aggregationMVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select min(mv) from testTable")
-        .thenResultIs("DOUBLE",
-            String.valueOf(
-                (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf((int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
         )
         .whenQueryWithNullHandlingEnabled("select min(mv) from testTable")
         .thenResultIs("DOUBLE", "null");
@@ -210,121 +172,98 @@ public class MinAggregationFunctionTest extends AbstractAggregationFunctionTest 
 
   @Test
   public void aggregationMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select min(mv) from testTable")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs("DOUBLE", String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)))
         .whenQueryWithNullHandlingEnabled("select min(mv) from testTable")
         .thenResultIs("DOUBLE", "1");
   }
 
   @Test
   public void aggregationGroupBySVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"})
+        .andOnSecondInstance(new Object[]{"null", "k1"})
         .whenQuery("select min_mv(mv) from testTable group by sv")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs("DOUBLE", String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)))
         .whenQueryWithNullHandlingEnabled("select min_mv(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "null");
   }
 
   @Test
   public void aggregationMVGroupBySVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"},
-            new Object[]{"1;2;3", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k2"},
-            new Object[]{"1;2;3", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"}, new Object[]{"1;2;3", "k2"})
+        .andOnSecondInstance(new Object[]{"null", "k2"}, new Object[]{"1;2;3", "k1"})
         .whenQuery("select min(mv) from testTable group by sv")
-        .thenResultIs("DOUBLE", String.valueOf(
-            ((Number) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                null)).doubleValue()), String.valueOf(
-            ((Number) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                null)).doubleValue()))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(
+                ((Number) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)).doubleValue()),
+            String.valueOf(
+                ((Number) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)).doubleValue())
+        )
         .whenQueryWithNullHandlingEnabled("select min(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "1", "1");
   }
 
   @Test
   public void aggregationMVGroupByMVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select min(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select min(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "null", "null");
   }
 
   @Test
   public void aggregationMVGroupByMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select min(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select min(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "1", "1");
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinLongAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinLongAggregationFunctionTest.java
@@ -20,6 +20,8 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,141 +32,106 @@ public class MinLongAggregationFunctionTest extends AbstractAggregationFunctionT
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
     return new Object[] {
-        new DataTypeScenario(FieldSpec.DataType.INT),
-        new DataTypeScenario(FieldSpec.DataType.LONG)
+        new DataTypeScenario(DataType.INT),
+        new DataTypeScenario(DataType.LONG)
     };
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select minlong(myField) from testTable")
-        .thenResultIs("LONG",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null)));
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select minlong(myField) from testTable")
+        .thenResultIs(
+            "LONG",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, scenario.getDataType(), null))
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select minlong(myField) from testTable")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select minlong(myField) from testTable")
         .thenResultIs("LONG", "null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', minlong(myField) from testTable group by 'literal'")
-        .thenResultIs("STRING | LONG", "literal | "
-            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null));
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', minlong(myField) from testTable group by 'literal'")
+        .thenResultIs(
+            "STRING | LONG",
+            "literal | " + FieldSpec.getDefaultNullValue(FieldType.DIMENSION, scenario.getDataType(), null)
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', minlong(myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', minlong(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | LONG", "literal | null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "5",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "2",
-            "null"
-        ).whenQuery("select minlong(myField) from testTable")
-        .thenResultIs("LONG",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null)));
+        .onFirstInstance("myField", "5", "null", "3")
+        .andOnSecondInstance("myField", "null", "2", "null")
+        .whenQuery("select minlong(myField) from testTable")
+        .thenResultIs(
+            "LONG",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, scenario.getDataType(), null))
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "5",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "2",
-            "null"
-        ).whenQuery("select minlong(myField) from testTable")
+        .onFirstInstance("myField", "5", "null", "3")
+        .andOnSecondInstance("myField", "null", "2", "null")
+        .whenQuery("select minlong(myField) from testTable")
         .thenResultIs("LONG", "2");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "5",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "2",
-            "null"
-        ).whenQuery("select 'literal', minlong(myField) from testTable group by 'literal'")
-        .thenResultIs("STRING | LONG", "literal | "
-            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null));
+        .onFirstInstance("myField", "5", "null", "3")
+        .andOnSecondInstance("myField", "null", "2", "null")
+        .whenQuery("select 'literal', minlong(myField) from testTable group by 'literal'")
+        .thenResultIs(
+            "STRING | LONG",
+            "literal | " + FieldSpec.getDefaultNullValue(FieldType.DIMENSION, scenario.getDataType(), null)
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "5",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select 'literal', minlong(myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "5", "null", "3")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select 'literal', minlong(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | LONG", "literal | 3");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupByMV(DataTypeScenario scenario) {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addMetricField("value", scenario.getDataType())
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addMetricField("value", scenario.getDataType())
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", 2},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", 2}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, minlong(value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | LONG",
@@ -183,89 +150,69 @@ public class MinLongAggregationFunctionTest extends AbstractAggregationFunctionT
 
   @Test
   public void aggregationOnLargeLongValues() {
-    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "" + Long.MAX_VALUE,
-            "" + (Long.MAX_VALUE - 1),
-            "" + (Long.MAX_VALUE - 2)
-        ).andOnSecondInstance("myField",
-            "" + (Long.MAX_VALUE - 3),
-            "" + (Long.MAX_VALUE - 4),
-            "" + (Long.MAX_VALUE - 5)
-        ).whenQuery("select minlong(myField) from testTable")
-        .thenResultIs("LONG", "" + (Long.MAX_VALUE - 5));
+    new DataTypeScenario(DataType.LONG).getDeclaringTable(true)
+        .onFirstInstance("myField", "" + Long.MAX_VALUE, "" + (Long.MAX_VALUE - 1), "" + (Long.MAX_VALUE - 2))
+        .andOnSecondInstance("myField", "" + (Long.MAX_VALUE - 3), "" + (Long.MAX_VALUE - 4), "" + (Long.MAX_VALUE - 5))
+        .whenQuery("select minlong(myField) from testTable")
+        .thenResultIs("LONG", String.valueOf(Long.MAX_VALUE - 5));
   }
 
   @Test
   public void aggregationMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.LONG)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.LONG)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select minlong(mv) from testTable")
-        .thenResultIs("LONG",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.LONG, null)))
+        .thenResultIs("LONG", String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.LONG, null)))
         .whenQueryWithNullHandlingEnabled("select minlong(mv) from testTable")
         .thenResultIs("LONG", "1");
   }
 
   @Test
   public void aggregationMVGroupBySV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.LONG)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.LONG)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"},
-            new Object[]{"1;2;3", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k2"},
-            new Object[]{"1;2;3", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"}, new Object[]{"1;2;3", "k2"})
+        .andOnSecondInstance(new Object[]{"null", "k2"}, new Object[]{"1;2;3", "k1"})
         .whenQuery("select minlong(mv) from testTable group by sv")
-        .thenResultIs("LONG", String.valueOf(
-            ((Number) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.LONG,
-                null)).longValue()), String.valueOf(
-            ((Number) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.LONG,
-                null)).longValue()))
+        .thenResultIs(
+            "LONG",
+            String.valueOf(
+                ((Number) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.LONG, null)).longValue()),
+            String.valueOf(
+                ((Number) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.LONG, null)).longValue())
+        )
         .whenQueryWithNullHandlingEnabled("select minlong(mv) from testTable group by sv")
         .thenResultIs("LONG", "1", "1");
   }
 
   @Test
   public void aggregationMVGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.LONG)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.LONG)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select minlong(mv1) from testTable group by mv2")
-        .thenResultIs("LONG",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.LONG, null)),
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.LONG, null)))
+        .thenResultIs(
+            "LONG",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.LONG, null)),
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.LONG, null))
+        )
         .whenQueryWithNullHandlingEnabled("select minlong(mv1) from testTable group by mv2")
         .thenResultIs("LONG", "1", "1");
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunctionTest.java
@@ -20,6 +20,8 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -28,145 +30,115 @@ public class MinMVAggregationFunctionTest extends AbstractAggregationFunctionTes
 
   @Test
   public void aggregationAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select min_mv(mv) from testTable")
         .thenResultIs("DOUBLE",
-            String.valueOf(
-                (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
-        )
+            String.valueOf((int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)))
         .whenQueryWithNullHandlingEnabled("select min_mv(mv) from testTable")
         .thenResultIs("DOUBLE", "null");
   }
 
   @Test
   public void aggregationWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select min_mv(mv) from testTable")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs("DOUBLE", String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)))
         .whenQueryWithNullHandlingEnabled("select min_mv(mv) from testTable")
         .thenResultIs("DOUBLE", "1");
   }
 
   @Test
   public void aggregationGroupBySVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"})
+        .andOnSecondInstance(new Object[]{"null", "k1"})
         .whenQuery("select min_mv(mv) from testTable group by sv")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs("DOUBLE", String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)))
         .whenQueryWithNullHandlingEnabled("select min_mv(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "null");
   }
 
   @Test
   public void aggregationGroupBySVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"},
-            new Object[]{"1;2;3", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k2"},
-            new Object[]{"1;2;3", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"}, new Object[]{"1;2;3", "k2"})
+        .andOnSecondInstance(new Object[]{"null", "k2"}, new Object[]{"1;2;3", "k1"})
         .whenQuery("select min_mv(mv) from testTable group by sv")
-        .thenResultIs("DOUBLE", String.valueOf(
-            ((Number) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                null)).doubleValue()), String.valueOf(
-                ((Number) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                    null)).doubleValue()))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(
+                ((Number) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)).doubleValue()),
+            String.valueOf(
+                ((Number) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)).doubleValue())
+        )
         .whenQueryWithNullHandlingEnabled("select min_mv(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "1", "1");
   }
 
   @Test
   public void aggregationGroupByMVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select min_mv(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select min_mv(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "null", "null");
   }
 
   @Test
   public void aggregationGroupByMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select min_mv(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select min_mv(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "1", "1");
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunctionTest.java
@@ -21,6 +21,8 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.PinotDataType;
 import org.testng.annotations.DataProvider;
@@ -32,35 +34,33 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
     return new Object[] {
-        new DataTypeScenario(FieldSpec.DataType.INT),
-        new DataTypeScenario(FieldSpec.DataType.LONG),
-        new DataTypeScenario(FieldSpec.DataType.FLOAT),
-        new DataTypeScenario(FieldSpec.DataType.DOUBLE),
+        new DataTypeScenario(DataType.INT),
+        new DataTypeScenario(DataType.LONG),
+        new DataTypeScenario(DataType.FLOAT),
+        new DataTypeScenario(DataType.DOUBLE),
     };
   }
 
-  String diffBetweenMinAnd9(FieldSpec.DataType dt) {
+  String diffBetweenMinAnd9(DataType dt) {
     switch (dt) {
-      case INT: return "2.147483657E9";
-      case LONG: return "9.223372036854776E18";
-      case FLOAT: return "Infinity";
-      case DOUBLE: return "Infinity";
-      default: throw new IllegalArgumentException(dt.toString());
+      case INT:
+        return "2.147483657E9";
+      case LONG:
+        return "9.223372036854776E18";
+      case FLOAT:
+        return "Infinity";
+      case DOUBLE:
+        return "Infinity";
+      default:
+        throw new IllegalArgumentException(dt.toString());
     }
   }
 
   @Test(dataProvider = "scenarios")
   void aggrWithoutNull(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "9",
-            "null"
-        )
+        .onFirstInstance("myField", "null", "1", "null")
+        .andOnSecondInstance("myField", "null", "9", "null")
         .whenQuery("select minmaxrange(myField) from testTable")
         .thenResultIs("DOUBLE", diffBetweenMinAnd9(scenario.getDataType()));
   }
@@ -68,70 +68,51 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
   @Test(dataProvider = "scenarios")
   void aggrWithNull(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "9",
-            "null"
-        ).whenQuery("select minmaxrange(myField) from testTable")
+        .onFirstInstance("myField", "null", "1", "null")
+        .andOnSecondInstance("myField", "null", "9", "null")
+        .whenQuery("select minmaxrange(myField) from testTable")
         .thenResultIs("DOUBLE", "8");
   }
 
   @Test(dataProvider = "scenarios")
   void aggrWithAllNulls(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select minmaxrange(myField) from testTable")
+        .onFirstInstance("myField", "null", "null", "null")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select minmaxrange(myField) from testTable")
         .thenResultIs("DOUBLE", "null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggrSvWithoutNull(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "9",
-            "null"
-        ).whenQuery("select 'cte', minmaxrange(myField) from testTable group by 'cte'")
+        .onFirstInstance("myField", "null", "1", "null")
+        .andOnSecondInstance("myField", "null", "9", "null")
+        .whenQuery("select 'cte', minmaxrange(myField) from testTable group by 'cte'")
         .thenResultIs("STRING | DOUBLE", "cte | " + diffBetweenMinAnd9(scenario.getDataType()));
   }
 
   @Test(dataProvider = "scenarios")
   void aggrSvWithNull(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "9",
-            "null"
-        ).whenQuery("select 'cte', minmaxrange(myField) from testTable group by 'cte'")
+        .onFirstInstance("myField", "null", "1", "null")
+        .andOnSecondInstance("myField", "null", "9", "null")
+        .whenQuery("select 'cte', minmaxrange(myField) from testTable group by 'cte'")
         .thenResultIs("STRING | DOUBLE", "cte | 8");
   }
 
-  String aggrSvSelfWithoutNullResult(FieldSpec.DataType dt) {
+  String aggrSvSelfWithoutNullResult(DataType dt) {
     switch (dt) {
-      case INT: return "0";
-      case LONG: return "0";
-      case FLOAT: return "NaN";
-      case DOUBLE: return "NaN";
-      default: throw new IllegalArgumentException(dt.toString());
+      case INT:
+        return "0";
+      case LONG:
+        return "0";
+      case FLOAT:
+        return "NaN";
+      case DOUBLE:
+        return "NaN";
+      default:
+        throw new IllegalArgumentException(dt.toString());
     }
   }
 
@@ -158,19 +139,15 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
     }
 
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "2"
-        ).andOnSecondInstance("myField",
-            "null",
-            "1",
-            "2"
-        ).whenQuery("select myField, minmaxrange(myField) from testTable group by myField order by myField")
-        .thenResultIs(pinotDataType + " | DOUBLE",
+        .onFirstInstance("myField", "null", "1", "2")
+        .andOnSecondInstance("myField", "null", "1", "2")
+        .whenQuery("select myField, minmaxrange(myField) from testTable group by myField order by myField")
+        .thenResultIs(
+            pinotDataType + " | DOUBLE",
             defaultNullValue + " | " + aggrSvSelfWithoutNullResult(scenario.getDataType()),
             "1                   | 0",
-            "2                   | 0");
+            "2                   | 0"
+        );
   }
 
   @Test(dataProvider = "scenarios")
@@ -178,36 +155,28 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
     PinotDataType pinotDataType = PinotDataType.valueOf(scenario.getDataType().name());
 
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "2"
-        ).andOnSecondInstance("myField",
-            "null",
-            "1",
-            "2"
-        ).whenQuery("select myField, minmaxrange(myField) from testTable group by myField order by myField")
-        .thenResultIs(pinotDataType + " | DOUBLE", "1 | 0", "2 | 0", "null | null");
+        .onFirstInstance("myField", "null", "1", "2")
+        .andOnSecondInstance("myField", "null", "1", "2")
+        .whenQuery("select myField, minmaxrange(myField) from testTable group by myField order by myField")
+        .thenResultIs(
+            pinotDataType + " | DOUBLE",
+            "1 | 0",
+            "2 | 0",
+            "null | null"
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupByMV(DataTypeScenario scenario) {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addMetricField("value", scenario.getDataType())
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addMetricField("value", scenario.getDataType())
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", 2},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", 2}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, minmaxrange(value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | DOUBLE",
@@ -226,19 +195,14 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
 
   @Test
   public void aggregationMVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select min_max_range(mv) from testTable")
         .thenResultIs("DOUBLE", "0.0")
         .whenQueryWithNullHandlingEnabled("select min_max_range(mv) from testTable")
@@ -247,43 +211,34 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
 
   @Test
   public void aggregationMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select min_max_range(mv) from testTable")
-        .thenResultIs("DOUBLE", String.valueOf(
-            3.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(3.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select min_max_range(mv) from testTable")
         .thenResultIs("DOUBLE", "2");
   }
 
   @Test
   public void aggregationMVGroupBySVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"})
+        .andOnSecondInstance(new Object[]{"null", "k1"})
         .whenQuery("select min_max_range(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "0")
         .whenQueryWithNullHandlingEnabled("select min_max_range(mv) from testTable group by sv")
@@ -292,48 +247,36 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
 
   @Test
   public void aggregationMVGroupBySVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"},
-            new Object[]{"1;2;3", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k2"},
-            new Object[]{"1;2;3", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"}, new Object[]{"1;2;3", "k2"})
+        .andOnSecondInstance(new Object[]{"null", "k2"}, new Object[]{"1;2;3", "k1"})
         .whenQuery("select min_max_range(mv) from testTable group by sv")
-        .thenResultIs("DOUBLE", String.valueOf(
-            3.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                null)), String.valueOf(
-            3.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(3.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(3.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select min_max_range(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "2", "2");
   }
 
   @Test
   public void aggregationMVGroupByMVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select min_max_range(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "0", "0")
         .whenQueryWithNullHandlingEnabled("select min_max_range(mv1) from testTable group by mv2")
@@ -342,26 +285,21 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
 
   @Test
   public void aggregationMVGroupByMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select min_max_range(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE", String.valueOf(
-            2.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                null)), String.valueOf(
-            2.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(2.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(2.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select min_max_range(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "1", "1");
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunctionTest.java
@@ -20,6 +20,8 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -28,19 +30,14 @@ public class MinMaxRangeMVAggregationFunctionTest extends AbstractAggregationFun
 
   @Test
   public void aggregationAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select min_max_range_mv(mv) from testTable")
         .thenResultIs("DOUBLE", "0.0")
         .whenQueryWithNullHandlingEnabled("select min_max_range_mv(mv) from testTable")
@@ -49,43 +46,34 @@ public class MinMaxRangeMVAggregationFunctionTest extends AbstractAggregationFun
 
   @Test
   public void aggregationWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select min_max_range_mv(mv) from testTable")
-        .thenResultIs("DOUBLE", String.valueOf(
-            3.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(3.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select min_max_range_mv(mv) from testTable")
         .thenResultIs("DOUBLE", "2");
   }
 
   @Test
   public void aggregationGroupBySVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"})
+        .andOnSecondInstance(new Object[]{"null", "k1"})
         .whenQuery("select min_max_range_mv(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "0")
         .whenQueryWithNullHandlingEnabled("select min_max_range_mv(mv) from testTable group by sv")
@@ -94,48 +82,36 @@ public class MinMaxRangeMVAggregationFunctionTest extends AbstractAggregationFun
 
   @Test
   public void aggregationGroupBySVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"},
-            new Object[]{"1;2;3", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k2"},
-            new Object[]{"1;2;3", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"}, new Object[]{"1;2;3", "k2"})
+        .andOnSecondInstance(new Object[]{"null", "k2"}, new Object[]{"1;2;3", "k1"})
         .whenQuery("select min_max_range_mv(mv) from testTable group by sv")
-        .thenResultIs("DOUBLE", String.valueOf(
-            3.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                null)), String.valueOf(
-            3.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(3.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(3.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select min_max_range_mv(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "2", "2");
   }
 
   @Test
   public void aggregationGroupByMVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select min_max_range_mv(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "0", "0")
         .whenQueryWithNullHandlingEnabled("select min_max_range_mv(mv1) from testTable group by mv2")
@@ -144,26 +120,21 @@ public class MinMaxRangeMVAggregationFunctionTest extends AbstractAggregationFun
 
   @Test
   public void aggregationGroupByMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select min_max_range_mv(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE", String.valueOf(
-            2.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                null)), String.valueOf(
-            2.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(2.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(2.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select min_max_range_mv(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "1", "1");
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinStringAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinStringAggregationFunctionTest.java
@@ -28,7 +28,7 @@ import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.testng.annotations.Test;
@@ -46,25 +46,22 @@ public class MinStringAggregationFunctionTest extends AbstractAggregationFunctio
   /// This is used to simulate the DataTypeScenario concept from numeric aggregation tests,
   /// but fixed for the STRING data type.
   protected FluentQueryTest.DeclaringTable getDeclaringTable(boolean enableColumnBasedNullHandling) {
-    return FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(enableColumnBasedNullHandling)
-                .addSingleValueDimension("myField", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG);
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(enableColumnBasedNullHandling)
+        .addSingleValueDimension("myField", DataType.STRING)
+        .build();
+    return FluentQueryTest.withBaseDir(_baseDir).givenTable(schema, SINGLE_FIELD_TABLE_CONFIG);
   }
 
   @Test
   public void testNumericColumnExceptioninAggregateMethod() {
     ExpressionContext expression = RequestContextUtils.getExpression("column");
-    MinStringAggregationFunction function = new MinStringAggregationFunction(List.of(expression),
-        false);
+    MinStringAggregationFunction function = new MinStringAggregationFunction(List.of(expression), false);
 
     AggregationResultHolder resultHolder = function.createAggregationResultHolder();
     Map<ExpressionContext, BlockValSet> blockValSetMap = new HashMap<>();
     BlockValSet mockBlockValSet = mock(BlockValSet.class);
-    when(mockBlockValSet.getValueType()).thenReturn(FieldSpec.DataType.INT);
+    when(mockBlockValSet.getValueType()).thenReturn(DataType.INT);
     blockValSetMap.put(expression, mockBlockValSet);
 
     try {
@@ -78,13 +75,12 @@ public class MinStringAggregationFunctionTest extends AbstractAggregationFunctio
   @Test
   public void testNumericColumnExceptioninAggregateGroupBySVMethod() {
     ExpressionContext expression = RequestContextUtils.getExpression("column");
-    MinStringAggregationFunction function = new MinStringAggregationFunction(List.of(expression),
-        false);
+    MinStringAggregationFunction function = new MinStringAggregationFunction(List.of(expression), false);
 
     GroupByResultHolder groupByResultHolder = function.createGroupByResultHolder(10, 20);
     Map<ExpressionContext, BlockValSet> blockValSetMap = new HashMap<>();
     BlockValSet mockBlockValSet = mock(BlockValSet.class);
-    when(mockBlockValSet.getValueType()).thenReturn(FieldSpec.DataType.INT);
+    when(mockBlockValSet.getValueType()).thenReturn(DataType.INT);
     blockValSetMap.put(expression, mockBlockValSet);
     try {
       function.aggregateGroupBySV(10, new int[10], groupByResultHolder, blockValSetMap);
@@ -97,13 +93,12 @@ public class MinStringAggregationFunctionTest extends AbstractAggregationFunctio
   @Test
   public void testNumericColumnExceptioninAggregateGroupByMVMethod() {
     ExpressionContext expression = RequestContextUtils.getExpression("column");
-    MinStringAggregationFunction function = new MinStringAggregationFunction(List.of(expression),
-        false);
+    MinStringAggregationFunction function = new MinStringAggregationFunction(List.of(expression), false);
 
     GroupByResultHolder groupByResultHolder = function.createGroupByResultHolder(10, 20);
     Map<ExpressionContext, BlockValSet> blockValSetMap = new HashMap<>();
     BlockValSet mockBlockValSet = mock(BlockValSet.class);
-    when(mockBlockValSet.getValueType()).thenReturn(FieldSpec.DataType.INT);
+    when(mockBlockValSet.getValueType()).thenReturn(DataType.INT);
     blockValSetMap.put(expression, mockBlockValSet);
     try {
       function.aggregateGroupByMV(10, new int[10][], groupByResultHolder, blockValSetMap);
@@ -116,8 +111,7 @@ public class MinStringAggregationFunctionTest extends AbstractAggregationFunctio
   @Test
   public void testFunctionBasics() {
     ExpressionContext expression = RequestContextUtils.getExpression("column");
-    MinStringAggregationFunction function = new MinStringAggregationFunction(List.of(expression),
-        false);
+    MinStringAggregationFunction function = new MinStringAggregationFunction(List.of(expression), false);
 
     // Test function type
     assertEquals(function.getType(), AggregationFunctionType.MINSTRING);
@@ -138,12 +132,9 @@ public class MinStringAggregationFunctionTest extends AbstractAggregationFunctio
     // the result should be 'null' as there's no valid string to compare.
     // This differs from numeric MAX/MIN which might return an initial default value.
     getDeclaringTable(false) // nullHandlingEnabled = false
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select minstring(myField) from testTable")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select minstring(myField) from testTable")
         .thenResultIs("STRING", "\"null\""); // Asserting "null" as a string literal for the result
   }
 
@@ -151,12 +142,9 @@ public class MinStringAggregationFunctionTest extends AbstractAggregationFunctio
   void aggregationAllNullsWithNullHandlingEnabled() {
     // When null handling is enabled, and all values are null, the result should also be 'null'.
     getDeclaringTable(true) // nullHandlingEnabled = true
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select minstring(myField) from testTable")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select minstring(myField) from testTable")
         .thenResultIs("STRING", "\"null\""); // Asserting "null" as a string literal for the result
   }
 
@@ -165,12 +153,9 @@ public class MinStringAggregationFunctionTest extends AbstractAggregationFunctio
     // For group by, if all values in a group are null and null handling is disabled,
     // the group's result for MINSTRING should be 'null'.
     getDeclaringTable(false) // nullHandlingEnabled = false
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', minstring(myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', minstring(myField) from testTable group by 'literal'")
         // Expected "null" as a string literal for the aggregated column
         .thenResultIs("STRING | STRING", "literal | \"null\"");
   }
@@ -180,12 +165,9 @@ public class MinStringAggregationFunctionTest extends AbstractAggregationFunctio
     // For group by, if all values in a group are null and null handling is enabled,
     // the group's result for MINSTRING should be 'null'.
     getDeclaringTable(true) // nullHandlingEnabled = true
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', minstring(myField) from testTable group by 'literal'")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', minstring(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | STRING", "literal | \"null\"");
   }
 
@@ -194,15 +176,9 @@ public class MinStringAggregationFunctionTest extends AbstractAggregationFunctio
     // With null handling disabled, null values are effectively skipped, and the minimum non-null
     // string should be found. The updated function handles this correctly.
     getDeclaringTable(false) // nullHandlingEnabled = false
-        .onFirstInstance("myField",
-            "cat",
-            "null",
-            "apple"
-        ).andOnSecondInstance("myField",
-            "null",
-            "zebra",
-            "null"
-        ).whenQuery("select minstring(myField) from testTable")
+        .onFirstInstance("myField", "cat", "null", "apple")
+        .andOnSecondInstance("myField", "null", "zebra", "null")
+        .whenQuery("select minstring(myField) from testTable")
         .thenResultIs("STRING", "apple"); // Min of {"cat", "apple", "zebra"} is "apple"
   }
 
@@ -211,15 +187,9 @@ public class MinStringAggregationFunctionTest extends AbstractAggregationFunctio
     // With null handling enabled, null values are explicitly ignored, and the minimum non-null
     // string should be found. The updated function handles this correctly.
     getDeclaringTable(true) // nullHandlingEnabled = true
-        .onFirstInstance("myField",
-            "cat",
-            "null",
-            "apple"
-        ).andOnSecondInstance("myField",
-            "null",
-            "zebra",
-            "null"
-        ).whenQuery("select minstring(myField) from testTable")
+        .onFirstInstance("myField", "cat", "null", "apple")
+        .andOnSecondInstance("myField", "null", "zebra", "null")
+        .whenQuery("select minstring(myField) from testTable")
         .thenResultIs("STRING", "apple"); // Min of {"cat", "apple", "zebra"} is "apple"
   }
 
@@ -229,15 +199,19 @@ public class MinStringAggregationFunctionTest extends AbstractAggregationFunctio
     // Null handling disabled: nulls are ignored if there's at least one non-null value in the group.
     // The updated function should now correctly find the min among non-nulls.
     getDeclaringTable(false) // nullHandlingEnabled = false
-        .onFirstInstance("myField",
+        .onFirstInstance(
+            "myField",
             "alpha", // Grouped with 'literal'
             "null",  // Grouped with 'literal'
             "gamma"  // Grouped with 'literal'
-        ).andOnSecondInstance("myField",
+        )
+        .andOnSecondInstance(
+            "myField",
             "null",  // Grouped with 'literal'
             "beta",  // Grouped with 'literal'
             "null"   // Grouped with 'literal'
-        ).whenQuery("select 'literal', minstring(myField) from testTable group by 'literal'")
+        )
+        .whenQuery("select 'literal', minstring(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | STRING", "literal | alpha"); // Min of {"alpha", "gamma", "beta"} is "alpha"
   }
 
@@ -247,28 +221,31 @@ public class MinStringAggregationFunctionTest extends AbstractAggregationFunctio
     // Null handling enabled: nulls are ignored.
     // The updated function should now correctly find the min among non-nulls.
     getDeclaringTable(true) // nullHandlingEnabled = true
-        .onFirstInstance("myField",
+        .onFirstInstance(
+            "myField",
             "alpha", // Grouped with 'literal'
             "null",  // Grouped with 'literal'
             "gamma"  // Grouped with 'literal'
-        ).andOnSecondInstance("myField",
+        )
+        .andOnSecondInstance(
+            "myField",
             "null",  // Grouped with 'literal'
             "beta",  // Grouped with 'literal'
             "null"   // Grouped with 'literal'
-        ).whenQuery("select 'literal', minstring(myField) from testTable group by 'literal'")
+        )
+        .whenQuery("select 'literal', minstring(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | STRING", "literal | alpha"); // Min of {"alpha", "gamma", "beta"} is "alpha"
   }
 
   @Test
   void aggregationGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true) // Set at schema level for general behavior
+        .addMultiValueDimension("tags", DataType.STRING) // Dimension for tags
+        .addDimensionField("value", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true) // Set at schema level for general behavior
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING) // Dimension for tags
-                .addDimensionField("value", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
         .onFirstInstance(
             new Object[]{"tag1;tag2", "banana"}, // Row 1: tag1 -> "banana", tag2 -> "banana"
             new Object[]{"tag2;tag3", null}      // Row 2: tag2 -> null, tag3 -> null
@@ -286,8 +263,7 @@ public class MinStringAggregationFunctionTest extends AbstractAggregationFunctio
             "tag3    | cherry"  // Values for tag3: null, "cherry". Min is "cherry".
         )
         // Query with explicit null handling enabled via query option
-        .whenQueryWithNullHandlingEnabled("select tags, MINSTRING(value) from testTable "
-            + "group by tags order by tags")
+        .whenQueryWithNullHandlingEnabled("select tags, MINSTRING(value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | STRING",
             "tag1    | apple", // Values for tag1: "banana", "apple". Min is "apple".

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ModeAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ModeAggregationFunctionTest.java
@@ -21,7 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.config.table.FieldConfig;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.PinotDataType;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,20 +32,19 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
     return new Object[] {
-        new Scenario(FieldSpec.DataType.INT, true),
-
-        new Scenario(FieldSpec.DataType.INT, false),
-        new Scenario(FieldSpec.DataType.LONG, false),
-        new Scenario(FieldSpec.DataType.FLOAT, false),
-        new Scenario(FieldSpec.DataType.DOUBLE, false),
+        new Scenario(DataType.INT, true),
+        new Scenario(DataType.INT, false),
+        new Scenario(DataType.LONG, false),
+        new Scenario(DataType.FLOAT, false),
+        new Scenario(DataType.DOUBLE, false),
     };
   }
 
   public class Scenario {
-    private final FieldSpec.DataType _dataType;
+    private final DataType _dataType;
     private final boolean _dictionary;
 
-    public Scenario(FieldSpec.DataType dataType, boolean dictionary) {
+    public Scenario(DataType dataType, boolean dictionary) {
       _dataType = dataType;
       _dictionary = dictionary;
     }
@@ -68,51 +67,41 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
   @Test(dataProvider = "scenarios")
   void aggrWithoutNullAndEmptySegments(Scenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select mode(myField) as mode from testTable")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null", "null")
+        .whenQuery("select mode(myField) as mode from testTable")
         .thenResultIs("DOUBLE", aggrWithoutNullResult(scenario._dataType));
   }
 
   @Test(dataProvider = "scenarios")
   void aggrWithNullAndEmptySegments(Scenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select mode(myField) as mode from testTable")
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null", "null")
+        .whenQuery("select mode(myField) as mode from testTable")
         .thenResultIs("DOUBLE", "null");
   }
 
-  String aggrWithoutNullResult(FieldSpec.DataType dt) {
+  String aggrWithoutNullResult(DataType dt) {
     switch (dt) {
-      case INT: return "-2.147483648E9";
-      case LONG: return "-9.223372036854776E18";
-      case FLOAT: return "-Infinity";
-      case DOUBLE: return "-Infinity";
-      default: throw new IllegalArgumentException(dt.toString());
+      case INT:
+        return "-2.147483648E9";
+      case LONG:
+        return "-9.223372036854776E18";
+      case FLOAT:
+        return "-Infinity";
+      case DOUBLE:
+        return "-Infinity";
+      default:
+        throw new IllegalArgumentException(dt.toString());
     }
   }
 
   @Test(dataProvider = "scenarios")
   void aggrWithoutNull(Scenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "1",
-            "null"
-        )
+        .onFirstInstance("myField", "null", "1", "null")
+        .andOnSecondInstance("myField", "null", "1", "null")
         .whenQuery("select mode(myField) as mode from testTable")
         .thenResultIs("DOUBLE", aggrWithoutNullResult(scenario._dataType));
   }
@@ -120,55 +109,42 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
   @Test(dataProvider = "scenarios")
   void aggrWithNull(Scenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "1",
-            "null"
-        ).whenQuery("select mode(myField) as mode from testTable")
+        .onFirstInstance("myField", "null", "1", "null")
+        .andOnSecondInstance("myField", "null", "1", "null")
+        .whenQuery("select mode(myField) as mode from testTable")
         .thenResultIs("DOUBLE", "1");
   }
 
-  String aggrSvWithoutNullResult(FieldSpec.DataType dt) {
+  String aggrSvWithoutNullResult(DataType dt) {
     switch (dt) {
-      case INT: return "-2.147483648E9";
-      case LONG: return "-9.223372036854776E18";
-      case FLOAT: return "-Infinity";
-      case DOUBLE: return "-Infinity";
-      default: throw new IllegalArgumentException(dt.toString());
+      case INT:
+        return "-2.147483648E9";
+      case LONG:
+        return "-9.223372036854776E18";
+      case FLOAT:
+        return "-Infinity";
+      case DOUBLE:
+        return "-Infinity";
+      default:
+        throw new IllegalArgumentException(dt.toString());
     }
   }
 
   @Test(dataProvider = "scenarios")
   void aggrSvWithoutNull(Scenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "1",
-            "null"
-        ).whenQuery("select 'cte', mode(myField) as mode from testTable group by 'cte'")
+        .onFirstInstance("myField", "null", "1", "null")
+        .andOnSecondInstance("myField", "null", "1", "null")
+        .whenQuery("select 'cte', mode(myField) as mode from testTable group by 'cte'")
         .thenResultIs("STRING | DOUBLE", "cte | " + aggrSvWithoutNullResult(scenario._dataType));
   }
 
   @Test(dataProvider = "scenarios")
   void aggrSvWithNull(Scenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "1",
-            "null"
-        ).whenQuery("select 'cte', mode(myField) as mode from testTable group by 'cte'")
+        .onFirstInstance("myField", "null", "1", "null")
+        .andOnSecondInstance("myField", "null", "1", "null")
+        .whenQuery("select 'cte', mode(myField) as mode from testTable group by 'cte'")
         .thenResultIs("STRING | DOUBLE", "cte | 1");
   }
 
@@ -195,19 +171,15 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
     }
 
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "2"
-        ).andOnSecondInstance("myField",
-            "null",
-            "1",
-            "2"
-        ).whenQuery("select myField, mode(myField) as mode from testTable group by myField order by myField")
-        .thenResultIs(pinotDataType + " | DOUBLE",
+        .onFirstInstance("myField", "null", "1", "2")
+        .andOnSecondInstance("myField", "null", "1", "2")
+        .whenQuery("select myField, mode(myField) as mode from testTable group by myField order by myField")
+        .thenResultIs(
+            pinotDataType + " | DOUBLE",
             defaultNullValue + " | " + aggrSvWithoutNullResult(scenario._dataType),
             "1           | 1",
-            "2           | 2");
+            "2           | 2"
+        );
   }
 
   @Test(dataProvider = "scenarios")
@@ -215,25 +187,29 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
     PinotDataType pinotDataType = PinotDataType.valueOf(scenario._dataType.name());
 
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "2"
-        ).andOnSecondInstance("myField",
-            "null",
-            "1",
-            "2"
-        ).whenQuery("select myField, mode(myField) as mode from testTable group by myField order by myField")
-        .thenResultIs(pinotDataType + " | DOUBLE", "1 | 1", "2 | 2", "null | null");
+        .onFirstInstance("myField", "null", "1", "2")
+        .andOnSecondInstance("myField", "null", "1", "2")
+        .whenQuery("select myField, mode(myField) as mode from testTable group by myField order by myField")
+        .thenResultIs(
+            pinotDataType + " | DOUBLE",
+            "1 | 1",
+            "2 | 2",
+            "null | null"
+        );
   }
 
-  String aggrMvWithoutNullResult(FieldSpec.DataType dt) {
+  String aggrMvWithoutNullResult(DataType dt) {
     switch (dt) {
-      case INT: return "-2.147483648E9";
-      case LONG: return "-9.223372036854776E18";
-      case FLOAT: return "-Infinity";
-      case DOUBLE: return "-Infinity";
-      default: throw new IllegalArgumentException(dt.toString());
+      case INT:
+        return "-2.147483648E9";
+      case LONG:
+        return "-9.223372036854776E18";
+      case FLOAT:
+        return "-Infinity";
+      case DOUBLE:
+        return "-Infinity";
+      default:
+        throw new IllegalArgumentException(dt.toString());
     }
   }
 
@@ -241,15 +217,9 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
   void aggrMvWithoutNull(Scenario scenario) {
     // TODO: This test is not actually exercising aggregateGroupByMV
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "1",
-            "null"
-        ).whenQuery("select 'cte1' as cte1, 'cte2' as cte2, mode(myField) as mode from testTable group by cte1, cte2")
+        .onFirstInstance("myField", "null", "1", "null")
+        .andOnSecondInstance("myField", "null", "1", "null")
+        .whenQuery("select 'cte1' as cte1, 'cte2' as cte2, mode(myField) as mode from testTable group by cte1, cte2")
         .thenResultIs("STRING | STRING | DOUBLE", "cte1 | cte2 | " + aggrMvWithoutNullResult(scenario._dataType));
   }
 
@@ -257,15 +227,9 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
   void aggrMvWithNull(Scenario scenario) {
     // TODO: This test is not actually exercising aggregateGroupByMV
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField",
-            "null",
-            "1",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null",
-            "1",
-            "null"
-        ).whenQuery("select 'cte1' as cte1, 'cte2' as cte2, mode(myField) as mode from testTable group by cte1, cte2")
+        .onFirstInstance("myField", "null", "1", "null")
+        .andOnSecondInstance("myField", "null", "1", "null")
+        .whenQuery("select 'cte1' as cte1, 'cte2' as cte2, mode(myField) as mode from testTable group by cte1, cte2")
         .thenResultIs("STRING | STRING | DOUBLE", "cte1 | cte2 | 1");
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunctionTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class PercentileEstAggregationFunctionTest extends AbstractPercentileAggregationFunctionTest {
@@ -32,12 +32,16 @@ public class PercentileEstAggregationFunctionTest extends AbstractPercentileAggr
     return "LONG";
   }
 
-  String minValue(FieldSpec.DataType dataType) {
+  String minValue(DataType dataType) {
     switch (dataType) {
-      case INT: return "-2147483648";
-      case LONG: return "-9223372036854775808";
-      case FLOAT: return "-9223372036854775808";
-      case DOUBLE: return "-9223372036854775808";
+      case INT:
+        return "-2147483648";
+      case LONG:
+        return "-9223372036854775808";
+      case FLOAT:
+        return "-9223372036854775808";
+      case DOUBLE:
+        return "-9223372036854775808";
       default:
         throw new IllegalArgumentException("Unexpected type " + dataType);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunctionTest.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -28,19 +28,14 @@ public class PercentileEstMVAggregationFunctionTest extends AbstractAggregationF
 
   @Test
   public void testAggregationMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.LONG)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.LONG)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3;4;5"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"6;7;8;9;10"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3;4;5"})
+        .andOnSecondInstance(new Object[]{"6;7;8;9;10"})
         // All values: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 - p50 should be around 6
         .whenQuery("select percentileest(mv, 50) from testTable")
         .thenResultIs("LONG", "6");
@@ -48,48 +43,39 @@ public class PercentileEstMVAggregationFunctionTest extends AbstractAggregationF
 
   @Test
   public void testAggregationMVGroupBySV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.LONG)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.LONG)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3;4;5", "k1"},
-            new Object[]{"10;20;30", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"6;7;8;9;10", "k1"},
-            new Object[]{"40;50", "k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3;4;5", "k1"}, new Object[]{"10;20;30", "k2"})
+        .andOnSecondInstance(new Object[]{"6;7;8;9;10", "k1"}, new Object[]{"40;50", "k2"})
         .whenQuery("select sv, percentileest(mv, 50) from testTable group by sv order by sv")
-        .thenResultIs("STRING | LONG",
+        .thenResultIs(
+            "STRING | LONG",
             "k1 | 6",    // values: 1-10, p50 ~= 6
-            "k2 | 30");  // values: 10, 20, 30, 40, 50, p50 ~= 30
+            "k2 | 30"    // values: 10, 20, 30, 40, 50, p50 ~= 30
+        );
   }
 
   @Test
   public void testAggregationMVGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("nums", DataType.LONG)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("nums", FieldSpec.DataType.LONG)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            // Column order is alphabetical: nums, tags
-            new Object[]{"1;2;3", "tag1;tag2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"4;5;6", "tag1;tag2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3", "tag1;tag2"})  // Column order is alphabetical: nums, tags
+        .andOnSecondInstance(new Object[]{"4;5;6", "tag1;tag2"})
         .whenQuery("select tags, percentileest(nums, 50) from testTable group by tags order by tags")
-        .thenResultIs("STRING | LONG",
+        .thenResultIs(
+            "STRING | LONG",
             "tag1 | 4",   // nums: 1, 2, 3, 4, 5, 6, p50 ~= 4
-            "tag2 | 4");  // nums: 1, 2, 3, 4, 5, 6, p50 ~= 4
+            "tag2 | 4"    // nums: 1, 2, 3, 4, 5, 6, p50 ~= 4
+        );
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileKLLMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileKLLMVAggregationFunctionTest.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -28,19 +28,14 @@ public class PercentileKLLMVAggregationFunctionTest extends AbstractAggregationF
 
   @Test
   public void testAggregationMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.DOUBLE)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.DOUBLE)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1.0;2.0;3.0;4.0;5.0"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"6.0;7.0;8.0;9.0;10.0"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1.0;2.0;3.0;4.0;5.0"})
+        .andOnSecondInstance(new Object[]{"6.0;7.0;8.0;9.0;10.0"})
         // All values: 1-10, p50 should be around 5
         .whenQuery("select percentilekll(mv, 50) from testTable")
         .thenResultIs("DOUBLE", "5.0");
@@ -48,48 +43,39 @@ public class PercentileKLLMVAggregationFunctionTest extends AbstractAggregationF
 
   @Test
   public void testAggregationMVGroupBySV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.DOUBLE)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.DOUBLE)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1.0;2.0;3.0;4.0;5.0", "k1"},
-            new Object[]{"10.0;20.0;30.0", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"6.0;7.0;8.0;9.0;10.0", "k1"},
-            new Object[]{"40.0;50.0", "k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1.0;2.0;3.0;4.0;5.0", "k1"}, new Object[]{"10.0;20.0;30.0", "k2"})
+        .andOnSecondInstance(new Object[]{"6.0;7.0;8.0;9.0;10.0", "k1"}, new Object[]{"40.0;50.0", "k2"})
         .whenQuery("select sv, percentilekll(mv, 50) from testTable group by sv order by sv")
-        .thenResultIs("STRING | DOUBLE",
+        .thenResultIs(
+            "STRING | DOUBLE",
             "k1 | 5.0",   // values: 1-10, p50 ~= 5
-            "k2 | 30.0"); // values: 10, 20, 30, 40, 50, p50 ~= 30
+            "k2 | 30.0"   // values: 10, 20, 30, 40, 50, p50 ~= 30
+        );
   }
 
   @Test
   public void testAggregationMVGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("nums", DataType.DOUBLE)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("nums", FieldSpec.DataType.DOUBLE)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            // Column order is alphabetical: nums, tags
-            new Object[]{"1.0;2.0;3.0", "tag1;tag2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"4.0;5.0;6.0", "tag1;tag2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1.0;2.0;3.0", "tag1;tag2"})  // Column order is alphabetical: nums, tags
+        .andOnSecondInstance(new Object[]{"4.0;5.0;6.0", "tag1;tag2"})
         .whenQuery("select tags, percentilekll(nums, 50) from testTable group by tags order by tags")
-        .thenResultIs("STRING | DOUBLE",
+        .thenResultIs(
+            "STRING | DOUBLE",
             "tag1 | 3.0",  // nums: 1, 2, 3, 4, 5, 6, p50 ~= 3
-            "tag2 | 3.0"); // nums: 1, 2, 3, 4, 5, 6, p50 ~= 3
+            "tag2 | 3.0"   // nums: 1, 2, 3, 4, 5, 6, p50 ~= 3
+        );
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunctionTest.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -28,19 +28,14 @@ public class PercentileMVAggregationFunctionTest extends AbstractAggregationFunc
 
   @Test
   public void testAggregationMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3;4;5"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"6;7;8;9;10"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3;4;5"})
+        .andOnSecondInstance(new Object[]{"6;7;8;9;10"})
         // All values: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 - p50 should be 6
         .whenQuery("select percentile(mv, 50) from testTable")
         .thenResultIs("DOUBLE", "6.0");
@@ -48,48 +43,39 @@ public class PercentileMVAggregationFunctionTest extends AbstractAggregationFunc
 
   @Test
   public void testAggregationMVGroupBySV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3;4;5", "k1"},
-            new Object[]{"10;20;30", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"6;7;8;9;10", "k1"},
-            new Object[]{"40;50", "k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3;4;5", "k1"}, new Object[]{"10;20;30", "k2"})
+        .andOnSecondInstance(new Object[]{"6;7;8;9;10", "k1"}, new Object[]{"40;50", "k2"})
         .whenQuery("select sv, percentile(mv, 50) from testTable group by sv order by sv")
-        .thenResultIs("STRING | DOUBLE",
+        .thenResultIs(
+            "STRING | DOUBLE",
             "k1 | 6.0",   // values: 1-10, p50 = 6
-            "k2 | 30.0"); // values: 10, 20, 30, 40, 50, p50 = 30
+            "k2 | 30.0"  // values: 10, 20, 30, 40, 50, p50 = 30
+        );
   }
 
   @Test
   public void testAggregationMVGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("nums", DataType.INT)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("nums", FieldSpec.DataType.INT)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            // Column order is alphabetical: nums, tags
-            new Object[]{"1;2;3", "tag1;tag2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"4;5;6", "tag1;tag2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3", "tag1;tag2"})  // Column order is alphabetical: nums, tags
+        .andOnSecondInstance(new Object[]{"4;5;6", "tag1;tag2"})
         .whenQuery("select tags, percentile(nums, 50) from testTable group by tags order by tags")
-        .thenResultIs("STRING | DOUBLE",
+        .thenResultIs(
+            "STRING | DOUBLE",
             "tag1 | 4.0",   // nums: 1, 2, 3, 4, 5, 6, p50 = 4
-            "tag2 | 4.0");  // nums: 1, 2, 3, 4, 5, 6, p50 = 4
+            "tag2 | 4.0"    // nums: 1, 2, 3, 4, 5, 6, p50 = 4
+        );
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunctionTest.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -28,19 +28,14 @@ public class PercentileTDigestMVAggregationFunctionTest extends AbstractAggregat
 
   @Test
   public void testAggregationMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.DOUBLE)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.DOUBLE)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1.0;2.0;3.0;4.0;5.0"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"6.0;7.0;8.0;9.0;10.0"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1.0;2.0;3.0;4.0;5.0"})
+        .andOnSecondInstance(new Object[]{"6.0;7.0;8.0;9.0;10.0"})
         // t-digest 3.3 keeps singleton centroids discrete, so p50 selects 6 for the values 1-10.
         .whenQuery("select percentiletdigest(mv, 50) from testTable")
         .thenResultIs("DOUBLE", "6.0");
@@ -48,48 +43,39 @@ public class PercentileTDigestMVAggregationFunctionTest extends AbstractAggregat
 
   @Test
   public void testAggregationMVGroupBySV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.DOUBLE)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.DOUBLE)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1.0;2.0;3.0;4.0;5.0", "k1"},
-            new Object[]{"10.0;20.0;30.0", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"6.0;7.0;8.0;9.0;10.0", "k1"},
-            new Object[]{"40.0;50.0", "k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1.0;2.0;3.0;4.0;5.0", "k1"}, new Object[]{"10.0;20.0;30.0", "k2"})
+        .andOnSecondInstance(new Object[]{"6.0;7.0;8.0;9.0;10.0", "k1"}, new Object[]{"40.0;50.0", "k2"})
         .whenQuery("select sv, percentiletdigest(mv, 50) from testTable group by sv order by sv")
-        .thenResultIs("STRING | DOUBLE",
+        .thenResultIs(
+            "STRING | DOUBLE",
             "k1 | 6.0",   // values: 1-10, p50 = 6 with discrete singleton centroids
-            "k2 | 30.0"); // values: 10, 20, 30, 40, 50, p50 ~= 30
+            "k2 | 30.0"   // values: 10, 20, 30, 40, 50, p50 ~= 30
+        );
   }
 
   @Test
   public void testAggregationMVGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("nums", DataType.DOUBLE)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("nums", FieldSpec.DataType.DOUBLE)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            // Column order is alphabetical: nums, tags
-            new Object[]{"1.0;2.0;3.0", "tag1;tag2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"4.0;5.0;6.0", "tag1;tag2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1.0;2.0;3.0", "tag1;tag2"})  // Column order is alphabetical: nums, tags
+        .andOnSecondInstance(new Object[]{"4.0;5.0;6.0", "tag1;tag2"})
         .whenQuery("select tags, percentiletdigest(nums, 50) from testTable group by tags order by tags")
-        .thenResultIs("STRING | DOUBLE",
+        .thenResultIs(
+            "STRING | DOUBLE",
             "tag1 | 4.0",  // nums: 1, 2, 3, 4, 5, 6, p50 = 4 with discrete singleton centroids
-            "tag2 | 4.0"); // nums: 1, 2, 3, 4, 5, 6, p50 = 4 with discrete singleton centroids
+            "tag2 | 4.0"   // nums: 1, 2, 3, 4, 5, 6, p50 = 4 with discrete singleton centroids
+        );
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/StUnionAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/StUnionAggregationFunctionTest.java
@@ -26,7 +26,7 @@ import org.apache.pinot.core.common.SyntheticBlockValSets;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.segment.local.utils.GeometrySerializer;
 import org.apache.pinot.segment.local.utils.GeometryUtils;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.util.GeometryCombiner;
 import org.locationtech.jts.operation.union.UnaryUnionOp;
@@ -71,8 +71,7 @@ public class StUnionAggregationFunctionTest {
     };
 
     AggregationResultHolder aggregationResultHolder = aggregationFunction.createAggregationResultHolder();
-    Map<ExpressionContext, BlockValSet> blockValSetMap =
-        Map.of(expression, new BytesBlockValSet(values));
+    Map<ExpressionContext, BlockValSet> blockValSetMap = Map.of(expression, new BytesBlockValSet(values));
 
     aggregationFunction.aggregate(values.length, aggregationResultHolder, blockValSetMap);
 
@@ -88,8 +87,8 @@ public class StUnionAggregationFunctionTest {
     }
 
     @Override
-    public FieldSpec.DataType getValueType() {
-      return FieldSpec.DataType.BYTES;
+    public DataType getValueType() {
+      return DataType.BYTES;
     }
 
     @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunctionTest.java
@@ -20,6 +20,8 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -29,142 +31,104 @@ public class SumAggregationFunctionTest extends AbstractAggregationFunctionTest 
 
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
-    return new Object[] {
-        new DataTypeScenario(FieldSpec.DataType.INT),
-        new DataTypeScenario(FieldSpec.DataType.LONG),
-        new DataTypeScenario(FieldSpec.DataType.FLOAT),
-        new DataTypeScenario(FieldSpec.DataType.DOUBLE),
-        new DataTypeScenario(FieldSpec.DataType.BIG_DECIMAL)
+    return new Object[]{
+        new DataTypeScenario(DataType.INT),
+        new DataTypeScenario(DataType.LONG),
+        new DataTypeScenario(DataType.FLOAT),
+        new DataTypeScenario(DataType.DOUBLE),
+        new DataTypeScenario(DataType.BIG_DECIMAL)
     };
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select sum(myField) from testTable")
-        .thenResultIs("DOUBLE",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null)));
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select sum(myField) from testTable")
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.METRIC, scenario.getDataType(), null))
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select sum(myField) from testTable")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select sum(myField) from testTable")
         .thenResultIs("DOUBLE", "null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', sum(myField) from testTable group by 'literal'")
-        .thenResultIs("STRING | DOUBLE", "literal | "
-            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null));
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', sum(myField) from testTable group by 'literal'")
+        .thenResultIs(
+            "STRING | DOUBLE",
+            "literal | " + FieldSpec.getDefaultNullValue(FieldType.METRIC, scenario.getDataType(), null)
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', sum(myField) from testTable group by 'literal'")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', sum(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "3",
-            "null",
-            "5"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select sum(myField) from testTable")
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "3", "null", "5")
+        .andOnSecondInstance("myField", "null", "null")
+        .whenQuery("select sum(myField) from testTable")
         .thenResultIs("DOUBLE", "8");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "5",
-            "null"
-        ).andOnSecondInstance("myField",
-            "2",
-            "null",
-            "3"
-        ).whenQuery("select sum(myField) from testTable")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "5", "null")
+        .andOnSecondInstance("myField", "2", "null", "3")
+        .whenQuery("select sum(myField) from testTable")
         .thenResultIs("DOUBLE", "10");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "5",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "2",
-            "null"
-        ).whenQuery("select 'literal', sum(myField) from testTable group by 'literal'")
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "5", "null", "3")
+        .andOnSecondInstance("myField", "null", "2", "null")
+        .whenQuery("select 'literal', sum(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | 10");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "5",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select 'literal', sum(myField) from testTable group by 'literal'")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "5", "null", "3")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select 'literal', sum(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | 8");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupByMV(DataTypeScenario scenario) {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addSingleValueDimension("value", scenario.getDataType(), -1)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addSingleValueDimension("value", scenario.getDataType(), -1)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", 2},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", 2}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, SUM(value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | DOUBLE",
@@ -183,24 +147,18 @@ public class SumAggregationFunctionTest extends AbstractAggregationFunctionTest 
 
   @Test
   public void aggregationMVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select sum(mv) from testTable")
-        .thenResultIs("DOUBLE",
-            String.valueOf(
-                2.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                    null))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(2.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
         )
         .whenQueryWithNullHandlingEnabled("select sum(mv) from testTable")
         .thenResultIs("DOUBLE", "null");
@@ -208,124 +166,102 @@ public class SumAggregationFunctionTest extends AbstractAggregationFunctionTest 
 
   @Test
   public void aggregationMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select sum(mv) from testTable")
-        .thenResultIs("DOUBLE", String.valueOf(
-            1 + 2 + 3 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(1 + 2 + 3 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select sum(mv) from testTable")
-        .thenResultIs("DOUBLE",
-            String.valueOf(1 + 2 + 3));
+        .thenResultIs("DOUBLE", String.valueOf(1 + 2 + 3));
   }
 
   @Test
   public void aggregationMVGroupBySVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"})
+        .andOnSecondInstance(new Object[]{"null", "k1"})
         .whenQuery("select sum(mv) from testTable group by sv")
-        .thenResultIs("DOUBLE", String.valueOf(
-            2.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(2.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select sum(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "null");
   }
 
   @Test
   public void aggregationMVGroupBySVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"},
-            new Object[]{"1;2;3", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k2"},
-            new Object[]{"1;2;3", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"}, new Object[]{"1;2;3", "k2"})
+        .andOnSecondInstance(new Object[]{"null", "k2"}, new Object[]{"1;2;3", "k1"})
         .whenQuery("select sum(mv) from testTable group by sv")
-        .thenResultIs("DOUBLE", String.valueOf(
-                6.0 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
-            String.valueOf(
-                6.0 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(6.0 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(6.0 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select sum(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "6", "6");
   }
 
   @Test
   public void aggregationMVGroupByMVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select sum(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE", String.valueOf(
-                2.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
-            String.valueOf(
-                2.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(2.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(2.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select sum(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "null", "null");
   }
 
   @Test
   public void aggregationMVGroupByMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select sum(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE", String.valueOf(
-                3.0 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
-            String.valueOf(
-                3.0 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(3.0 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(3.0 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select sum(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "3", "3");
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SumIntAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SumIntAggregationFunctionTest.java
@@ -20,6 +20,8 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,137 +32,99 @@ public class SumIntAggregationFunctionTest extends AbstractAggregationFunctionTe
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
     return new Object[]{
-        new DataTypeScenario(FieldSpec.DataType.INT)
+        new DataTypeScenario(DataType.INT)
     };
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select sumint(myField) from testTable")
-        .thenResultIs("LONG",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null)));
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select sumint(myField) from testTable")
+        .thenResultIs(
+            "LONG",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.METRIC, scenario.getDataType(), null))
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select sumint(myField) from testTable")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select sumint(myField) from testTable")
         .thenResultIs("LONG", "null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', sumint(myField) from testTable group by 'literal'")
-        .thenResultIs("STRING | LONG", "literal | "
-            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null));
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', sumint(myField) from testTable group by 'literal'")
+        .thenResultIs(
+            "STRING | LONG",
+            "literal | " + FieldSpec.getDefaultNullValue(FieldType.METRIC, scenario.getDataType(), null)
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', sumint(myField) from testTable group by 'literal'")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', sumint(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | LONG", "literal | null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "3",
-            "null",
-            "5"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select sumint(myField) from testTable")
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "3", "null", "5")
+        .andOnSecondInstance("myField", "null", "null")
+        .whenQuery("select sumint(myField) from testTable")
         .thenResultIs("LONG", "8");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "5",
-            "null"
-        ).andOnSecondInstance("myField",
-            "2",
-            "null",
-            "3"
-        ).whenQuery("select sumint(myField) from testTable")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "5", "null")
+        .andOnSecondInstance("myField", "2", "null", "3")
+        .whenQuery("select sumint(myField) from testTable")
         .thenResultIs("LONG", "10");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "5",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "2",
-            "null"
-        ).whenQuery("select 'literal', sumint(myField) from testTable group by 'literal'")
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "5", "null", "3")
+        .andOnSecondInstance("myField", "null", "2", "null")
+        .whenQuery("select 'literal', sumint(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | LONG", "literal | 10");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "5",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select 'literal', sumint(myField) from testTable group by 'literal'")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "5", "null", "3")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select 'literal', sumint(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | LONG", "literal | 8");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupByMV(DataTypeScenario scenario) {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addSingleValueDimension("value", scenario.getDataType(), -1)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addSingleValueDimension("value", scenario.getDataType(), -1)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", 2},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", 2}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, SUMINT(value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | LONG",

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SumLongAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SumLongAggregationFunctionTest.java
@@ -20,6 +20,8 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,137 +32,99 @@ public class SumLongAggregationFunctionTest extends AbstractAggregationFunctionT
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
     return new Object[]{
-        new DataTypeScenario(FieldSpec.DataType.LONG)
+        new DataTypeScenario(DataType.LONG)
     };
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select sumlong(myField) from testTable")
-        .thenResultIs("LONG",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null)));
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select sumlong(myField) from testTable")
+        .thenResultIs(
+            "LONG",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.METRIC, scenario.getDataType(), null))
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select sumlong(myField) from testTable")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select sumlong(myField) from testTable")
         .thenResultIs("LONG", "null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', sumlong(myField) from testTable group by 'literal'")
-        .thenResultIs("STRING | LONG", "literal | "
-            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null));
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', sumlong(myField) from testTable group by 'literal'")
+        .thenResultIs(
+            "STRING | LONG",
+            "literal | " + FieldSpec.getDefaultNullValue(FieldType.METRIC, scenario.getDataType(), null)
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', sumlong(myField) from testTable group by 'literal'")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', sumlong(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | LONG", "literal | null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "3",
-            "null",
-            "5"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select sumlong(myField) from testTable")
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "3", "null", "5")
+        .andOnSecondInstance("myField", "null", "null")
+        .whenQuery("select sumlong(myField) from testTable")
         .thenResultIs("LONG", "8");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "5",
-            "null"
-        ).andOnSecondInstance("myField",
-            "2",
-            "null",
-            "3"
-        ).whenQuery("select sumlong(myField) from testTable")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "5", "null")
+        .andOnSecondInstance("myField", "2", "null", "3")
+        .whenQuery("select sumlong(myField) from testTable")
         .thenResultIs("LONG", "10");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "5",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "2",
-            "null"
-        ).whenQuery("select 'literal', sumlong(myField) from testTable group by 'literal'")
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "5", "null", "3")
+        .andOnSecondInstance("myField", "null", "2", "null")
+        .whenQuery("select 'literal', sumlong(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | LONG", "literal | 10");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "5",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select 'literal', sumlong(myField) from testTable group by 'literal'")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "5", "null", "3")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select 'literal', sumlong(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | LONG", "literal | 8");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupByMV(DataTypeScenario scenario) {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addSingleValueDimension("value", scenario.getDataType(), -1)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addSingleValueDimension("value", scenario.getDataType(), -1)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", 2},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", 2}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, sumlong(value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | LONG",
@@ -179,76 +143,61 @@ public class SumLongAggregationFunctionTest extends AbstractAggregationFunctionT
 
   @Test
   public void aggregationMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.LONG)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.LONG)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select sumlong(mv) from testTable")
-        .thenResultIs("LONG", String.valueOf(
-            1 + 2 + 3 + (long) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.LONG,
-                null)))
+        .thenResultIs(
+            "LONG",
+            String.valueOf(1 + 2 + 3 + (long) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.LONG, null))
+        )
         .whenQueryWithNullHandlingEnabled("select sumlong(mv) from testTable")
-        .thenResultIs("LONG",
-            String.valueOf(1 + 2 + 3));
+        .thenResultIs("LONG", String.valueOf(1 + 2 + 3));
   }
 
   @Test
   public void aggregationMVGroupBySV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.LONG)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.LONG)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"},
-            new Object[]{"1;2;3", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k2"},
-            new Object[]{"1;2;3", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"}, new Object[]{"1;2;3", "k2"})
+        .andOnSecondInstance(new Object[]{"null", "k2"}, new Object[]{"1;2;3", "k1"})
         .whenQuery("select sumlong(mv) from testTable group by sv")
-        .thenResultIs("LONG", String.valueOf(
-                6 + (long) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.LONG, null)),
-            String.valueOf(
-                6 + (long) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.LONG, null)))
+        .thenResultIs(
+            "LONG",
+            String.valueOf(6 + (long) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.LONG, null)),
+            String.valueOf(6 + (long) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.LONG, null))
+        )
         .whenQueryWithNullHandlingEnabled("select sumlong(mv) from testTable group by sv")
         .thenResultIs("LONG", "6", "6");
   }
 
   @Test
   public void aggregationMVGroupByMV() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.LONG)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.LONG)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select sumlong(mv1) from testTable group by mv2")
-        .thenResultIs("LONG", String.valueOf(
-                3 + (long) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.LONG, null)),
-            String.valueOf(
-                3 + (long) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.LONG, null)))
+        .thenResultIs(
+            "LONG",
+            String.valueOf(3 + (long) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.LONG, null)),
+            String.valueOf(3 + (long) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.LONG, null))
+        )
         .whenQueryWithNullHandlingEnabled("select sumlong(mv1) from testTable group by mv2")
         .thenResultIs("LONG", "3", "3");
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunctionTest.java
@@ -20,6 +20,8 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -28,24 +30,18 @@ public class SumMVAggregationFunctionTest extends AbstractAggregationFunctionTes
 
   @Test
   public void aggregationAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select sum_mv(mv) from testTable")
-        .thenResultIs("DOUBLE",
-            String.valueOf(
-                2.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                    null))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(2.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
         )
         .whenQueryWithNullHandlingEnabled("select sum_mv(mv) from testTable")
         .thenResultIs("DOUBLE", "null");
@@ -53,124 +49,102 @@ public class SumMVAggregationFunctionTest extends AbstractAggregationFunctionTes
 
   @Test
   public void aggregationWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2;3"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2;3"})
+        .andOnSecondInstance(new Object[]{"null"})
         .whenQuery("select sum_mv(mv) from testTable")
-        .thenResultIs("DOUBLE", String.valueOf(
-            1 + 2 + 3 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
-                null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(1 + 2 + 3 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select sum_mv(mv) from testTable")
-        .thenResultIs("DOUBLE",
-            String.valueOf(1 + 2 + 3));
+        .thenResultIs("DOUBLE", String.valueOf(1 + 2 + 3));
   }
 
   @Test
   public void aggregationGroupBySVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"})
+        .andOnSecondInstance(new Object[]{"null", "k1"})
         .whenQuery("select sum_mv(mv) from testTable group by sv")
-        .thenResultIs("DOUBLE", String.valueOf(
-            2.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(2.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select sum_mv(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "null");
   }
 
   @Test
   public void aggregationGroupBySVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv", DataType.INT)
+        .addSingleValueDimension("sv", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
-                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1"},
-            new Object[]{"1;2;3", "k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k2"},
-            new Object[]{"1;2;3", "k1"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1"}, new Object[]{"1;2;3", "k2"})
+        .andOnSecondInstance(new Object[]{"null", "k2"}, new Object[]{"1;2;3", "k1"})
         .whenQuery("select sum_mv(mv) from testTable group by sv")
-        .thenResultIs("DOUBLE", String.valueOf(
-                6.0 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
-            String.valueOf(
-                6.0 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(6.0 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(6.0 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select sum_mv(mv) from testTable group by sv")
         .thenResultIs("DOUBLE", "6", "6");
   }
 
   @Test
   public void aggregationGroupByMVAllNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"null", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"null", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select sum_mv(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE", String.valueOf(
-                2.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
-            String.valueOf(
-                2.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(2.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(2.0 * (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select sum_mv(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "null", "null");
   }
 
   @Test
   public void aggregationGroupByMVWithNulls() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("mv1", DataType.INT)
+        .addMultiValueDimension("mv2", DataType.STRING)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
-                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"1;2", "k1;k2"}
-        )
-        .andOnSecondInstance(
-            new Object[]{"null", "k1;k2"}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"1;2", "k1;k2"})
+        .andOnSecondInstance(new Object[]{"null", "k1;k2"})
         .whenQuery("select sum_mv(mv1) from testTable group by mv2")
-        .thenResultIs("DOUBLE", String.valueOf(
-                3.0 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
-            String.valueOf(
-                3.0 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .thenResultIs(
+            "DOUBLE",
+            String.valueOf(3.0 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null)),
+            String.valueOf(3.0 + (int) FieldSpec.getDefaultNullValue(FieldType.DIMENSION, DataType.INT, null))
+        )
         .whenQueryWithNullHandlingEnabled("select sum_mv(mv1) from testTable group by mv2")
         .thenResultIs("DOUBLE", "3", "3");
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SumPrecisionAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SumPrecisionAggregationFunctionTest.java
@@ -20,6 +20,8 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,141 +32,103 @@ public class SumPrecisionAggregationFunctionTest extends AbstractAggregationFunc
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
     return new Object[] {
-        new DataTypeScenario(FieldSpec.DataType.INT),
-        new DataTypeScenario(FieldSpec.DataType.LONG),
-        new DataTypeScenario(FieldSpec.DataType.FLOAT),
-        new DataTypeScenario(FieldSpec.DataType.DOUBLE),
-        new DataTypeScenario(FieldSpec.DataType.BIG_DECIMAL)
+        new DataTypeScenario(DataType.INT),
+        new DataTypeScenario(DataType.LONG),
+        new DataTypeScenario(DataType.FLOAT),
+        new DataTypeScenario(DataType.DOUBLE),
+        new DataTypeScenario(DataType.BIG_DECIMAL)
     };
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select sumprecision(myField) from testTable")
-        .thenResultIs("STRING",
-            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null)));
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select sumprecision(myField) from testTable")
+        .thenResultIs(
+            "STRING",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldType.METRIC, scenario.getDataType(), null))
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select sumprecision(myField) from testTable")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select sumprecision(myField) from testTable")
         .thenResultIs("STRING", "null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', sumprecision(myField) from testTable group by 'literal'")
-        .thenResultIs("STRING | STRING", "literal | "
-            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null));
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', sumprecision(myField) from testTable group by 'literal'")
+        .thenResultIs(
+            "STRING | STRING",
+            "literal | " + FieldSpec.getDefaultNullValue(FieldType.METRIC, scenario.getDataType(), null)
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', sumprecision(myField) from testTable group by 'literal'")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', sumprecision(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | STRING", "literal | null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "3",
-            "null",
-            "5"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null"
-        ).whenQuery("select sumprecision(myField) from testTable")
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "3", "null", "5")
+        .andOnSecondInstance("myField", "null", "null")
+        .whenQuery("select sumprecision(myField) from testTable")
         .thenResultIs("STRING", getStringValueOfSum(8, scenario.getDataType()));
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "5",
-            "null"
-        ).andOnSecondInstance("myField",
-            "2",
-            "null",
-            "3"
-        ).whenQuery("select sumprecision(myField) from testTable")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "5", "null")
+        .andOnSecondInstance("myField", "2", "null", "3")
+        .whenQuery("select sumprecision(myField) from testTable")
         .thenResultIs("STRING", getStringValueOfSum(10, scenario.getDataType()));
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "5",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "2",
-            "null"
-        ).whenQuery("select 'literal', sumprecision(myField) from testTable group by 'literal'")
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "5", "null", "3")
+        .andOnSecondInstance("myField", "null", "2", "null")
+        .whenQuery("select 'literal', sumprecision(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | STRING", "literal | " + getStringValueOfSum(10, scenario.getDataType()));
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "5",
-            "null",
-            "3"
-        ).andOnSecondInstance("myField",
-            "null",
-            "null",
-            "null"
-        ).whenQuery("select 'literal', sumprecision(myField) from testTable group by 'literal'")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "5", "null", "3")
+        .andOnSecondInstance("myField", "null", "null", "null")
+        .whenQuery("select 'literal', sumprecision(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | STRING", "literal | " + getStringValueOfSum(8, scenario.getDataType()));
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupByMV(DataTypeScenario scenario) {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addSingleValueDimension("value", scenario.getDataType(), -1)
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addSingleValueDimension("value", scenario.getDataType(), -1)
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
-        .onFirstInstance(
-            new Object[]{"tag1;tag2", 1},
-            new Object[]{"tag2;tag3", null}
-        )
-        .andOnSecondInstance(
-            new Object[]{"tag1;tag2", 2},
-            new Object[]{"tag2;tag3", null}
-        )
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(new Object[]{"tag1;tag2", 1}, new Object[]{"tag2;tag3", null})
+        .andOnSecondInstance(new Object[]{"tag1;tag2", 2}, new Object[]{"tag2;tag3", null})
         .whenQuery("select tags, sumprecision(value) from testTable group by tags order by tags")
         .thenResultIs(
             "STRING | STRING",
@@ -181,8 +145,8 @@ public class SumPrecisionAggregationFunctionTest extends AbstractAggregationFunc
         );
   }
 
-  private String getStringValueOfSum(int sum, FieldSpec.DataType dataType) {
-    if (dataType == FieldSpec.DataType.FLOAT || dataType == FieldSpec.DataType.DOUBLE) {
+  private String getStringValueOfSum(int sum, DataType dataType) {
+    if (dataType == DataType.FLOAT || dataType == DataType.DOUBLE) {
       return String.valueOf((double) sum);
     } else {
       return String.valueOf(sum);

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/VarianceAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/VarianceAggregationFunctionTest.java
@@ -23,7 +23,8 @@ import java.util.List;
 import java.util.Set;
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -33,11 +34,19 @@ import static org.apache.pinot.core.query.aggregation.utils.StatisticalAggregati
 
 public class VarianceAggregationFunctionTest extends AbstractAggregationFunctionTest {
 
-  private static final EnumSet<AggregationFunctionType> VARIANCE_FUNCTIONS = EnumSet.of(AggregationFunctionType.VARPOP,
-      AggregationFunctionType.VARSAMP, AggregationFunctionType.STDDEVPOP, AggregationFunctionType.STDDEVSAMP);
+  private static final EnumSet<AggregationFunctionType> VARIANCE_FUNCTIONS = EnumSet.of(
+      AggregationFunctionType.VARPOP,
+      AggregationFunctionType.VARSAMP,
+      AggregationFunctionType.STDDEVPOP,
+      AggregationFunctionType.STDDEVSAMP
+  );
 
-  private static final Set<FieldSpec.DataType> DATA_TYPES = Set.of(FieldSpec.DataType.INT, FieldSpec.DataType.LONG,
-      FieldSpec.DataType.FLOAT, FieldSpec.DataType.DOUBLE);
+  private static final Set<DataType> DATA_TYPES = Set.of(
+      DataType.INT,
+      DataType.LONG,
+      DataType.FLOAT,
+      DataType.DOUBLE
+  );
 
   @DataProvider(name = "scenarios")
   Object[][] scenarios() {
@@ -45,7 +54,7 @@ public class VarianceAggregationFunctionTest extends AbstractAggregationFunction
 
     int i = 0;
     for (AggregationFunctionType functionType : VARIANCE_FUNCTIONS) {
-      for (FieldSpec.DataType dataType : DATA_TYPES) {
+      for (DataType dataType : DATA_TYPES) {
         scenarios[i][0] = functionType;
         scenarios[i][1] = new DataTypeScenario(dataType);
         i++;
@@ -57,127 +66,90 @@ public class VarianceAggregationFunctionTest extends AbstractAggregationFunction
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingDisabled(AggregationFunctionType functionType, DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select " + functionType.getName() + "(myField) from testTable")
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select " + functionType.getName() + "(myField) from testTable")
         .thenResultIs("DOUBLE", "0.0");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationAllNullsWithNullHandlingEnabled(AggregationFunctionType functionType, DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select " + functionType.getName() + "(myField) from testTable")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select " + functionType.getName() + "(myField) from testTable")
         .thenResultIs("DOUBLE", "null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingDisabled(AggregationFunctionType functionType,
       DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', " + functionType.getName() + "(myField) from testTable group by 'literal'")
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', " + functionType.getName() + "(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | 0.0");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVAllNullsWithNullHandlingEnabled(AggregationFunctionType functionType,
       DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "null",
-            "null"
-        ).andOnSecondInstance("myField",
-            "null"
-        ).whenQuery("select 'literal', " + functionType.getName() + "(myField) from testTable group by 'literal'")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "null", "null")
+        .andOnSecondInstance("myField", "null")
+        .whenQuery("select 'literal', " + functionType.getName() + "(myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | null");
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingDisabled(AggregationFunctionType functionType, DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "1",
-            "null",
-            "2"
-        ).andOnSecondInstance("myField",
-            "3",
-            "6",
-            "null"
-        ).whenQuery("select " + functionType.getName() + "(myField) from testTable")
-        .thenResultIs("DOUBLE", String.valueOf(calculateVariance(List.of(1.0, 0.0, 2.0, 3.0, 6.0, 0.0),
-            functionType)));
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "1", "null", "2")
+        .andOnSecondInstance("myField", "3", "6", "null")
+        .whenQuery("select " + functionType.getName() + "(myField) from testTable")
+        .thenResultIs("DOUBLE", String.valueOf(calculateVariance(List.of(1.0, 0.0, 2.0, 3.0, 6.0, 0.0), functionType)));
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationWithNullHandlingEnabled(AggregationFunctionType functionType, DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "1",
-            "null",
-            "2"
-        ).andOnSecondInstance("myField",
-            "3",
-            "6",
-            "null"
-        ).whenQuery("select " + functionType.getName() + "(myField) from testTable")
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "1", "null", "2")
+        .andOnSecondInstance("myField", "3", "6", "null")
+        .whenQuery("select " + functionType.getName() + "(myField) from testTable")
         .thenResultIs("DOUBLE", String.valueOf(calculateVariance(List.of(1.0, 2.0, 3.0, 6.0), functionType)));
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingDisabled(AggregationFunctionType functionType, DataTypeScenario scenario) {
-    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "1",
-            "null",
-            "2"
-        ).andOnSecondInstance("myField",
-            "3",
-            "6",
-            "null"
-        ).whenQuery("select 'literal', " + functionType.getName() + "(myField) from testTable group by 'literal'")
-        .thenResultIs("STRING | DOUBLE", "literal | "
-            + calculateVariance(List.of(1.0, 0.0, 2.0, 3.0, 6.0, 0.0), functionType));
+    scenario.getDeclaringTable(false, FieldType.METRIC)
+        .onFirstInstance("myField", "1", "null", "2")
+        .andOnSecondInstance("myField", "3", "6", "null")
+        .whenQuery("select 'literal', " + functionType.getName() + "(myField) from testTable group by 'literal'")
+        .thenResultIs(
+            "STRING | DOUBLE",
+            "literal | " + calculateVariance(List.of(1.0, 0.0, 2.0, 3.0, 6.0, 0.0), functionType)
+        );
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupBySVWithNullHandlingEnabled(AggregationFunctionType functionType, DataTypeScenario scenario) {
-    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
-        .onFirstInstance("myField",
-            "1",
-            "null",
-            "2"
-        ).andOnSecondInstance("myField",
-            "3",
-            "6",
-            "null"
-        ).whenQuery("select 'literal', " + functionType.getName() + "(myField) from testTable group by 'literal'")
-        .thenResultIs("STRING | DOUBLE", "literal | "
-            + calculateVariance(List.of(1.0, 2.0, 3.0, 6.0), functionType));
+    scenario.getDeclaringTable(true, FieldType.METRIC)
+        .onFirstInstance("myField", "1", "null", "2")
+        .andOnSecondInstance("myField", "3", "6", "null")
+        .whenQuery("select 'literal', " + functionType.getName() + "(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | " + calculateVariance(List.of(1.0, 2.0, 3.0, 6.0), functionType));
   }
 
   @Test(dataProvider = "scenarios")
   void aggregationGroupByMV(AggregationFunctionType functionType, DataTypeScenario scenario) {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addMultiValueDimension("tags", DataType.STRING)
+        .addMetricField("value", scenario.getDataType())
+        .build();
     FluentQueryTest.withBaseDir(_baseDir)
-        .givenTable(
-            new Schema.SchemaBuilder()
-                .setSchemaName("testTable")
-                .setEnableColumnBasedNullHandling(true)
-                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
-                .addMetricField("value", scenario.getDataType())
-                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .givenTable(schema, SINGLE_FIELD_TABLE_CONFIG)
         .onFirstInstance(
             new Object[]{"tag1;tag2", 1},
             new Object[]{"tag1;tag2", null},
@@ -189,11 +161,15 @@ public class VarianceAggregationFunctionTest extends AbstractAggregationFunction
             new Object[]{"tag1;tag2", null}
         )
         .whenQuery("select tags, " + functionType.getName() + "(value) from testTable group by tags order by tags")
-        .thenResultIs(new Object[]{"tag1", calculateVariance(List.of(1.0, 0.0, 2.0, 3.0, 6.0, 0.0), functionType)},
-            new Object[]{"tag2", calculateVariance(List.of(1.0, 0.0, 2.0, 3.0, 6.0, 0.0), functionType)})
-        .whenQueryWithNullHandlingEnabled("select tags, " + functionType.getName() + "(value) from testTable "
-            + "group by tags order by tags")
-        .thenResultIs(new Object[]{"tag1", calculateVariance(List.of(1.0, 2.0, 3.0, 6.0), functionType)},
-            new Object[]{"tag2", calculateVariance(List.of(1.0, 2.0, 3.0, 6.0), functionType)});
+        .thenResultIs(
+            new Object[]{"tag1", calculateVariance(List.of(1.0, 0.0, 2.0, 3.0, 6.0, 0.0), functionType)},
+            new Object[]{"tag2", calculateVariance(List.of(1.0, 0.0, 2.0, 3.0, 6.0, 0.0), functionType)}
+        )
+        .whenQueryWithNullHandlingEnabled(
+            "select tags, " + functionType.getName() + "(value) from testTable group by tags order by tags")
+        .thenResultIs(
+            new Object[]{"tag1", calculateVariance(List.of(1.0, 2.0, 3.0, 6.0), functionType)},
+            new Object[]{"tag2", calculateVariance(List.of(1.0, 2.0, 3.0, 6.0), functionType)}
+        );
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelNullHandlingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelNullHandlingTest.java
@@ -49,7 +49,7 @@ import static org.testng.Assert.assertNull;
 /// Null handling for the window funnel functions.
 ///
 /// A funnel reads more than one column per row, so it never received the option through
-/// [org.apache.pinot.core.query.aggregation.function.NullableSingleInputAggregationFunction] and is invisible to
+/// [org.apache.pinot.core.query.aggregation.function.BaseSingleInputAggregationFunction] and is invisible to
 /// [org.apache.pinot.core.query.aggregation.function.AggregationFunctionNullContractTest], whose synthetic block
 /// supplies a single column.
 ///

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
@@ -45,7 +45,7 @@ import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
@@ -116,12 +116,12 @@ public class DictionaryBasedGroupKeyGeneratorTest {
 
     // Create an index segment with the random values
     Schema schema = new Schema();
-    schema.addField(new DimensionFieldSpec(FILTER_COLUMN, FieldSpec.DataType.INT, true));
+    schema.addField(new DimensionFieldSpec(FILTER_COLUMN, DataType.INT, true));
     for (String singleValueColumn : SV_COLUMNS) {
-      schema.addField(new DimensionFieldSpec(singleValueColumn, FieldSpec.DataType.INT, true));
+      schema.addField(new DimensionFieldSpec(singleValueColumn, DataType.INT, true));
     }
     for (String multiValueColumn : MV_COLUMNS) {
-      schema.addField(new DimensionFieldSpec(multiValueColumn, FieldSpec.DataType.INT, false));
+      schema.addField(new DimensionFieldSpec(multiValueColumn, DataType.INT, false));
     }
 
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("test").build();

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/GroupByTrimTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/GroupByTrimTest.java
@@ -43,7 +43,7 @@ import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -174,7 +174,7 @@ public class GroupByTrimTest {
 
     for (int i = 0; i < NUM_COLUMNS; i++) {
       String metricName = METRIC_PREFIX + i;
-      MetricFieldSpec metricFieldSpec = new MetricFieldSpec(metricName, FieldSpec.DataType.DOUBLE);
+      MetricFieldSpec metricFieldSpec = new MetricFieldSpec(metricName, DataType.DOUBLE);
       schema.addField(metricFieldSpec);
       _columns[i] = metricName;
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
@@ -45,7 +45,7 @@ import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.BytesUtils;
@@ -82,13 +82,13 @@ public class NoDictionaryGroupKeyGeneratorTest {
   private static final TableConfig TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
       .setNoDictionaryColumns(COLUMNS.subList(0, NUM_COLUMNS - 1)).build();
   private static final Schema SCHEMA =
-      new Schema.SchemaBuilder().addSingleValueDimension(INT_COLUMN, FieldSpec.DataType.INT)
-          .addSingleValueDimension(LONG_COLUMN, FieldSpec.DataType.LONG)
-          .addSingleValueDimension(FLOAT_COLUMN, FieldSpec.DataType.FLOAT)
-          .addSingleValueDimension(DOUBLE_COLUMN, FieldSpec.DataType.DOUBLE)
-          .addSingleValueDimension(STRING_COLUMN, FieldSpec.DataType.STRING)
-          .addSingleValueDimension(BYTES_COLUMN, FieldSpec.DataType.BYTES)
-          .addSingleValueDimension(BYTES_DICT_COLUMN, FieldSpec.DataType.BYTES).build();
+      new Schema.SchemaBuilder().addSingleValueDimension(INT_COLUMN, DataType.INT)
+          .addSingleValueDimension(LONG_COLUMN, DataType.LONG)
+          .addSingleValueDimension(FLOAT_COLUMN, DataType.FLOAT)
+          .addSingleValueDimension(DOUBLE_COLUMN, DataType.DOUBLE)
+          .addSingleValueDimension(STRING_COLUMN, DataType.STRING)
+          .addSingleValueDimension(BYTES_COLUMN, DataType.BYTES)
+          .addSingleValueDimension(BYTES_DICT_COLUMN, DataType.BYTES).build();
 
   private static final int NUM_RECORDS = 1000;
   private static final int NUM_UNIQUE_RECORDS = 100;


### PR DESCRIPTION
## Summary

Follow-up cleanup to the null-contract work in #19218, in two parts.

### Null-handling helpers

Now that every user-facing aggregation supports null handling, the option and the helpers for reading only non-null rows no longer belong to a mixin that only single-input functions could inherit.

**`NullSkippingUtils`** — the iteration helpers move out of `NullableSingleInputAggregationFunction` into a static utility, so code that is not an `AggregationFunction` at all can share them. The funnel aggregation strategies were carrying their own copy of the walk; they now call the utility.

**`BaseAggregationFunction`** — a new base holding `_nullHandlingEnabled` plus the convenience wrappers. `BaseSingleInputAggregationFunction` extends it, so its 48 subclasses are unaffected beyond the repoint. Multi-input functions (`COVAR_POP`/`COVAR_SAMP`, the window funnels, `TIMESERIESAGGREGATE` and the `EXPR_MIN`/`EXPR_MAX` parent) extend it directly and decide for themselves which column a `null` disqualifies the row on, since that follows from what each column is for — for a funnel the timestamp gates the row, while a step predicate over `NULL` is already UNKNOWN and an extra field is payload. That reasoning used to live on a private helper in each funnel class and is now class-level Javadoc.

`NullableSingleInputAggregationFunction` is deleted.

**`RoaringBitmapUtils.foldUnset`** joins `forEachUnset`, and the `Reducer` interface moves next to it. The two walks are written out separately on purpose: routing either through the other would allocate an adapter lambda or a mutable box on every call, and both sit on the aggregation path. The Javadoc on each points at the other.

**Empty ranges** — the helpers already guaranteed that a consumer never receives `from == to`, but 24 `if (to == from) { return; }` guards across 8 functions were defending against it anyway. Those are gone, and the invariant is now stated where it is enforced rather than re-checked at each call site.

### Absorbing the two functions #19357 conformed

`TimeSeriesAggregationFunction` and `ParentExprMinMaxAggregationFunction` each grew their own `_nullHandlingEnabled` field and a private null-range helper in #19357, because the shared base did not exist yet. Both now extend `BaseAggregationFunction` and drop those: the time-series one uses the inherited two-column `forEachNotNull`, and the exprmin/exprmax one keeps only its measuring-column bitmap union and hands it to `NullSkippingUtils`. `ParentAggregationFunction` takes the option through its constructor to make that possible.

### Aggregation function tests

Mechanical cleanup across 48 test classes:

- Import `FieldSpec.DataType` and `FieldSpec.FieldType` directly instead of qualifying every use.
- At `FluentQueryTest.givenTable()` call sites, bind the schema to a local rather than inlining the whole builder in the argument list.
- Flatten the fluent chains so each step starts a line, and drop the stray space in `new Object[] {`.

`FirstWithTimeAggregationFunctionTest` and `LastWithTimeAggregationFunctionTest` additionally move their multi-line queries to text blocks with `.formatted(...)`. Java text blocks do not interpolate, so the data type is passed as `%s` rather than concatenated; the generated SQL is character-for-character what the concatenated form produced.

### Behaviour

No functional change: no aggregation answer moves in either null-handling mode. One mechanism did shift and is worth a reviewer's eye — the zero-length block. `forEachNotNull` previously invoked `consume(0, 0)` when null handling was off or the block had no null bitmap, so a function creating its accumulator inside the callback would build an empty one; it now skips, leaving the holder untouched. Every affected function either substitutes the empty accumulator in `extractAggregationResult` or accepts `@Nullable` in `extractFinalResult` and returns the same identity, and `AggregationFunctionUtils.merge` is null-tolerant on both sides, so the result is unchanged. The only caller that can pass a zero length is `MultistageAggregationExecutor` for a filtered aggregation that matched no row, and MSE always enables null handling; the single-stage path cannot, because `DocIdSetOperator` returns `null` rather than a zero-doc block. That dependency is now recorded at the guard.
