### PR TITLE
Fix protobuf descriptor file temp directory leak

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoder.java
@@ -48,9 +48,10 @@ public class ProtoBufMessageDecoder implements StreamMessageDecoder<byte[]> {
         "Protocol Buffer schema descriptor file must be provided");
 
     _protoClassName = props.getOrDefault(PROTO_CLASS_NAME, "");
-    InputStream descriptorFileInputStream = ProtoBufUtils.getDescriptorFileInputStream(
-        props.get(DESCRIPTOR_FILE_PATH));
-    Descriptors.Descriptor descriptor = buildProtoBufDescriptor(descriptorFileInputStream);
+    Descriptors.Descriptor descriptor;
+    try (InputStream fin = ProtoBufUtils.openDescriptorFile(props.get(DESCRIPTOR_FILE_PATH))) {
+      descriptor = buildProtoBufDescriptor(fin);
+    }
     _recordExtractor = new ProtoBufRecordExtractor();
     _recordExtractor.init(fieldsToRead, null);
     DynamicMessage dynamicMessage = DynamicMessage.getDefaultInstance(descriptor);

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordReader.java
@@ -79,10 +79,9 @@ public class ProtoBufRecordReader implements RecordReader {
 
   private Descriptors.Descriptor buildProtoBufDescriptor(ProtoBufRecordReaderConfig protoBufRecordReaderConfig)
       throws IOException {
-    try {
-      InputStream fin = ProtoBufUtils.getDescriptorFileInputStream(
-          protoBufRecordReaderConfig.getDescriptorFile().toString());
-      DescriptorProtos.FileDescriptorSet set = DescriptorProtos.FileDescriptorSet.parseFrom(fin);
+    try (InputStream in = ProtoBufUtils.openDescriptorFile(
+        protoBufRecordReaderConfig.getDescriptorFile().toString())) {
+      DescriptorProtos.FileDescriptorSet set = DescriptorProtos.FileDescriptorSet.parseFrom(in);
       Descriptors.FileDescriptor fileDescriptor =
           Descriptors.FileDescriptor.buildFrom(set.getFile(0), new Descriptors.FileDescriptor[]{});
       return fileDescriptor.getMessageTypes().get(0);

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufUtils.java
@@ -21,7 +21,6 @@ package org.apache.pinot.plugin.inputformat.protobuf;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.ProtobufInternalUtils;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
@@ -39,6 +38,9 @@ public class ProtoBufUtils {
   private ProtoBufUtils() {
   }
 
+  /// Copies a remote file to a local temp directory and returns the local copy. Used by the codegen
+  /// decoder path for JAR files that must remain on disk for the lifetime of the classloader.
+  /// The caller is responsible for managing the lifetime of the returned file and its parent directory.
   public static File getFileCopiedToLocal(String filePath)
       throws Exception {
     URI fileURI = URI.create(filePath);
@@ -60,17 +62,28 @@ public class ProtoBufUtils {
     }
   }
 
-  public static InputStream getDescriptorFileInputStream(String descriptorFilePath)
-      throws Exception {
-    return new FileInputStream(getFileCopiedToLocal(descriptorFilePath));
-  }
-
   public static File createLocalFile(URI srcURI, File dstDir) {
     String sourceURIPath = srcURI.getPath();
     File dstFile = new File(dstDir, new File(sourceURIPath).getName());
     LOGGER.debug("Created empty local temporary file {} to copy protocol "
         + "buffer descriptor {}", dstFile.getAbsolutePath(), srcURI);
     return dstFile;
+  }
+
+  /// Opens a descriptor file (local or remote) and returns a stream over its contents.
+  /// The caller is responsible for closing the returned stream. No temporary files are created.
+  ///
+  /// @param descriptorFilePath URI string pointing to a `.desc` protobuf descriptor file
+  /// @return an open [InputStream] over the descriptor file contents
+  public static InputStream openDescriptorFile(String descriptorFilePath)
+      throws Exception {
+    URI fileURI = URI.create(descriptorFilePath);
+    String scheme = fileURI.getScheme();
+    if (scheme == null) {
+      scheme = PinotFSFactory.LOCAL_PINOT_FS_SCHEME;
+    }
+    PinotFS pinotFS = PinotFSFactory.create(scheme);
+    return pinotFS.open(fileURI);
   }
 
   public static String getFullJavaName(Descriptors.Descriptor descriptor) {

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufTempFileLeakTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufTempFileLeakTest.java
@@ -1,0 +1,185 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.protobuf;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.filesystem.LocalPinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.plugin.inputformat.protobuf.ProtoBufTestDataGenerator.getFieldsInSampleRecord;
+import static org.apache.pinot.plugin.inputformat.protobuf.ProtoBufTestDataGenerator.getSampleRecordMessage;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/// Verifies that reading a protobuf descriptor file does not copy it to a local temporary file.
+///
+/// Both consumers of [ProtoBufUtils#openDescriptorFile] are configured with a remote (non-`file:`) URI backed by
+/// [ClasspathPinotFS], which counts filesystem interactions. Each test asserts that the descriptor was streamed via
+/// [org.apache.pinot.spi.filesystem.PinotFS#open] and never staged through `copyToLocalFile`, and that the consumer
+/// closed the stream it was handed. Assertions are made against these counters rather than by scanning the shared
+/// `java.io.tmpdir`, which races with any other test creating directories with the same prefix.
+public class ProtoBufTempFileLeakTest {
+  private static final String REMOTE_SCHEME = "proto-test-remote";
+  private static final String SAMPLE_DESCRIPTOR_URI = REMOTE_SCHEME + ":///sample.desc";
+
+  @BeforeClass
+  public void setUp() {
+    PinotFSFactory.register(REMOTE_SCHEME, ClasspathPinotFS.class.getName(), null);
+  }
+
+  @BeforeMethod
+  public void resetCounters() {
+    ClasspathPinotFS.reset();
+  }
+
+  /// [ProtoBufMessageDecoder#init] must stream the descriptor and close it, without staging a local copy.
+  @Test
+  public void testMessageDecoderInitStreamsDescriptorWithoutLocalCopy()
+      throws Exception {
+    Map<String, String> decoderProps = new HashMap<>();
+    decoderProps.put(ProtoBufMessageDecoder.DESCRIPTOR_FILE_PATH, SAMPLE_DESCRIPTOR_URI);
+    ProtoBufMessageDecoder decoder = new ProtoBufMessageDecoder();
+    decoder.init(decoderProps, getFieldsInSampleRecord(), "");
+
+    // Verify decoding works off the remotely-read descriptor
+    GenericRow destination = new GenericRow();
+    decoder.decode(getSampleRecordMessage().toByteArray(), destination);
+    assertEquals(destination.getValue("email"), "foobar@hello.com");
+
+    assertStreamedAndClosed();
+  }
+
+  /// [ProtoBufRecordReader#init] must stream the descriptor and close it, without staging a local copy.
+  @Test
+  public void testRecordReaderInitStreamsDescriptorWithoutLocalCopy()
+      throws Exception {
+    File tempDataDir = Files.createTempDirectory("protobuf-descriptor-test-data").toFile();
+    try {
+      File dataFile = new File(tempDataDir, "test.data");
+      try (FileOutputStream out = new FileOutputStream(dataFile)) {
+        getSampleRecordMessage().writeDelimitedTo(out);
+      }
+
+      ProtoBufRecordReaderConfig config = new ProtoBufRecordReaderConfig();
+      config.setDescriptorFile(URI.create(SAMPLE_DESCRIPTOR_URI));
+
+      try (ProtoBufRecordReader reader = new ProtoBufRecordReader()) {
+        reader.init(dataFile, getFieldsInSampleRecord(), config);
+        assertTrue(reader.hasNext());
+        GenericRow row = reader.next(new GenericRow());
+        assertEquals(row.getValue("email"), "foobar@hello.com");
+      }
+    } finally {
+      FileUtils.deleteDirectory(tempDataDir);
+    }
+
+    assertStreamedAndClosed();
+  }
+
+  /// Asserts the descriptor was read exactly once via `open`, never staged through `copyToLocalFile`, and that
+  /// every stream handed to the consumer was closed.
+  private static void assertStreamedAndClosed() {
+    assertEquals(ClasspathPinotFS.getCopyToLocalFileCount(), 0,
+        "Descriptor must be streamed, not copied to a local temporary file");
+    assertEquals(ClasspathPinotFS.getOpenCount(), 1, "Descriptor should be opened exactly once");
+    assertEquals(ClasspathPinotFS.getClosedCount(), ClasspathPinotFS.getOpenCount(),
+        "Every opened descriptor stream must be closed");
+  }
+
+  /// PinotFS that serves classpath resources and records how it was used. Counters are static because
+  /// [PinotFSFactory] instantiates and wraps the filesystem itself, leaving no handle on the instance.
+  public static class ClasspathPinotFS extends LocalPinotFS {
+    private static final AtomicInteger OPEN_COUNT = new AtomicInteger();
+    private static final AtomicInteger CLOSED_COUNT = new AtomicInteger();
+    private static final AtomicInteger COPY_TO_LOCAL_FILE_COUNT = new AtomicInteger();
+
+    static void reset() {
+      OPEN_COUNT.set(0);
+      CLOSED_COUNT.set(0);
+      COPY_TO_LOCAL_FILE_COUNT.set(0);
+    }
+
+    static int getOpenCount() {
+      return OPEN_COUNT.get();
+    }
+
+    static int getClosedCount() {
+      return CLOSED_COUNT.get();
+    }
+
+    static int getCopyToLocalFileCount() {
+      return COPY_TO_LOCAL_FILE_COUNT.get();
+    }
+
+    @Override
+    public InputStream open(URI uri)
+        throws IOException {
+      OPEN_COUNT.incrementAndGet();
+      return new FilterInputStream(openResource(uri)) {
+        private boolean _closed;
+
+        /// Counts at most once per stream: protobuf parsing closes the stream it consumes, and the caller's
+        /// try-with-resources closes it again. Both are correct; the assertion cares that it was closed at all.
+        @Override
+        public void close()
+            throws IOException {
+          if (!_closed) {
+            _closed = true;
+            CLOSED_COUNT.incrementAndGet();
+          }
+          super.close();
+        }
+      };
+    }
+
+    @Override
+    public void copyToLocalFile(URI srcUri, File dstFile)
+        throws Exception {
+      COPY_TO_LOCAL_FILE_COUNT.incrementAndGet();
+      try (InputStream in = openResource(srcUri)) {
+        FileUtils.copyInputStreamToFile(in, dstFile);
+      }
+    }
+
+    private static InputStream openResource(URI uri)
+        throws IOException {
+      String name = new File(uri.getPath()).getName();
+      InputStream in = ClasspathPinotFS.class.getClassLoader().getResourceAsStream(name);
+      if (in == null) {
+        throw new IOException("Classpath resource not found: " + name);
+      }
+      return in;
+    }
+  }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Fixed descriptor leak by streaming via PinotFS and closing with try\-with\-resources in MessageDecoder and RecordReader\.

```mermaid
flowchart TD
  N0["MessageDecoder#46;init#58; try block #40;F1#41;"]:::stModified
  N1["RecordReader#46;init#58; try block #40;F2#41;"]:::stModified
  N2["openDescriptorFile #40;F3#41;"]:::stAdded
  N3["PinotFSFactory#46;create #40;F3#41;"]:::stModified
  N4["PinotFS#46;open #40;F3#41;"]:::stModified
  N5["Descriptor InputStream #40;F3#41;"]:::stModified
  N0 -->|"calls"| N2
  N1 -->|"calls"| N2
  N2 -->|"calls"| N3
  N3 -->|"uses result to call"| N4
  N4 -->|"returns"| N5
  N5 -->|"used in"| N0
  N5 -->|"used in"| N1
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-plugins/pinot\-input\-format/pinot\-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoder\.java — [before](https://github.com/apache/pinot/blob/b916e5474c95fa07b20ee385d8067677c285e01f/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoder.java) · [after](https://github.com/apache/pinot/blob/09215d3d9125e325d0ce722e95ec039b59facb7b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoder.java)
- F2: pinot\-plugins/pinot\-input\-format/pinot\-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordReader\.java — [before](https://github.com/apache/pinot/blob/b916e5474c95fa07b20ee385d8067677c285e01f/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordReader.java) · [after](https://github.com/apache/pinot/blob/09215d3d9125e325d0ce722e95ec039b59facb7b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordReader.java)
- F3: pinot\-plugins/pinot\-input\-format/pinot\-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufUtils\.java — [before](https://github.com/apache/pinot/blob/b916e5474c95fa07b20ee385d8067677c285e01f/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufUtils.java) · [after](https://github.com/apache/pinot/blob/09215d3d9125e325d0ce722e95ec039b59facb7b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufUtils.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImI5MTZlNTQ3NGM5NWZhMDdiMjBlZTM4NWQ4MDY3Njc3YzI4NWUwMWYiLCJjb250ZXh0X2hhc2giOiJlMzE4MGRkMTMyNzk4YzhlNjQ1MzY3MGUzNzYxMDMzNzdiNDE0Njc1NzdjNjJiOWViYjEyNjY0M2U3ZjFlMWVkIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MjYxNjcxLCJoZWFkX3NoYSI6IjA5MjE1ZDNkOTEyNWUzMjVkMGNlNzIyZTk1ZWMwMzliNTlmYWNiN2IiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJiOTE2ZTU0NzRjOTVmYTA3YjIwZWUzODVkODA2NzY3N2MyODVlMDFmIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature b4203155f58a08d72f9e0e25e01e77376bef31858b3b0f4ce8fbe52d59fd9028 -->
<!-- pinot-pr-flow:end -->

## Problem

`ProtoBufUtils.getDescriptorFileInputStream()` copied the descriptor file to a temporary directory (prefix `pinot-protobuf`) via `getFileCopiedToLocal()` and wrapped it in a `FileInputStream`. Neither was ever released, so every `ProtoBufMessageDecoder.init()` and `ProtoBufRecordReader.init()` leaked one directory under `java.io.tmpdir` plus one open file descriptor.

## Fix

Replaced it with `openDescriptorFile()`, which resolves the scheme and returns `PinotFS.open(uri)` directly. No local copy is made, and local `file://` URIs go through `LocalPinotFS.open()` just the same. Both callers now read the descriptor inside try-with-resources, so the stream is closed once parsing completes.

The change is three files:

| File | Change |
|---|---|
| `ProtoBufUtils` | `getDescriptorFileInputStream()` → `openDescriptorFile()` (streams via `PinotFS.open`, no temp file) |
| `ProtoBufMessageDecoder` | Call site only; opens in try-with-resources |
| `ProtoBufRecordReader` | Call site only; existing `try` became try-with-resources |

Exception handling in both callers is unchanged from master.

## Backward incompatibility

The public method `ProtoBufUtils.getDescriptorFileInputStream(String)` is **removed**. It has been public since 0.12.0, but its entire body was the leak being fixed here:

```java
return new FileInputStream(getFileCopiedToLocal(descriptorFilePath));
```

It could not be preserved without preserving the undeleted temp directory and the unclosed stream, so there is no compatible way to keep it. Both in-tree callers (`ProtoBufMessageDecoder`, `ProtoBufRecordReader`) are updated in this PR; a repo-wide search finds no other reference, in this module or any other.

**Replacement**: `ProtoBufUtils.openDescriptorFile(String)`, same parameter and return type, but the stream comes from `PinotFS.open()` with no local copy. Out-of-tree callers should switch to it and close the returned stream — note it no longer leaves a temp file behind, so any caller that relied on the file persisting will need to use `getFileCopiedToLocal` explicitly.

## Not in scope

`ProtoBufCodeGenMessageDecoder` passes its JAR through `getFileCopiedToLocal()`, which still creates a per-decoder temp directory that nothing deletes. Fixing that properly requires an owned classloader/segment lifecycle or a JAR cache keyed by URI and version — `StreamMessageDecoder` has no `Closeable` hook, so there is no place to release it on segment offload. Per review discussion that is left to a follow-up, keeping this PR a small and complete fix for the descriptor path.

## Testing

Added `ProtoBufTempFileLeakTest`. It registers a `ClasspathPinotFS` under a custom scheme so both consumers are configured with a remote (non-`file:`) descriptor URI and actually exercise the `PinotFS` path. The fake filesystem counts `open()` / `copyToLocalFile()` calls and tracks stream closure, so assertions read the real filesystem interactions instead of scanning the shared `java.io.tmpdir` — which races with any other test creating directories under the same prefix.

| Test | Asserts |
|---|---|
| `testMessageDecoderInitStreamsDescriptorWithoutLocalCopy` | `copyToLocalFile` never called, descriptor opened once, stream closed, record decodes |
| `testRecordReaderInitStreamsDescriptorWithoutLocalCopy` | same, across the full reader lifecycle |

Both tests fail against the pre-fix code (`copyToLocalFile` count 1). The record reader test was additionally verified by mutation — removing its try-with-resources fails the close assertion. The decoder's stream is also closed by `DynamicSchema.parseFrom`, so that assertion confirms the stream is closed after `init` returns rather than attributing the close to the try-with-resources block.

Full module suite: 169/169 tests pass.
