### PR TITLE
Fix shared Random and low repeat ratio in BenchmarkIndexedTable

### DIFF
--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
@@ -21,7 +21,6 @@ package org.apache.pinot.perf;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -29,6 +28,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -58,8 +58,7 @@ import org.openjdk.jmh.runner.options.TimeValue;
 public class BenchmarkIndexedTable {
   private static final int TRIM_SIZE = 800;
   private static final int TRIM_THRESHOLD = TRIM_SIZE * 4;
-  private static final int NUM_RECORDS = 1000;
-  private static final Random RANDOM = new Random();
+  private static final int NUM_RECORDS = 100_000;
 
   private QueryContext _queryContext;
   private DataSchema _dataSchema;
@@ -102,9 +101,10 @@ public class BenchmarkIndexedTable {
   }
 
   private Record getNewRecord() {
+    ThreadLocalRandom random = ThreadLocalRandom.current();
     Object[] columns = new Object[]{
-        _d1.get(RANDOM.nextInt(_d1.size())), _d2.get(RANDOM.nextInt(_d2.size())), (double) RANDOM.nextInt(1000),
-        (double) RANDOM.nextInt(1000)
+        _d1.get(random.nextInt(_d1.size())), _d2.get(random.nextInt(_d2.size())), (double) random.nextInt(1000),
+        (double) random.nextInt(1000)
     };
     return new Record(columns);
   }


### PR DESCRIPTION
## Summary

While investigating #10498 (part of the GROUP BY optimization tracking issue #11924), found two issues in `BenchmarkIndexedTable` that made the benchmark's results misleading:

- `getNewRecord()` used a single `java.util.Random` field shared across all 10 worker threads. `Random` updates an internal seed via CAS, so under concurrent access this itself becomes a contention point unrelated to the `IndexedTable` implementations being benchmarked. In a JFR profile, `Random.next(int)` accounted for over half of all CPU samples, dwarfing the actual table operations. Switched to `ThreadLocalRandom`.
- `NUM_RECORDS` (1000) was close to the key cardinality (100 x 100 = 10,000), so most upserts inserted a new key rather than updating an existing group. This doesn't exercise the repeated-group-update pattern typical of real GROUP BY workloads. Bumped to 100,000 so each group is hit roughly 100 times on average.

## Verification

Ran an isolated before/after comparison (same cardinality, same JMH settings, only swapping `Random` for `ThreadLocalRandom`) to confirm the shared-`Random` issue was materially affecting results, not just a theoretical concern — the relative ordering of `concurrentIndexedTable` vs `simpleIndexedTable` flipped depending on which `Random` implementation was used.

## Test plan

- [x] `mvn -pl pinot-perf compile` succeeds
- [x] Ran `BenchmarkIndexedTable` locally and confirmed consistent results across multiple forks