### PR TITLE
Retry consuming-segment stream init on the consumer thread

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -238,8 +238,11 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private static final int MSG_COUNT_THRESHOLD_FOR_LOG = 100000;
   private static final int BUILD_TIME_LEASE_SECONDS = 30;
   private static final int MAX_CONSECUTIVE_ERROR_COUNT = 5;
-  // 8 min max timeout for the retry policy
-  private static final RetryPolicy CONSUMER_RECREATE_RETRY_POLICY =
+  // 8 min max timeout for the retry policy. Used for both mid-consume recreate (#17062) and first
+  // consumer creation on the consumer thread, so a retryable Kafka/DNS init failure does not mark
+  // the replica OFFLINE after the short Helix-thread path (~10s).
+  @VisibleForTesting
+  static final RetryPolicy CONSUMER_RECREATE_RETRY_POLICY =
       RetryPolicies.exponentialBackoffRetryPolicy(10, 1000L, 2.0f);
 
   // Interrupt consumer thread every 10 seconds in case it doesn't stop, e.g. interrupt flag getting cleared somehow
@@ -317,7 +320,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private final PartitionGroupConsumptionStatus _partitionGroupConsumptionStatus;
   final String _clientId;
   private final TransformPipeline _transformPipeline;
-  private PartitionGroupConsumer _partitionGroupConsumer = null;
+  private final AtomicReference<PartitionGroupConsumer> _partitionGroupConsumer = new AtomicReference<>();
   private StreamMetadataProvider _partitionMetadataProvider = null;
   private final File _resourceTmpDir;
   private final String _tableNameWithType;
@@ -512,7 +515,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       // Update _currentOffset upon return from this method
       MessageBatch messageBatch;
       try {
-        messageBatch = _partitionGroupConsumer.fetchMessages(_currentOffset, _streamConfig.getFetchTimeoutMillis());
+        messageBatch =
+            _partitionGroupConsumer.get().fetchMessages(_currentOffset, _streamConfig.getFetchTimeoutMillis());
         //track realtime rows fetched on a table level. This included valid + invalid rows
         _serverMetrics.addMeteredTableValue(_clientId, ServerMeter.REALTIME_ROWS_FETCHED,
             messageBatch.getUnfilteredMessageCount());
@@ -820,6 +824,22 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         _segmentLogger.info("Starting consumption on segment: {}, maxRowCount: {}, maxEndTime: {}.", _llcSegmentName,
             _segmentMaxRowCount, new DateTime(_consumeEndTime, DateTimeZone.UTC));
 
+        // Create the stream consumer here (consumer thread) with CONSUMER_RECREATE_RETRY_POLICY. Doing this in
+        // the Helix constructor would either block the state-transition thread for the long retry window or keep
+        // the short Kafka 5x2s path and mark the replica OFFLINE. See
+        // https://github.com/apache/pinot/issues/11314 and https://github.com/apache/pinot/pull/17062.
+        if (_shouldStop) {
+          return;
+        }
+        makeStreamConsumer("Starting");
+        if (_shouldStop) {
+          // Leave a successfully created consumer in place so CONSUMING -> ONLINE can catch up.
+          return;
+        }
+        if (_partitionGroupConsumer.get() == null) {
+          throw new IllegalStateException("Stream consumer was not created for " + _clientId);
+        }
+
         // TODO:
         //   When reaching here, the current consuming segment has already acquired the consumer semaphore, but there is
         //   no guarantee that the previous consuming segment is already persisted (replaced with immutable segment). It
@@ -957,7 +977,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
             }
             case COMMIT: {
               _state = State.COMMITTING;
-              _currentOffset = _partitionGroupConsumer.checkpoint(_currentOffset);
+              _currentOffset = _partitionGroupConsumer.get().checkpoint(_currentOffset);
               // Lock the segment to avoid multiple threads touching the same segment.
               Lock segmentLock = _realtimeTableDataManager.getSegmentLock(_segmentNameStr);
               // NOTE: We need to lock interruptibly because the lock might already be held by the Helix thread for the
@@ -1454,11 +1474,12 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     }
   }
 
+  /// Closes the current consumer in place and leaves the reference set. COMMIT/CATCH_UP may still
+  /// call [PartitionGroupConsumer#checkpoint] on that closed instance (the default is identity).
   private void closePartitionGroupConsumer() {
-    try {
-      _partitionGroupConsumer.close();
-    } catch (Exception e) {
-      _segmentLogger.warn("Could not close stream consumer", e);
+    PartitionGroupConsumer consumer = _partitionGroupConsumer.get();
+    if (consumer != null) {
+      closeQuietly(consumer);
     }
   }
 
@@ -1680,16 +1701,18 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
             }
           } else {
             boolean success = false;
-            // Since online helix transition for a segment can arrive before segment's consumer acquires the
-            // semaphore, check _consumerSemaphoreAcquired before catching up.
-            // This is to avoid consuming in parallel to another segment's consumer.
-            if (_consumerSemaphoreAcquired.get()) {
+            // ONLINE can arrive before the consumer thread has acquired the semaphore or finished first
+            // create. Catch up only when both are true; otherwise download. The semaphore used to imply a
+            // live consumer because the Helix constructor created it. It no longer does.
+            if (_consumerSemaphoreAcquired.get() && _partitionGroupConsumer.get() != null) {
               _segmentLogger.info("Attempting to catch up from offset {} to {} ", _currentOffset, endOffset);
               success = catchupToFinalOffset(endOffset,
                   TimeUnit.MILLISECONDS.convert(MAX_TIME_FOR_CONSUMING_TO_ONLINE_IN_SECONDS, TimeUnit.SECONDS));
             } else {
-              _segmentLogger.warn("Consumer semaphore was not acquired, Skipping catch up from offset {} to {} ",
-                  _currentOffset, endOffset);
+              _segmentLogger.warn(
+                  "Skipping catch up from offset {} to {} (consumerSemaphoreAcquired={}, consumerPresent={})",
+                  _currentOffset, endOffset, _consumerSemaphoreAcquired.get(),
+                  _partitionGroupConsumer.get() != null);
             }
 
             if (success) {
@@ -1978,7 +2001,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       // Initialize stopOnDecodeError configuration with proper validation
       _stopOnDecodeError = parseStopOnDecodeErrorConfig(_streamConfig);
 
-      makeStreamConsumer("Starting");
+      // Stream consumer creation is deferred to PartitionConsumer.run() so a retryable init failure
+      // uses CONSUMER_RECREATE_RETRY_POLICY on the consumer thread instead of blocking Helix.
       createPartitionMetadataProvider("Starting");
       setPartitionParameters(realtimeSegmentConfigBuilder, indexingConfig.getSegmentPartitionConfig());
       _realtimeSegment = new MutableSegmentImpl(realtimeSegmentConfigBuilder.build(), serverMetrics);
@@ -2152,16 +2176,33 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     }
   }
 
-  /// Creates a new stream consumer
+  /// Creates a new stream consumer using [CONSUMER_RECREATE_RETRY_POLICY].
+  ///
+  /// Called from the consumer thread at the start of [PartitionConsumer#run], not from the Helix
+  /// constructor, so a retryable stream/init error does not block the state-transition thread.
   private void makeStreamConsumer(String reason) {
-    if (_partitionGroupConsumer != null) {
+    if (_streamConsumerClosed.get()) {
+      return;
+    }
+    if (_partitionGroupConsumer.get() != null) {
       closePartitionGroupConsumer();
     }
     _segmentLogger.info("Creating new stream consumer for topic partition {} , reason: {}", _clientId, reason);
     try {
-      _partitionGroupConsumer =
-          _streamConsumerFactory.createPartitionGroupConsumer(_clientId, _partitionGroupConsumptionStatus);
-      _partitionGroupConsumer.start(_currentOffset);
+      PartitionGroupConsumer consumer =
+          _streamConsumerFactory.createPartitionGroupConsumer(_clientId, _partitionGroupConsumptionStatus,
+              CONSUMER_RECREATE_RETRY_POLICY);
+      consumer.start(_currentOffset);
+      // Offload may have closed a still-null field while create was in flight. Do not close on
+      // _shouldStop: stop() is also used for CONSUMING -> ONLINE catchup.
+      if (_streamConsumerClosed.get()) {
+        closeQuietly(consumer);
+        return;
+      }
+      _partitionGroupConsumer.set(consumer);
+      if (_streamConsumerClosed.get()) {
+        closePartitionGroupConsumer();
+      }
     } catch (Exception e) {
       _segmentLogger.error("Faced exception while trying to create stream consumer for topic partition {} reason {}",
           _clientId, reason, e);
@@ -2170,17 +2211,26 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     }
   }
 
+  private void closeQuietly(PartitionGroupConsumer consumer) {
+    try {
+      consumer.close();
+    } catch (Exception e) {
+      _segmentLogger.warn("Could not close stream consumer", e);
+    }
+  }
+
   /// Checkpoints existing consumer before creating a new consumer instance
   /// Assumes there is a valid instance of [PartitionGroupConsumer]
   private void recreateStreamConsumer(String reason) {
     _segmentLogger.info("Recreating stream consumer for topic partition {}, reason: {}", _clientId, reason);
-    _currentOffset = _partitionGroupConsumer.checkpoint(_currentOffset);
+    _currentOffset = _partitionGroupConsumer.get().checkpoint(_currentOffset);
     closePartitionGroupConsumer();
     try {
-      _partitionGroupConsumer =
+      PartitionGroupConsumer consumer =
           _streamConsumerFactory.createPartitionGroupConsumer(_clientId, _partitionGroupConsumptionStatus,
               CONSUMER_RECREATE_RETRY_POLICY);
-      _partitionGroupConsumer.start(_currentOffset);
+      consumer.start(_currentOffset);
+      _partitionGroupConsumer.set(consumer);
     } catch (Exception e) {
       _segmentLogger.error("Faced exception while trying to recreate stream consumer for topic partition {}", _clientId,
           e);
@@ -2283,6 +2333,17 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   @VisibleForTesting
   AtomicBoolean getConsumerSemaphoreAcquired() {
     return _consumerSemaphoreAcquired;
+  }
+
+  @VisibleForTesting
+  @Nullable
+  PartitionGroupConsumer getPartitionGroupConsumer() {
+    return _partitionGroupConsumer.get();
+  }
+
+  @VisibleForTesting
+  void setPartitionGroupConsumer(@Nullable PartitionGroupConsumer partitionGroupConsumer) {
+    _partitionGroupConsumer.set(partitionGroupConsumer);
   }
 
   /// Parses the stopOnDecodeError configuration with proper validation and type safety.

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -67,6 +67,7 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.LongMsgOffsetFactory;
+import org.apache.pinot.spi.stream.PartitionGroupConsumer;
 import org.apache.pinot.spi.stream.PermanentConsumerException;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
@@ -75,6 +76,7 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -181,6 +183,115 @@ public class RealtimeSegmentDataManagerTest {
     }
   }
 
+  @Test
+  public void testHelixConstructorDoesNotCreateStreamConsumer()
+      throws Exception {
+    TableConfig tableConfig = Fixtures.createTableConfig(RecordingStreamConsumerFactory.class.getName(),
+        FakeStreamMessageDecoder.class.getName());
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager(false, new TimeSupplier(), null,
+        null, tableConfig)) {
+      Assert.assertNull(segmentDataManager.getPartitionGroupConsumer());
+      Assert.assertEquals(RecordingStreamConsumerFactory.CREATE_WITHOUT_POLICY_COUNT.get(), 0);
+      Assert.assertEquals(RecordingStreamConsumerFactory.CREATE_WITH_POLICY_COUNT.get(), 0);
+      Assert.assertFalse(segmentDataManager._postConsumeStoppedCalled);
+    }
+  }
+
+  @Test
+  public void testPartitionConsumerInitUsesRecreateRetryPolicy()
+      throws Exception {
+    TableConfig tableConfig = Fixtures.createTableConfig(RecordingStreamConsumerFactory.class.getName(),
+        FakeStreamMessageDecoder.class.getName());
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager(false, new TimeSupplier(), null,
+        null, tableConfig)) {
+      Assert.assertNull(segmentDataManager.getPartitionGroupConsumer());
+
+      RealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
+      LongMsgOffset endOffset = new LongMsgOffset(START_OFFSET_VALUE + 500);
+      segmentDataManager._consumeOffsets.add(endOffset);
+      segmentDataManager._responses.add(new SegmentCompletionProtocol.Response(
+          new SegmentCompletionProtocol.Response.Params().withStatus(
+                  SegmentCompletionProtocol.ControllerResponseStatus.HOLD)
+              .withStreamPartitionMsgOffset(endOffset.toString())));
+
+      consumer.run();
+
+      Assert.assertSame(RecordingStreamConsumerFactory.LAST_RETRY_POLICY.get(),
+          RealtimeSegmentDataManager.CONSUMER_RECREATE_RETRY_POLICY);
+      Assert.assertEquals(RecordingStreamConsumerFactory.CREATE_WITH_POLICY_COUNT.get(), 1);
+      Assert.assertEquals(RecordingStreamConsumerFactory.CREATE_WITHOUT_POLICY_COUNT.get(), 0);
+      Assert.assertNotNull(segmentDataManager.getPartitionGroupConsumer());
+      Assert.assertFalse(segmentDataManager._postConsumeStoppedCalled);
+    }
+  }
+
+  @Test
+  public void testConsumerInitFailureAfterRetryExhaustionPostsStopConsumed()
+      throws Exception {
+    RecordingStreamConsumerFactory.FAIL_CREATE.set(true);
+    TableConfig tableConfig = Fixtures.createTableConfig(RecordingStreamConsumerFactory.class.getName(),
+        FakeStreamMessageDecoder.class.getName());
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager(false, new TimeSupplier(), null,
+        null, tableConfig)) {
+      Assert.assertNull(segmentDataManager.getPartitionGroupConsumer());
+      Assert.assertFalse(segmentDataManager._postConsumeStoppedCalled);
+
+      segmentDataManager.createPartitionConsumer().run();
+
+      Assert.assertSame(RecordingStreamConsumerFactory.LAST_RETRY_POLICY.get(),
+          RealtimeSegmentDataManager.CONSUMER_RECREATE_RETRY_POLICY);
+      Assert.assertEquals(RecordingStreamConsumerFactory.CREATE_WITH_POLICY_COUNT.get(), 1);
+      Assert.assertEquals(RecordingStreamConsumerFactory.CREATE_WITHOUT_POLICY_COUNT.get(), 0);
+      Assert.assertNull(segmentDataManager.getPartitionGroupConsumer());
+      Assert.assertTrue(segmentDataManager._postConsumeStoppedCalled);
+      Assert.assertEquals(segmentDataManager._state.get(segmentDataManager), RealtimeSegmentDataManager.State.ERROR);
+    }
+  }
+
+  @Test
+  public void testOffloadSucceedsWhenStreamConsumerWasNeverCreated()
+      throws Exception {
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
+      Assert.assertNull(segmentDataManager.getPartitionGroupConsumer());
+    }
+  }
+
+  @Test
+  public void testStopDuringConsumerInitKeepsConsumerForCatchup()
+      throws Exception {
+    TableConfig tableConfig = Fixtures.createTableConfig(RecordingStreamConsumerFactory.class.getName(),
+        FakeStreamMessageDecoder.class.getName());
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager(false, new TimeSupplier(), null,
+        null, tableConfig)) {
+      RecordingStreamConsumerFactory.BEFORE_CREATE_WITH_POLICY.set(segmentDataManager::stop);
+
+      segmentDataManager.createPartitionConsumer().run();
+
+      Assert.assertEquals(RecordingStreamConsumerFactory.CREATE_WITH_POLICY_COUNT.get(), 1);
+      Assert.assertNotNull(segmentDataManager.getPartitionGroupConsumer());
+      Assert.assertEquals(RecordingStreamConsumerFactory.CLOSE_COUNT.get(), 0);
+      Assert.assertFalse(segmentDataManager._postConsumeStoppedCalled);
+    }
+  }
+
+  @Test
+  public void testOffloadDuringConsumerInitClosesCreatedConsumer()
+      throws Exception {
+    TableConfig tableConfig = Fixtures.createTableConfig(RecordingStreamConsumerFactory.class.getName(),
+        FakeStreamMessageDecoder.class.getName());
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager(false, new TimeSupplier(), null,
+        null, tableConfig)) {
+      RecordingStreamConsumerFactory.BEFORE_CREATE_WITH_POLICY.set(segmentDataManager::offload);
+
+      segmentDataManager.createPartitionConsumer().run();
+
+      Assert.assertEquals(RecordingStreamConsumerFactory.CREATE_WITH_POLICY_COUNT.get(), 1);
+      Assert.assertNull(segmentDataManager.getPartitionGroupConsumer());
+      Assert.assertEquals(RecordingStreamConsumerFactory.CLOSE_COUNT.get(), 1);
+      Assert.assertFalse(segmentDataManager._postConsumeStoppedCalled);
+    }
+  }
+
   private FakeRealtimeSegmentDataManager createFakeSegmentManager(boolean noUpsert, TimeSupplier timeSupplier,
       @Nullable String maxRows, @Nullable String maxDuration, @Nullable TableConfig tableConfig)
       throws Exception {
@@ -220,6 +331,11 @@ public class RealtimeSegmentDataManagerTest {
 
     FileUtils.deleteQuietly(TEMP_DIR);
     SegmentBuildTimeLeaseExtender.initExecutor();
+  }
+
+  @BeforeMethod
+  public void resetRecordingStreamConsumerFactory() {
+    RecordingStreamConsumerFactory.reset();
   }
 
   @AfterClass
@@ -611,6 +727,7 @@ public class RealtimeSegmentDataManagerTest {
     // If catching up, but we did not get to the final offset, then download and replace
     try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
       segmentDataManager.getConsumerSemaphoreAcquired().set(true);
+      segmentDataManager.setPartitionGroupConsumer(mock(PartitionGroupConsumer.class));
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, RealtimeSegmentDataManager.State.CATCHING_UP);
       segmentDataManager._consumeOffsets.add(new LongMsgOffset(finalOffsetValue - 1));
@@ -622,12 +739,24 @@ public class RealtimeSegmentDataManagerTest {
     // But then if we get to the exact offset, we get to build and replace, not download
     try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
       segmentDataManager.getConsumerSemaphoreAcquired().set(true);
+      segmentDataManager.setPartitionGroupConsumer(mock(PartitionGroupConsumer.class));
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, RealtimeSegmentDataManager.State.CATCHING_UP);
       segmentDataManager._consumeOffsets.add(finalOffset);
       segmentDataManager.goOnlineFromConsuming(metadata);
       Assert.assertFalse(segmentDataManager._downloadAndReplaceCalled);
       Assert.assertTrue(segmentDataManager._buildAndReplaceCalled);
+    }
+
+    // Semaphore acquired but first create never finished: skip catchup and download.
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
+      segmentDataManager.getConsumerSemaphoreAcquired().set(true);
+      segmentDataManager._stopWaitTimeMs = 0;
+      segmentDataManager._state.set(segmentDataManager, RealtimeSegmentDataManager.State.CATCHING_UP);
+      segmentDataManager._consumeOffsets.add(finalOffset);
+      segmentDataManager.goOnlineFromConsuming(metadata);
+      Assert.assertTrue(segmentDataManager._downloadAndReplaceCalled);
+      Assert.assertFalse(segmentDataManager._buildAndReplaceCalled);
     }
 
     // But then if we get to the exact offset, we download the segment because consumer semaphore was never acquired.

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RecordingStreamConsumerFactory.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RecordingStreamConsumerFactory.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.realtime;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConsumerFactory;
+import org.apache.pinot.spi.stream.MessageBatch;
+import org.apache.pinot.spi.stream.PartitionGroupConsumer;
+import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.apache.pinot.spi.utils.retry.RetryPolicy;
+
+/// Test [org.apache.pinot.spi.stream.StreamConsumerFactory] that records which create overload was used
+/// and can fail create to simulate exhausted stream-consumer init.
+public class RecordingStreamConsumerFactory extends FakeStreamConsumerFactory {
+  static final AtomicInteger CREATE_WITHOUT_POLICY_COUNT = new AtomicInteger();
+  static final AtomicInteger CREATE_WITH_POLICY_COUNT = new AtomicInteger();
+  static final AtomicReference<RetryPolicy> LAST_RETRY_POLICY = new AtomicReference<>();
+  static final AtomicBoolean FAIL_CREATE = new AtomicBoolean();
+  static final AtomicReference<Runnable> BEFORE_CREATE_WITH_POLICY = new AtomicReference<>();
+  static final AtomicInteger CLOSE_COUNT = new AtomicInteger();
+
+  static void reset() {
+    CREATE_WITHOUT_POLICY_COUNT.set(0);
+    CREATE_WITH_POLICY_COUNT.set(0);
+    LAST_RETRY_POLICY.set(null);
+    FAIL_CREATE.set(false);
+    BEFORE_CREATE_WITH_POLICY.set(null);
+    CLOSE_COUNT.set(0);
+  }
+
+  @Override
+  public PartitionGroupConsumer createPartitionGroupConsumer(String clientId,
+      PartitionGroupConsumptionStatus partitionGroupConsumptionStatus) {
+    CREATE_WITHOUT_POLICY_COUNT.incrementAndGet();
+    if (FAIL_CREATE.get()) {
+      throw new RuntimeException("stream consumer create failed");
+    }
+    return super.createPartitionGroupConsumer(clientId, partitionGroupConsumptionStatus);
+  }
+
+  @Override
+  public PartitionGroupConsumer createPartitionGroupConsumer(String clientId,
+      PartitionGroupConsumptionStatus partitionGroupConsumptionStatus, RetryPolicy retryPolicy) {
+    CREATE_WITH_POLICY_COUNT.incrementAndGet();
+    LAST_RETRY_POLICY.set(retryPolicy);
+    Runnable beforeCreate = BEFORE_CREATE_WITH_POLICY.get();
+    if (beforeCreate != null) {
+      beforeCreate.run();
+    }
+    if (FAIL_CREATE.get()) {
+      throw new RuntimeException("stream consumer create exhausted");
+    }
+    PartitionGroupConsumer delegate =
+        super.createPartitionGroupConsumer(clientId, partitionGroupConsumptionStatus);
+    return new CloseCountingPartitionGroupConsumer(delegate);
+  }
+
+  private static final class CloseCountingPartitionGroupConsumer implements PartitionGroupConsumer {
+    private final PartitionGroupConsumer _delegate;
+
+    CloseCountingPartitionGroupConsumer(PartitionGroupConsumer delegate) {
+      _delegate = delegate;
+    }
+
+    @Override
+    public void start(StreamPartitionMsgOffset startOffset) {
+      _delegate.start(startOffset);
+    }
+
+    @Override
+    public MessageBatch fetchMessages(StreamPartitionMsgOffset startOffset, int timeoutMs)
+        throws TimeoutException {
+      return _delegate.fetchMessages(startOffset, timeoutMs);
+    }
+
+    @Override
+    public StreamPartitionMsgOffset checkpoint(StreamPartitionMsgOffset lastOffset) {
+      return _delegate.checkpoint(lastOffset);
+    }
+
+    @Override
+    public void close()
+        throws IOException {
+      CLOSE_COUNT.incrementAndGet();
+      _delegate.close();
+    }
+  }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Moves stream consumer creation to consumer thread with long retry policy, adding checks for stop and consumer validity before proceeding to consume loop\.

```mermaid
flowchart TD
  N0["Helix constructor #40;no stream consumer creation#41; #40;F1#41;"]:::stRemoved
  N1["PartitionConsumer#46;run#40;#41; start #40;F1#41;"]:::stAdded
  N2["#95;shouldStop check #40;first#41; #40;F1#41;"]:::stAdded
  N3["makeStreamConsumer #40;Starting#41; #40;F1#41;"]:::stAdded
  N4["#95;shouldStop check #40;second#41; #40;F1#41;"]:::stAdded
  N5["consumer null check #40;F1#41;"]:::stAdded
  N6["Proceed to consume loop #40;using consumer via get#40;#41;#41; #40;F1#41;"]:::stModified
  N1 -->|"if not stopped"| N2
  N2 --> N3
  N3 --> N4
  N4 -->|"if not stopped"| N5
  N5 -->|"if consumer not null"| N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager\.java — [before](https://github.com/apache/pinot/blob/d40dcebf1b0a9dd689403be0df771c069cd20059/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java) · [after](https://github.com/apache/pinot/blob/ed1761ba9b3f3a0254843b2eeb38541b35a89d35/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImQ0MGRjZWJmMWIwYTlkZDY4OTQwM2JlMGRmNzcxYzA2OWNkMjAwNTkiLCJjb250ZXh0X2hhc2giOiJjM2Y2MDhkNWM3NjZkODEzNzg5ZmE2NjMzODA0OTE5ODU2MzIxMzhiYWZhY2U5MDBhNGUzOWZjMDE0MzE3M2UyIiwiZ2VuZXJhdGVkX2F0IjoxNzg5Nzk1ODIzLCJoZWFkX3NoYSI6ImVkMTc2MWJhOWIzZjNhMDI1NDg0M2IyZWViMzg1NDFiMzVhODlkMzUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJkNDBkY2ViZjFiMGE5ZGQ2ODk0MDNiZTBkZjc3MWMwNjljZDIwMDU5IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 3c291840e25de24ba4758d22a7d91e771ab74df9abe845d34033a4371e5e8222 -->
<!-- pinot-pr-flow:end -->

## Problem

A retryable Kafka/DNS failure during consuming-segment init still runs on the Helix state-transition thread. That path uses Kafka's short 5x2s retry, then marks the replica OFFLINE after about 10s. Healthy replicas keep consuming. The partition stays under-replicated until the next natural flush.

#17062 already retries mid-consume recreate on the consumer thread with `CONSUMER_RECREATE_RETRY_POLICY` (about 8 minutes). First create did not use that path.

#19083 tried a controller-side auto force-commit. Review feedback was that one bad server must not force healthy replicas to commit, and that the remaining hole is this init path, not another default-off controller flag.

## What I did

Move first `makeStreamConsumer("Starting")` from the Helix constructor onto `PartitionConsumer.run()`, after the ready-wait and consumer semaphore. First create now uses the same `CONSUMER_RECREATE_RETRY_POLICY` as mid-consume recreate (10 attempts, 1s, factor 2).

No force-commit. No new controller config. #17754 (`controller.realtime.segment.partialOfflineReplicaRepairEnabled`, default false) is unchanged. All-OFFLINE recreate is unchanged.

## How

- Helix constructor still builds the decoder, transform pipeline, mutable segment, and partition metadata provider. It does not open the stream consumer.
- Exhausted init still takes the existing `postStopConsumedMsg` / ERROR / OFFLINE path.
- `stop()` for CONSUMING to ONLINE keeps a just-created consumer so catchup can use it. Offload during in-flight create closes the uninstalled client.
- Catchup requires both the consumer semaphore and a live consumer. Otherwise the replica downloads.
- Close leaves the reference in place so COMMIT/CATCH_UP can still `checkpoint` a closed instance (default is identity).

## Impact

A transient Kafka/DNS blip on one server retries on that server's consumer thread instead of going OFFLINE after about 10s. Other replicas are not force-committed. Brokers do not start preferring a replica that is hours behind.

Helix state-transition threads are not blocked for the long retry window.

## Not in this PR

`createPartitionMetadataProvider("Starting")` still runs on the Helix constructor. For Kafka that opens a metadata-provider client on the short 5x2s path. A retryable DNS failure there can still OFFLINE a replica after about 10s. Fetch fallbacks already exist for offset lookup; provider construction itself can still throw.

## Testing

`RealtimeSegmentDataManagerTest`: 33 tests, 0 failures.

- ctor does not create a stream consumer
- first create uses `CONSUMER_RECREATE_RETRY_POLICY`
- exhaustion posts stop-consumed and goes ERROR
- offload with never-created consumer succeeds
- stop during init keeps the consumer for catchup
- offload during init closes the created client
- ONLINE with semaphore but no consumer downloads

```
./mvnw -pl pinot-core -am -Dtest=RealtimeSegmentDataManagerTest -Dsurefire.failIfNoSpecifiedTests=false test
```

Please tag `bug` and `testing`. No `release-notes` (no new config).

## Related

- #15897
- #11314
- #17062
- #17754
- Alternative to #19083 (no force-commit, no new controller flag)

cc @noob-se7en

##### Was generative AI tooling used to co-author this PR?

- [x] Yes