### PR TITLE
Include segment names to needReload API

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ServerSegmentsReloadCheckResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ServerSegmentsReloadCheckResponse.java
@@ -20,12 +20,14 @@ package org.apache.pinot.common.restlet.resources;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.Nullable;
 
 
-/// This class gives the data of a server if there exists any segments that need to be reloaded
-///
-/// It has details of server id and returns true/false if there are any segments to be reloaded or not.
+/// Server response for /segments/needReload. `segmentsNeedingReload` is populated only when the
+/// endpoint is invoked with `verbose=true`.
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ServerSegmentsReloadCheckResponse {
   @JsonProperty("needReload")
@@ -33,6 +35,11 @@ public class ServerSegmentsReloadCheckResponse {
 
   @JsonProperty("instanceId")
   private final String _instanceId;
+
+  @Nullable
+  @JsonProperty("segmentsNeedingReload")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final List<String> _segmentsNeedingReload;
 
   public boolean isNeedReload() {
     return _needReload;
@@ -42,10 +49,21 @@ public class ServerSegmentsReloadCheckResponse {
     return _instanceId;
   }
 
+  @Nullable
+  public List<String> getSegmentsNeedingReload() {
+    return _segmentsNeedingReload;
+  }
+
   @JsonCreator
   public ServerSegmentsReloadCheckResponse(@JsonProperty("needReload") boolean needReload,
-      @JsonProperty("instanceId") String instanceId) {
+      @JsonProperty("instanceId") String instanceId,
+      @JsonProperty("segmentsNeedingReload") @Nullable List<String> segmentsNeedingReload) {
     _needReload = needReload;
     _instanceId = instanceId;
+    _segmentsNeedingReload = segmentsNeedingReload;
+  }
+
+  public ServerSegmentsReloadCheckResponse(boolean needReload, String instanceId) {
+    this(needReload, instanceId, null);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableReloadResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableReloadResource.java
@@ -178,7 +178,10 @@ public class PinotTableReloadResource {
       @ApiParam(value = "Table name with type suffix", required = true, example = "myTable_REALTIME")
       @PathParam("tableNameWithType") String tableNameWithType,
       @ApiParam(value = "Include detailed server responses", defaultValue = "false") @QueryParam("verbose")
-      @DefaultValue("false") boolean verbose, @Context HttpHeaders headers) {
-    return _service.needReload(tableNameWithType, verbose, headers);
+      @DefaultValue("false") boolean verbose,
+      @ApiParam(value = "Include names of segments that need reload; forces servers to walk all segments",
+          defaultValue = "false") @QueryParam("includeSegmentNames") @DefaultValue("false") boolean includeSegmentNames,
+      @Context HttpHeaders headers) {
+    return _service.needReload(tableNameWithType, verbose, includeSegmentNames, headers);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/services/PinotTableReloadService.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/services/PinotTableReloadService.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Strings;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -300,28 +301,34 @@ public class PinotTableReloadService {
 
   public String needReload(String tableNameWithType, boolean verbose, HttpHeaders headers) {
     tableNameWithType = DatabaseUtils.translateTableName(tableNameWithType, headers);
-    LOG.info("Received a request to check reload for all servers hosting segments for table {}", tableNameWithType);
+    LOG.info("Received a request to check reload for all servers hosting segments for table {} (verbose={})",
+        tableNameWithType, verbose);
     try {
       TableMetadataReader tableMetadataReader =
           new TableMetadataReader(_executor, _connectionManager, _pinotHelixResourceManager);
       Map<String, JsonNode> needReloadMetadata =
           tableMetadataReader.getServerCheckSegmentsReloadMetadata(tableNameWithType,
-              _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000).getServerReloadJsonResponses();
+              _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000, verbose).getServerReloadJsonResponses();
       boolean needReload =
           needReloadMetadata.values().stream().anyMatch(value -> value.get("needReload").booleanValue());
       Map<String, ServerSegmentsReloadCheckResponse> serverResponses = new HashMap<>();
-      TableSegmentsReloadCheckResponse tableNeedReloadResponse;
       if (verbose) {
         for (Map.Entry<String, JsonNode> entry : needReloadMetadata.entrySet()) {
+          JsonNode body = entry.getValue();
+          JsonNode names = body.get("segmentsNeedingReload");
+          List<String> segmentsNeedingReload = null;
+          if (names != null && names.isArray()) {
+            segmentsNeedingReload = new ArrayList<>(names.size());
+            for (JsonNode name : names) {
+              segmentsNeedingReload.add(name.asText());
+            }
+          }
           serverResponses.put(entry.getKey(),
-              new ServerSegmentsReloadCheckResponse(entry.getValue().get("needReload").booleanValue(),
-                  entry.getValue().get("instanceId").asText()));
+              new ServerSegmentsReloadCheckResponse(body.get("needReload").booleanValue(),
+                  body.get("instanceId").asText(), segmentsNeedingReload));
         }
-        tableNeedReloadResponse = new TableSegmentsReloadCheckResponse(needReload, serverResponses);
-      } else {
-        tableNeedReloadResponse = new TableSegmentsReloadCheckResponse(needReload, serverResponses);
       }
-      return JsonUtils.objectToPrettyString(tableNeedReloadResponse);
+      return JsonUtils.objectToPrettyString(new TableSegmentsReloadCheckResponse(needReload, serverResponses));
     } catch (InvalidConfigException e) {
       throw new ControllerApplicationException(LOG, e.getMessage(), Response.Status.BAD_REQUEST);
     } catch (IOException ioe) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/services/PinotTableReloadService.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/services/PinotTableReloadService.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Strings;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -314,18 +313,8 @@ public class PinotTableReloadService {
       Map<String, ServerSegmentsReloadCheckResponse> serverResponses = new HashMap<>();
       if (verbose) {
         for (Map.Entry<String, JsonNode> entry : needReloadMetadata.entrySet()) {
-          JsonNode body = entry.getValue();
-          JsonNode names = body.get("segmentsNeedingReload");
-          List<String> segmentsNeedingReload = null;
-          if (names != null && names.isArray()) {
-            segmentsNeedingReload = new ArrayList<>(names.size());
-            for (JsonNode name : names) {
-              segmentsNeedingReload.add(name.asText());
-            }
-          }
           serverResponses.put(entry.getKey(),
-              new ServerSegmentsReloadCheckResponse(body.get("needReload").booleanValue(),
-                  body.get("instanceId").asText(), segmentsNeedingReload));
+              JsonUtils.jsonNodeToObject(entry.getValue(), ServerSegmentsReloadCheckResponse.class));
         }
       }
       return JsonUtils.objectToPrettyString(new TableSegmentsReloadCheckResponse(needReload, serverResponses));

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/services/PinotTableReloadService.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/services/PinotTableReloadService.java
@@ -299,19 +299,27 @@ public class PinotTableReloadService {
 
 
   public String needReload(String tableNameWithType, boolean verbose, HttpHeaders headers) {
+    return needReload(tableNameWithType, verbose, false, headers);
+  }
+
+  public String needReload(String tableNameWithType, boolean verbose, boolean includeSegmentNames,
+      HttpHeaders headers) {
     tableNameWithType = DatabaseUtils.translateTableName(tableNameWithType, headers);
-    LOG.info("Received a request to check reload for all servers hosting segments for table {} (verbose={})",
-        tableNameWithType, verbose);
+    LOG.info("Received a request to check reload for all servers hosting segments for table {} "
+        + "(verbose={}, includeSegmentNames={})", tableNameWithType, verbose, includeSegmentNames);
     try {
       TableMetadataReader tableMetadataReader =
           new TableMetadataReader(_executor, _connectionManager, _pinotHelixResourceManager);
       Map<String, JsonNode> needReloadMetadata =
           tableMetadataReader.getServerCheckSegmentsReloadMetadata(tableNameWithType,
-              _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000, verbose).getServerReloadJsonResponses();
+              _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000, includeSegmentNames)
+              .getServerReloadJsonResponses();
       boolean needReload =
           needReloadMetadata.values().stream().anyMatch(value -> value.get("needReload").booleanValue());
       Map<String, ServerSegmentsReloadCheckResponse> serverResponses = new HashMap<>();
-      if (verbose) {
+      // Populate per-server responses when either flag asks for detail. includeSegmentNames implies
+      // per-server data since names are only meaningful when grouped by server.
+      if (verbose || includeSegmentNames) {
         for (Map.Entry<String, JsonNode> entry : needReloadMetadata.entrySet()) {
           serverResponses.put(entry.getKey(),
               JsonUtils.jsonNodeToObject(entry.getValue(), ServerSegmentsReloadCheckResponse.class));

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -244,16 +244,20 @@ public class ServerSegmentMetadataReader {
     return segmentsMetadata;
   }
 
-  /// This method is called when the API request is to fetch data about segment reload of the table.
-  /// This method makes a MultiGet call to all servers that host their respective segments and gets the results.
-  /// This method will return metadata of all the servers along with need reload flag.
-  /// In future additional details like segments list can also be added
   public TableReloadResponse getCheckReloadSegmentsFromServer(String tableNameWithType,
       Set<String> serverInstances, BiMap<String, String> endpoints, int timeoutMs) {
-    LOGGER.debug("Checking if reload is needed on segments from servers for table {}.", tableNameWithType);
+    return getCheckReloadSegmentsFromServer(tableNameWithType, serverInstances, endpoints, timeoutMs, false);
+  }
+
+  /// When {@code verbose} is true, each server response also names the segments needing reload.
+  public TableReloadResponse getCheckReloadSegmentsFromServer(String tableNameWithType,
+      Set<String> serverInstances, BiMap<String, String> endpoints, int timeoutMs, boolean verbose) {
+    LOGGER.debug("Checking if reload is needed on segments from servers for table {} (verbose={}).",
+        tableNameWithType, verbose);
     List<String> serverURLs = new ArrayList<>();
     for (String serverInstance : serverInstances) {
-      serverURLs.add(generateCheckReloadSegmentsServerURL(tableNameWithType, endpoints.get(serverInstance)));
+      String url = generateCheckReloadSegmentsServerURL(tableNameWithType, endpoints.get(serverInstance));
+      serverURLs.add(verbose ? url + "?verbose=true" : url);
     }
     BiMap<String, String> endpointsToServers = endpoints.inverse();
     CompletionServiceHelper completionServiceHelper =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -249,15 +249,16 @@ public class ServerSegmentMetadataReader {
     return getCheckReloadSegmentsFromServer(tableNameWithType, serverInstances, endpoints, timeoutMs, false);
   }
 
-  /// When {@code verbose} is true, each server response also names the segments needing reload.
+  /// When {@code includeSegmentNames} is true, each server response also names the segments needing
+  /// reload (server walks all segments instead of short-circuiting).
   public TableReloadResponse getCheckReloadSegmentsFromServer(String tableNameWithType,
-      Set<String> serverInstances, BiMap<String, String> endpoints, int timeoutMs, boolean verbose) {
-    LOGGER.debug("Checking if reload is needed on segments from servers for table {} (verbose={}).",
-        tableNameWithType, verbose);
+      Set<String> serverInstances, BiMap<String, String> endpoints, int timeoutMs, boolean includeSegmentNames) {
+    LOGGER.debug("Checking if reload is needed on segments from servers for table {} (includeSegmentNames={}).",
+        tableNameWithType, includeSegmentNames);
     List<String> serverURLs = new ArrayList<>();
     for (String serverInstance : serverInstances) {
       String url = generateCheckReloadSegmentsServerURL(tableNameWithType, endpoints.get(serverInstance));
-      serverURLs.add(verbose ? url + "?verbose=true" : url);
+      serverURLs.add(includeSegmentNames ? url + "?includeSegmentNames=true" : url);
     }
     BiMap<String, String> endpointsToServers = endpoints.inverse();
     CompletionServiceHelper completionServiceHelper =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -70,8 +70,15 @@ public class TableMetadataReader {
   public TableReloadJsonResponse getServerCheckSegmentsReloadMetadata(String tableNameWithType,
       int timeoutMs)
       throws InvalidConfigException, IOException {
+    return getServerCheckSegmentsReloadMetadata(tableNameWithType, timeoutMs, false);
+  }
+
+  /// Verbose overload: each server response also lists the segments on it that require reload.
+  public TableReloadJsonResponse getServerCheckSegmentsReloadMetadata(String tableNameWithType,
+      int timeoutMs, boolean verbose)
+      throws InvalidConfigException, IOException {
     ServerSegmentMetadataReader.TableReloadResponse segmentsMetadataResponse = getReloadCheckResponses(
-        tableNameWithType, timeoutMs);
+        tableNameWithType, timeoutMs, verbose);
     return processSegmentMetadataReloadResponse(segmentsMetadataResponse);
   }
 
@@ -80,12 +87,17 @@ public class TableMetadataReader {
   /// needReload throws an exception for servers that don't contain segments for the given table
   public ServerSegmentMetadataReader.TableReloadResponse getReloadCheckResponses(String tableNameWithType,
       int timeoutMs) throws InvalidConfigException {
+    return getReloadCheckResponses(tableNameWithType, timeoutMs, false);
+  }
+
+  public ServerSegmentMetadataReader.TableReloadResponse getReloadCheckResponses(String tableNameWithType,
+      int timeoutMs, boolean verbose) throws InvalidConfigException {
     ExternalView externalView = _pinotHelixResourceManager.getTableExternalView(tableNameWithType);
     Set<String> serverInstanceSet = new HashSet<>();
     if (externalView != null) {
       serverInstanceSet = getCurrentlyAssignedServersFromExternalView(externalView);
     }
-    return getServerSetReloadCheckResponses(tableNameWithType, timeoutMs, serverInstanceSet);
+    return getServerSetReloadCheckResponses(tableNameWithType, timeoutMs, serverInstanceSet, verbose);
   }
 
   private Set<String> getCurrentlyAssignedServersFromExternalView(ExternalView externalView) {
@@ -106,12 +118,17 @@ public class TableMetadataReader {
 
   public ServerSegmentMetadataReader.TableReloadResponse getServerSetReloadCheckResponses(String tableNameWithType,
       int timeoutMs, Set<String> serverInstanceSet) throws InvalidConfigException {
+    return getServerSetReloadCheckResponses(tableNameWithType, timeoutMs, serverInstanceSet, false);
+  }
+
+  public ServerSegmentMetadataReader.TableReloadResponse getServerSetReloadCheckResponses(String tableNameWithType,
+      int timeoutMs, Set<String> serverInstanceSet, boolean verbose) throws InvalidConfigException {
     BiMap<String, String> endpoints = _pinotHelixResourceManager.getDataInstanceAdminEndpoints(serverInstanceSet);
     ServerSegmentMetadataReader serverSegmentMetadataReader =
         new ServerSegmentMetadataReader(_executor, _connectionManager,
             _pinotHelixResourceManager.getServerAdminAuthProvider());
     return serverSegmentMetadataReader.getCheckReloadSegmentsFromServer(tableNameWithType, serverInstanceSet, endpoints,
-        timeoutMs);
+        timeoutMs, verbose);
   }
 
   private TableReloadJsonResponse processSegmentMetadataReloadResponse(

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -73,12 +73,13 @@ public class TableMetadataReader {
     return getServerCheckSegmentsReloadMetadata(tableNameWithType, timeoutMs, false);
   }
 
-  /// Verbose overload: each server response also lists the segments on it that require reload.
+  /// When {@code includeSegmentNames} is true, each server response also lists the segments on it
+  /// that require reload (server walks all segments instead of short-circuiting).
   public TableReloadJsonResponse getServerCheckSegmentsReloadMetadata(String tableNameWithType,
-      int timeoutMs, boolean verbose)
+      int timeoutMs, boolean includeSegmentNames)
       throws InvalidConfigException, IOException {
     ServerSegmentMetadataReader.TableReloadResponse segmentsMetadataResponse = getReloadCheckResponses(
-        tableNameWithType, timeoutMs, verbose);
+        tableNameWithType, timeoutMs, includeSegmentNames);
     return processSegmentMetadataReloadResponse(segmentsMetadataResponse);
   }
 
@@ -91,13 +92,13 @@ public class TableMetadataReader {
   }
 
   public ServerSegmentMetadataReader.TableReloadResponse getReloadCheckResponses(String tableNameWithType,
-      int timeoutMs, boolean verbose) throws InvalidConfigException {
+      int timeoutMs, boolean includeSegmentNames) throws InvalidConfigException {
     ExternalView externalView = _pinotHelixResourceManager.getTableExternalView(tableNameWithType);
     Set<String> serverInstanceSet = new HashSet<>();
     if (externalView != null) {
       serverInstanceSet = getCurrentlyAssignedServersFromExternalView(externalView);
     }
-    return getServerSetReloadCheckResponses(tableNameWithType, timeoutMs, serverInstanceSet, verbose);
+    return getServerSetReloadCheckResponses(tableNameWithType, timeoutMs, serverInstanceSet, includeSegmentNames);
   }
 
   private Set<String> getCurrentlyAssignedServersFromExternalView(ExternalView externalView) {
@@ -122,13 +123,13 @@ public class TableMetadataReader {
   }
 
   public ServerSegmentMetadataReader.TableReloadResponse getServerSetReloadCheckResponses(String tableNameWithType,
-      int timeoutMs, Set<String> serverInstanceSet, boolean verbose) throws InvalidConfigException {
+      int timeoutMs, Set<String> serverInstanceSet, boolean includeSegmentNames) throws InvalidConfigException {
     BiMap<String, String> endpoints = _pinotHelixResourceManager.getDataInstanceAdminEndpoints(serverInstanceSet);
     ServerSegmentMetadataReader serverSegmentMetadataReader =
         new ServerSegmentMetadataReader(_executor, _connectionManager,
             _pinotHelixResourceManager.getServerAdminAuthProvider());
     return serverSegmentMetadataReader.getCheckReloadSegmentsFromServer(tableNameWithType, serverInstanceSet, endpoints,
-        timeoutMs, verbose);
+        timeoutMs, includeSegmentNames);
   }
 
   private TableReloadJsonResponse processSegmentMetadataReloadResponse(

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -1659,9 +1659,21 @@ public abstract class BaseTableDataManager implements TableDataManager {
   @Override
   public boolean needReloadSegments()
       throws Exception {
+    return !findSegmentsNeedingReload(true).isEmpty();
+  }
+
+  @Override
+  public List<String> getSegmentNamesNeedingReload()
+      throws Exception {
+    return findSegmentsNeedingReload(false);
+  }
+
+  /// When {@code shortCircuit} is true, stops after the first match — same cost as the boolean check.
+  private List<String> findSegmentsNeedingReload(boolean shortCircuit)
+      throws Exception {
     IndexLoadingConfig indexLoadingConfig = fetchIndexLoadingConfig();
     List<SegmentDataManager> segmentDataManagers = acquireAllSegments();
-    boolean needReload = false;
+    List<String> segmentsNeedingReload = new ArrayList<>();
     try {
       for (SegmentDataManager segmentDataManager : segmentDataManagers) {
         IndexSegment segment = segmentDataManager.getSegment();
@@ -1669,8 +1681,10 @@ public abstract class BaseTableDataManager implements TableDataManager {
           ImmutableSegmentImpl immutableSegment = (ImmutableSegmentImpl) segment;
           indexLoadingConfig.setSegmentTier(immutableSegment.getTier());
           if (immutableSegment.isReloadNeeded(indexLoadingConfig)) {
-            needReload = true;
-            break;
+            segmentsNeedingReload.add(immutableSegment.getSegmentName());
+            if (shortCircuit) {
+              break;
+            }
           }
         }
       }
@@ -1679,7 +1693,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
         releaseSegment(segmentDataManager);
       }
     }
-    return needReload;
+    return segmentsNeedingReload;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -133,6 +133,12 @@ public interface TableDataManager {
   boolean needReloadSegments()
       throws Exception;
 
+  /// Non-short-circuiting variant of [#needReloadSegments] that names every segment needing reload.
+  default List<String> getSegmentNamesNeedingReload()
+      throws Exception {
+    return List.of();
+  }
+
   /// Downloads a segment and loads it into the table.
   /// NOTE: This method is part of the implementation detail of [#addOnlineSegment(String)].
   void downloadAndLoadSegment(SegmentZKMetadata zkMetadata, IndexLoadingConfig indexLoadingConfig)

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -1221,24 +1221,32 @@ public class TablesResource {
   @Path("/tables/{tableName}/segments/needReload")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Checks if reload is needed on any segment", notes = "Returns true if reload is required on"
-      + " any segment in this server")
+      + " any segment in this server. When verbose=true, also lists the segments that need reload.")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success", response = TableSegments.class), @ApiResponse(code = 500,
       message = "Internal Server error", response = ErrorInfo.class)
   })
   public String checkSegmentsReload(
       @ApiParam(value = "Table Name with type", required = true) @PathParam("tableName") String tableName,
+      @ApiParam(value = "Include names of segments that need reload in the response")
+      @QueryParam("verbose") @DefaultValue("false") boolean verbose,
       @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     TableDataManager tableDataManager = ServerResourceUtils.checkGetTableDataManager(_serverInstance, tableName);
-    boolean needReload = false;
+    ServerSegmentsReloadCheckResponse response;
     try {
-      needReload = tableDataManager.needReloadSegments();
+      if (verbose) {
+        List<String> segmentsNeedingReload = tableDataManager.getSegmentNamesNeedingReload();
+        response = new ServerSegmentsReloadCheckResponse(!segmentsNeedingReload.isEmpty(),
+            tableDataManager.getInstanceId(), segmentsNeedingReload);
+      } else {
+        response = new ServerSegmentsReloadCheckResponse(tableDataManager.needReloadSegments(),
+            tableDataManager.getInstanceId());
+      }
     } catch (Exception e) {
       throw new WebApplicationException(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
     }
-    return ResourceUtils.convertToJsonString(
-        new ServerSegmentsReloadCheckResponse(needReload, tableDataManager.getInstanceId()));
+    return ResourceUtils.convertToJsonString(response);
   }
 
   @GET

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -1221,7 +1221,7 @@ public class TablesResource {
   @Path("/tables/{tableName}/segments/needReload")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Checks if reload is needed on any segment", notes = "Returns true if reload is required on"
-      + " any segment in this server. When verbose=true, also lists the segments that need reload.")
+      + " any segment in this server. When includeSegmentNames=true, also lists the segments that need reload.")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success", response = TableSegments.class), @ApiResponse(code = 500,
       message = "Internal Server error", response = ErrorInfo.class)
@@ -1229,13 +1229,13 @@ public class TablesResource {
   public String checkSegmentsReload(
       @ApiParam(value = "Table Name with type", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "Include names of segments that need reload in the response")
-      @QueryParam("verbose") @DefaultValue("false") boolean verbose,
+      @QueryParam("includeSegmentNames") @DefaultValue("false") boolean includeSegmentNames,
       @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     TableDataManager tableDataManager = ServerResourceUtils.checkGetTableDataManager(_serverInstance, tableName);
     ServerSegmentsReloadCheckResponse response;
     try {
-      if (verbose) {
+      if (includeSegmentNames) {
         List<String> segmentsNeedingReload = tableDataManager.getSegmentNamesNeedingReload();
         response = new ServerSegmentsReloadCheckResponse(!segmentsNeedingReload.isEmpty(),
             tableDataManager.getInstanceId(), segmentsNeedingReload);


### PR DESCRIPTION
## Summary

Adds `?verbose=true` to `GET /tables/{tableName}/segments/needReload`. When set, each server response also lists the segments that need reload; the boolean short-circuited path is unchanged and remains the default.

- `ServerSegmentsReloadCheckResponse` gains a nullable `segmentsNeedingReload` (`@JsonInclude(NON_NULL)`, backward-compatible 2-arg ctor preserved).
- `TableDataManager` gets a default `getSegmentNamesNeedingReload()`; `BaseTableDataManager` consolidates both entry points into a shared `findSegmentsNeedingReload(boolean shortCircuit)` helper so the boolean path keeps its early-exit cost.
- `TablesResource` reads the query param and dispatches; `ServerSegmentMetadataReader`, `TableMetadataReader`, and `PinotTableReloadService` thread `verbose` down the call chain.

Existing callers that don't pass the verbose flag see no behavior change.