### PR TITLE
Default Kafka consumer auto.offset.reset to earliest to avoid data loss on expired offsets

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandler.java
@@ -41,6 +41,7 @@ import org.apache.pinot.plugin.stream.kafka.KafkaAdminClientManager;
 import org.apache.pinot.plugin.stream.kafka.KafkaConfigUtils;
 import org.apache.pinot.plugin.stream.kafka.KafkaPartitionLevelStreamConfig;
 import org.apache.pinot.plugin.stream.kafka.KafkaSSLUtils;
+import org.apache.pinot.plugin.stream.kafka.KafkaStreamConfigProperties;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
 import org.apache.pinot.spi.utils.retry.RetriableOperationException;
@@ -89,6 +90,8 @@ public abstract class KafkaPartitionLevelConnectionHandler {
   private Properties buildProperties(StreamConfig streamConfig) {
     Properties consumerProp = new Properties();
     consumerProp.putAll(streamConfig.getStreamConfigsMap());
+    consumerProp.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+        KafkaStreamConfigProperties.AUTO_OFFSET_RESET_DEFAULT);
     consumerProp.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, _config.getBootstrapHosts());
     consumerProp.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
     consumerProp.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumerTest.java
@@ -493,6 +493,10 @@ public class KafkaPartitionLevelConsumerTest {
     return KafkaConsumerFactory.class.getName();
   }
 
+  /// The start offset can expire while the table is behind, i.e. Kafka retention deletes records that have not been
+  /// consumed yet. Consumption must then resume from the earliest retained offset -- skipping only the deleted
+  /// records -- and report data loss. This has to hold without the table config setting the Kafka
+  /// `auto.offset.reset` property, whose own default (`latest`) would skip to the end of the log instead.
   @Test
   public void testOffsetsExpired()
       throws TimeoutException {
@@ -502,7 +506,9 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.broker.list", _kafkaBrokerAddress);
     streamConfigMap.put("stream.kafka.consumer.factory.class.name", getKafkaConsumerFactoryName());
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
-    streamConfigMap.put("auto.offset.reset", "earliest");
+    // Pinot's initial-offset criteria, as an operator would set it. Its vocabulary is not Kafka's, so it must not
+    // reach the client as the out-of-range reset policy.
+    streamConfigMap.put("stream.kafka.consumer.prop.auto.offset.reset", "smallest");
     StreamConfig streamConfig = new StreamConfig("tableName_REALTIME", streamConfigMap);
 
     StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
@@ -518,6 +524,7 @@ public class KafkaPartitionLevelConsumerTest {
       assertEquals(new String((byte[]) messageBatch.getStreamMessage(i).getValue()), "sample_msg_" + (200 + i));
     }
     assertEquals(messageBatch.getOffsetOfNextBatch().toString(), "700");
+    assertTrue(messageBatch.hasDataLoss(), "Records at the requested start offset were deleted by retention");
   }
 
   @Test

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/main/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/main/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConnectionHandler.java
@@ -41,6 +41,7 @@ import org.apache.pinot.plugin.stream.kafka.KafkaAdminClientManager;
 import org.apache.pinot.plugin.stream.kafka.KafkaConfigUtils;
 import org.apache.pinot.plugin.stream.kafka.KafkaPartitionLevelStreamConfig;
 import org.apache.pinot.plugin.stream.kafka.KafkaSSLUtils;
+import org.apache.pinot.plugin.stream.kafka.KafkaStreamConfigProperties;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
 import org.apache.pinot.spi.utils.retry.RetriableOperationException;
@@ -89,6 +90,8 @@ public abstract class KafkaPartitionLevelConnectionHandler {
   private Properties buildProperties(StreamConfig streamConfig) {
     Properties consumerProp = new Properties();
     consumerProp.putAll(streamConfig.getStreamConfigsMap());
+    consumerProp.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+        KafkaStreamConfigProperties.AUTO_OFFSET_RESET_DEFAULT);
     consumerProp.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, _config.getBootstrapHosts());
     consumerProp.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
     consumerProp.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/test/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/test/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConsumerTest.java
@@ -497,6 +497,10 @@ public class KafkaPartitionLevelConsumerTest {
     return KafkaConsumerFactory.class.getName();
   }
 
+  /// The start offset can expire while the table is behind, i.e. Kafka retention deletes records that have not been
+  /// consumed yet. Consumption must then resume from the earliest retained offset -- skipping only the deleted
+  /// records -- and report data loss. This has to hold without the table config setting the Kafka
+  /// `auto.offset.reset` property, whose own default (`latest`) would skip to the end of the log instead.
   @Test
   public void testOffsetsExpired()
       throws TimeoutException {
@@ -506,7 +510,9 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.broker.list", _kafkaBrokerAddress);
     streamConfigMap.put("stream.kafka.consumer.factory.class.name", getKafkaConsumerFactoryName());
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
-    streamConfigMap.put("auto.offset.reset", "earliest");
+    // Pinot's initial-offset criteria, as an operator would set it. Its vocabulary is not Kafka's, so it must not
+    // reach the client as the out-of-range reset policy.
+    streamConfigMap.put("stream.kafka.consumer.prop.auto.offset.reset", "smallest");
     StreamConfig streamConfig = new StreamConfig("tableName_REALTIME", streamConfigMap);
 
     StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
@@ -522,6 +528,7 @@ public class KafkaPartitionLevelConsumerTest {
       assertEquals(new String((byte[]) messageBatch.getStreamMessage(i).getValue()), "sample_msg_" + (200 + i));
     }
     assertEquals(messageBatch.getOffsetOfNextBatch().toString(), "700");
+    assertTrue(messageBatch.hasDataLoss(), "Records at the requested start offset were deleted by retention");
   }
 
   @Test

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaStreamConfigProperties.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaStreamConfigProperties.java
@@ -53,6 +53,19 @@ public class KafkaStreamConfigProperties {
 
   public static final String KAFKA_CONSUMER_PROP_PREFIX = "kafka.consumer.prop";
 
+  /// Default value of the Kafka client property `auto.offset.reset`
+  ///
+  /// Pinot always seeks the consumer to an explicit start offset before polling, so this policy takes effect only
+  /// when that offset is no longer in kafka. `earliest` then resumes from the oldest retained record, so
+  /// only the records the broker actually deleted are skipped. Kafka's own default (`latest`) would instead jump to
+  /// the end of the partition log and drop every retained record in between.
+  ///
+  /// This is deliberately independent of the table's initial-offset criteria
+  /// (`stream.<streamType>.consumer.prop.auto.offset.reset`), which only decides where a partition with no prior
+  /// offset starts consuming. To override, set the raw Kafka property `auto.offset.reset` in `streamConfigs`;
+  /// accepted values are Kafka's own (`earliest`, `latest`, `none`).
+  public static final String AUTO_OFFSET_RESET_DEFAULT = "earliest";
+
   /// Optional comma-separated list of Kafka partition IDs or inclusive ranges to consume
   /// (e.g. "0,2,5" or "0-399" or "0-99,200,300-399").
   /// When set, only these partitions are used for the table; when absent, all topic partitions are consumed.


### PR DESCRIPTION
### Problem

The Kafka clients created for realtime ingestion never receive an `auto.offset.reset` value, so they fall back to Kafka's default of `latest`. 

When kafka retention deletes records a consuming segment has not read yet, the client silently repositions to the **end** of the log, dropping every record still retained between the expired offset and the log end. A table catching up on a backlog can lose an arbitrary amount of retained data this way, and the further behind it is, the more it loses.

Setting `stream.kafka.consumer.prop.auto.offset.reset` does not prevent this. Despite its name, that key is parsed into the table's initial-offset criteria (`OffsetCriteria`) and never reaches the Kafka client; its accepted values (`smallest` / `largest`) are not valid Kafka values either.

### Fix

Default the Kafka client property to `earliest`, so an expired start offset resumes from the oldest retained record and only the records the broker actually deleted are skipped. The resulting gap is still surfaced by the existing `StreamDataLoss` detection.

Setting the raw `auto.offset.reset` property in `streamConfigs` continues to take precedence, and the initial-offset criteria is unaffected — it still decides only where a partition with no prior offset starts consuming.

### Testing

`KafkaPartitionLevelConsumerTest#testOffsetsExpired` pinned `auto.offset.reset=earliest` directly in the stream config, which masked the bug. It now uses the configuration an operator would actually write: on master it returns 0 records where 500 are expected, and it passes with this change. It also asserts that the skipped records are reported as data loss.

Applied to both `pinot-kafka-3.0` and `pinot-kafka-4.0`.

---

