### PR TITLE
Make logical EXPLAIN fail wherever query execution would fail

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -955,6 +955,9 @@ public class QueryEnvironment {
     /// Explain the query plan.
     /// The original query must be an EXPLAIN query and way it will be explained depends on the options of the EXPLAIN
     /// query and the [QueryEnvironment.Config] used to create the [QueryEnvironment] that compiled this query.
+    ///
+    /// Unless the query explicitly asks for a logical plan only (`EXPLAIN PLAN WITHOUT IMPLEMENTATION`), this builds
+    /// the dispatchable subplan and therefore fails wherever [#planQuery] would.
     public QueryEnvironment.QueryPlannerResult explain(long requestId,
         @Nullable AskingServerStageExplainer.OnServerExplainer onServerExplainer) {
       try {
@@ -971,9 +974,17 @@ public class QueryEnvironment {
           SqlExplainLevel level =
               explain.getDetailLevel() == null ? SqlExplainLevel.DIGEST_ATTRIBUTES : explain.getDetailLevel();
           Set<String> tableNames = RelToPlanNodeConverter.getTableNamesFromRelRoot(_relRoot.rel);
-          if (!explain.withImplementation() || onServerExplainer == null) {
+          if (!explain.withImplementation()) {
+            // The query explicitly asked to skip implementation planning, so render the logical plan as-is.
             return getQueryPlannerResult(_plannerContext, null, PlannerUtils.explainPlan(_relRoot.rel, format, level),
                 tableNames);
+          } else if (onServerExplainer == null) {
+            // Build the dispatchable subplan even though only the logical plan is rendered: some planning errors are
+            // raised while converting the plan or assigning workers (e.g. a `tableOptions` partition hint that
+            // disagrees with the table's actual partitioning), and EXPLAIN must fail wherever execution would.
+            DispatchableSubPlan dispatchableSubPlan = toDispatchableSubPlan(_relRoot, _plannerContext);
+            return getQueryPlannerResult(_plannerContext, dispatchableSubPlan,
+                PlannerUtils.explainPlan(_relRoot.rel, format, level), dispatchableSubPlan.getTableNames());
           } else {
             Map<String, String> options = _sqlNodeAndOptions.getOptions();
             boolean explainPlanVerbose = QueryOptionsUtils.isExplainPlanVerbose(options);
@@ -995,6 +1006,8 @@ public class QueryEnvironment {
                 PlannerUtils.explainPlan(explainedNode, format, level), dispatchableSubPlan.getTableNames());
           }
         }
+      } catch (QueryException e) {
+        throw e;
       } catch (Exception e) {
         throw new RuntimeException("Error explain query plan for: " + _textQuery, e);
       }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -567,9 +567,11 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
   public void testJoinPushTransitivePredicateLookupJoin() {
     // PinotJoinPushTransitivePredicatesRule
     // should not push to the right under lookup join hint
+    // NOTE: Selects explicit columns because `*` leaves no Project at all over the right table scan, which a lookup
+    // join requires (see RelToPlanNodeConverter#convertLogicalJoin). That case is covered in JoinPlans.json.
     String query = "EXPLAIN PLAN FOR\n"
         + "SELECT /*+ joinOptions(join_strategy='lookup') */ \n"
-        + "* FROM a\n"
+        + "a.col1, b.col2 FROM a\n"
         + "JOIN b\n"
         + "ON a.col1 = b.col1\n"
         + "WHERE a.col1 = 1;\n";
@@ -578,11 +580,14 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
     //@formatter:off
     assertEquals(explain,
         "Execution Plan\n"
-            + "LogicalJoin(condition=[=($0, $9)], joinType=[inner])\n"
-            + "  PinotLogicalExchange(distribution=[single])\n"
-            + "    LogicalFilter(condition=[=(CAST($0):INTEGER NOT NULL, 1)])\n"
-            + "      PinotLogicalTableScan(table=[[default, a]])\n"
-            + "  PinotLogicalTableScan(table=[[default, b]])\n");
+            + "LogicalProject(col1=[$0], col2=[$2])\n"
+            + "  LogicalJoin(condition=[=($0, $1)], joinType=[inner])\n"
+            + "    PinotLogicalExchange(distribution=[single])\n"
+            + "      LogicalProject(col1=[$0])\n"
+            + "        LogicalFilter(condition=[=(CAST($0):INTEGER NOT NULL, 1)])\n"
+            + "          PinotLogicalTableScan(table=[[default, a]])\n"
+            + "    LogicalProject(col1=[$0], col2=[$1])\n"
+            + "      PinotLogicalTableScan(table=[[default, b]])\n");
     //@formatter:on
   }
 

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/queries/ResourceBasedQueryPlansTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/queries/ResourceBasedQueryPlansTest.java
@@ -71,8 +71,6 @@ public class ResourceBasedQueryPlansTest extends QueryEnvironmentTestBase {
     try {
       long requestId = RANDOM_REQUEST_ID_GEN.nextLong();
       _queryEnvironment.explainQuery(query, requestId);
-      String queryWithoutExplainPlan = query.replaceFirst(EXPLAIN_REGEX, "");
-      _queryEnvironment.planQuery(queryWithoutExplainPlan);
       Assert.fail("Query compilation should have failed with exception message pattern: " + expectedException);
     } catch (Exception e) {
       if (expectedException == null) {

--- a/pinot-query-planner/src/test/resources/queries/JoinPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/JoinPlans.json
@@ -1133,6 +1133,11 @@
         "description": "Lookup join with transformation on right table joined key",
         "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy = 'lookup') */ a.col1, b.col2 FROM a JOIN b ON a.col1 = upper(b.col1)",
         "expectedException": "Right input for lookup join must be an identifier.*"
+      },
+      {
+        "description": "Lookup join selecting all columns leaves no Project over the right table scan",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy = 'lookup') */ * FROM a JOIN b ON a.col1 = b.col1 WHERE a.col1 = 1",
+        "expectedException": "Right input for lookup join must be a Project.*"
       }
     ]
   }

--- a/pinot-query-planner/src/test/resources/queries/ValidationErrorPlan.json
+++ b/pinot-query-planner/src/test/resources/queries/ValidationErrorPlan.json
@@ -12,6 +12,11 @@
         "expectedException": ".*'ArrayToMv' is not supported.*"
       },
       {
+        "description": "arrayToMV validation error 2 (physical optimizer)",
+        "sql": "SET usePhysicalOptimizer=true; EXPLAIN PLAN FOR SELECT SUM(a.col3) as sumCol3, arrayToMv(e.mcol1), a.col2  FROM a JOIN e on a.col1=e.col1 GROUP BY arrayToMv(e.mcol1), a.col2",
+        "expectedException": ".*'ArrayToMv' is not supported.*"
+      },
+      {
         "description": "Select * with negative limit -1",
         "sql": "EXPLAIN PLAN FOR SELECT * FROM d LIMIT -1",
         "expectedException": "Encountered.*LIMIT.*"


### PR DESCRIPTION
`EXPLAIN PLAN FOR <query>` can return a plan for a query that cannot actually run. The
following succeeds against `ColocatedJoinEngineQuickStart`:

```sql
EXPLAIN PLAN FOR
SELECT * FROM userAttributes /*+ tableOptions(partition_function='hashcode', partition_key='daysSinceFirstTrip', partition_size='2') */ a
JOIN userGroups /*+ tableOptions(partition_function='hashcode', partition_key='userUUID', partition_size='2') */ g
ON a.userUUID = g.userUUID
```

but running the same query fails with:

```
Partition key: daysSinceFirstTrip does not match partition column: userUUID for table: userAttributes_OFFLINE
```

## Root cause

`CompiledQuery#explain` renders a plain logical EXPLAIN straight off the optimized `RelNode`
tree and never calls `toDispatchableSubPlan`. Several classes of planning error are only raised
further down that path:

* `PinotLogicalQueryPlanner#makePlan` / `makePlanV2` (`RelNode` -> `PlanNode` conversion), e.g.
  lookup-join shape validation and `ArrayToMv` validation.
* `WorkerManager` worker assignment, e.g. `checkPartitionInfoMap`, which is where a
  `tableOptions` partition hint is compared against the table's real partitioning.

So the logical EXPLAIN reports a plan the engine would refuse to execute. The other two explain
branches (`EXPLAIN IMPLEMENTATION PLAN`, and `EXPLAIN PLAN WITH IMPLEMENTATION` when
`explainAskingServers` is on) already build the dispatchable subplan and therefore already fail
correctly — this only affects the default logical EXPLAIN.

## Fix

Build the dispatchable subplan on that branch too, and keep rendering the logical plan. Parity
becomes structural instead of a list of checks that has to be kept in sync, and all three explain
branches now go through the same pipeline.

`EXPLAIN PLAN WITHOUT IMPLEMENTATION` is deliberately left alone. `Parser.jj` maps it to
`SqlExplain.Depth.LOGICAL`, so its whole contract is "logical plan, skip implementation planning".
That branch is unchanged, which also leaves users an explicit way to get a logical plan for a query
that cannot currently be planned for execution.

`explain` now rethrows `QueryException` instead of wrapping it, matching `planQuery`. Without this,
the same `ArrayToMv` rejection surfaced as `QUERY_PLANNING`/HTTP 400 when executed but
`INTERNAL`/HTTP 500 with a WARN stack trace when explained — i.e. EXPLAIN would fail, but with the
wrong error code.

## This was not a single bad hint

`ResourceBasedQueryPlansTest#testQueryExplainPlansWithExceptions` was calling `explainQuery(query)`
**and then** `planQuery(query minus the EXPLAIN prefix)` inside one try block, so its
`expectedException` fixtures were being satisfied by the second call. That made the existing
fixtures look like EXPLAIN coverage when they were really execution coverage.

Dropping that second call turns the fixtures into genuine EXPLAIN assertions. With this fix the
suite passes; without it 9 cases fail, spanning three unrelated causes:

* 6 x partition-hint mismatch (`Partition key: ... does not match partition column: ...`,
  `Partition size mismatch`, `Partition function mismatch`, `Failed to find table partition info`)
* 2 x `'ArrayToMv' is not supported`
* 1 x `Right input for lookup join must be a Project`

## Behavior change

A plain `EXPLAIN PLAN FOR` now surfaces any planning error that execution would hit, including ones
that depend on live routing state (for example a table whose partitions have no fully replicated
server right now). This is the intended semantics — if the query cannot run, EXPLAIN should say so
rather than print a plan — but it does mean EXPLAIN can start failing where it previously returned a
plan. `EXPLAIN PLAN WITHOUT IMPLEMENTATION` still returns the logical plan in those cases.

Known consequence, not addressed here: `toDispatchableSubPlan` is not side-effect free, so a default
EXPLAIN now bumps the global `JOIN_COUNT` / `QUERIES_WITH_JOINS` / `WINDOW_COUNT` /
`QUERIES_WITH_WINDOW` broker meters (`RelToPlanNodeConverter`), and under the physical optimizer also
calls `PRelNodeTreeValidator.emitMetrics`. Those meters were already polluted by the
`EXPLAIN IMPLEMENTATION PLAN` / `WITH IMPLEMENTATION` modes, and `makePlanV2` already carries a
`// TODO(mse-physical): Don't emit metrics for explain statements.`; this makes it the default rather
than a rare path. Suppressing it means threading an is-explain flag through `makePlan`/`makePlanV2`
into `RelToPlanNodeConverter`, which is a separate change that would fix all three explain modes and
retire that TODO — happy to do it here instead if reviewers prefer.

## Tests

* `ResourceBasedQueryPlansTest`: removed the `planQuery` call from the exception path, so the
  existing `expectedException` fixtures now actually assert on EXPLAIN.
* `JoinPlans.json`: added the `SELECT *` lookup-join case, which is the query this change newly
  causes EXPLAIN to reject (`*` leaves no `Project` over the right table scan, which
  `RelToPlanNodeConverter#convertLogicalJoin` requires). The existing fixture next to it covers only
  the sibling "must be an identifier" branch.
* `ValidationErrorPlan.json`: added a `usePhysicalOptimizer=true` variant of the `arrayToMv` case, so
  the v2 half of the changed branch is covered too — previously all the negative cases exercised only
  the legacy planner.
* `QueryCompilationTest#testJoinPushTransitivePredicateLookupJoin` was asserting a plan for a query
  that cannot execute, for the `SELECT *` reason above. Switched to selecting explicit columns, which
  is the shape every other lookup-join fixture uses; the test still checks what it was written to
  check, that the transitive predicate is pushed only to the left side under the lookup hint.
