### PR TITLE
Budget-aware low disk mode table rebalance

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -337,13 +337,20 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
     // cannot progress at all within those bounds it relaxes them for a step rather than stalling. Replay the rebalance
     // to find out whether it has to, instead of assuming lowDiskMode always avoids the transient usage
     Map<String, Long> serversForcedOverBudget = getServersForcedOverDiskBudget(preCheckContext);
+    String unsafeDuringRebalance =
+        getUnsafeDiskUtilizationMessage("DURING rebalance", serversUnsafeDuringRebalance, threshold);
+    if (serversForcedOverBudget == null) {
+      // The replay could not be finished due to exception or step limit, so nothing was established. This is expected
+      // to be rare.
+      return RebalancePreCheckerResult.error(unsafeDuringRebalance + ". Whether lowDiskMode can avoid it for this "
+          + "target assignment could not be established, see the controller log. Treat the transient disk usage above "
+          + "as unsafe");
+    }
     if (!serversForcedOverBudget.isEmpty()) {
-      return RebalancePreCheckerResult.error(
-          getUnsafeDiskUtilizationMessage("DURING rebalance", serversUnsafeDuringRebalance, threshold)
-              + ". lowDiskMode cannot avoid it for this target assignment: the rebalance cannot make progress without "
-              + "going over the disk these servers start with, by up to " + formatBytesOverBudget(
-              serversForcedOverBudget) + ". Rebalance to a target assignment that frees up space on them first, or "
-              + "add capacity");
+      return RebalancePreCheckerResult.error(unsafeDuringRebalance
+          + ". lowDiskMode cannot avoid it for this target assignment: the rebalance cannot make progress without "
+          + "going over the disk these servers start with, by up to " + formatBytesOverBudget(serversForcedOverBudget)
+          + ". Rebalance to a target assignment that frees up space on them first, or add capacity");
     }
     return RebalancePreCheckerResult.pass(withinThreshold + " AFTER rebalance." + serversGoingOver + " lowDiskMode "
         + "avoids that transient disk usage by deleting segments before adding the new ones");
@@ -359,6 +366,7 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
   /// because the argument does not cover every later step, and going over a server's disk silently is worse than
   /// reporting a rebalance as unsafe.
   @VisibleForTesting
+  @Nullable
   protected Map<String, Long> getServersForcedOverDiskBudget(PreCheckContext preCheckContext) {
     Map<String, Map<String, String>> currentAssignment = preCheckContext.getCurrentAssignment();
     Map<String, Map<String, String>> targetAssignment = preCheckContext.getTargetAssignment();
@@ -370,7 +378,7 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
     int minAvailableReplicas = TableRebalancer.getMinAvailableReplicas(currentAssignment, targetAssignment,
         segmentsToMove, rebalanceConfig.getMinAvailableReplicas(), tableRebalanceLogger);
     if (minAvailableReplicas == TableRebalancer.ILLEGAL_MIN_AVAILABLE_REPLICAS) {
-      // The rebalance is going to fail on the config before it moves anything
+      // The rebalance is going to fail on the config before it moves anything, so the disk it would use is moot
       return Map.of();
     }
     boolean enableStrictReplicaGroup = tableConfig.getRoutingConfig() != null

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -17,6 +17,7 @@
  * under the License.
  */
 package org.apache.pinot.controller.helix.core.rebalance;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.pinot.common.assignment.InstanceAssignmentConfigUtils;
@@ -36,12 +38,14 @@ import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentUtils;
 import org.apache.pinot.controller.util.TableSizeReader;
 import org.apache.pinot.controller.validation.ResourceUtilizationInfo;
+import org.apache.pinot.spi.config.table.RoutingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TierConfig;
 import org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.config.table.assignment.InstanceReplicaGroupPartitionConfig;
+import org.apache.pinot.spi.utils.DataSizeUtils;
 import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.StringUtil;
 import org.slf4j.Logger;
@@ -329,8 +333,60 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
     }
     String serversGoingOver = " Servers that would go over it DURING the rebalance: " + String.join(", ",
         serversUnsafeDuringRebalance) + ".";
+    // lowDiskMode bounds the disk each server takes on to what it starts the rebalance with, but when the rebalance
+    // cannot progress at all within those bounds it relaxes them for a step rather than stalling. Replay the rebalance
+    // to find out whether it has to, instead of assuming lowDiskMode always avoids the transient usage
+    Map<String, Long> serversForcedOverBudget = getServersForcedOverDiskBudget(preCheckContext);
+    if (!serversForcedOverBudget.isEmpty()) {
+      return RebalancePreCheckerResult.error(
+          getUnsafeDiskUtilizationMessage("DURING rebalance", serversUnsafeDuringRebalance, threshold)
+              + ". lowDiskMode cannot avoid it for this target assignment: the rebalance cannot make progress without "
+              + "going over the disk these servers start with, by up to " + formatBytesOverBudget(
+              serversForcedOverBudget) + ". Rebalance to a target assignment that frees up space on them first, or "
+              + "add capacity");
+    }
     return RebalancePreCheckerResult.pass(withinThreshold + " AFTER rebalance." + serversGoingOver + " lowDiskMode "
         + "avoids that transient disk usage by deleting segments before adding the new ones");
+  }
+
+  /// Replays the rebalance to find the servers that lowDiskMode cannot keep within the disk they start with. Returns
+  /// an empty map when the replay cannot be run, so that a missing input never turns into a failed pre-check.
+  ///
+  /// No reachable rebalance has been found that ends up here with a non-empty result: at the first step a server is
+  /// only at its ceiling when the target assignment places no more on it than it already hosts, and a rebalance that
+  /// stalls needs every segment to be waiting to gain a replica, which means the target places more in total than the
+  /// current assignment does, so at least one server has room. This is kept as a guard rather than as an assertion
+  /// because the argument does not cover every later step, and going over a server's disk silently is worse than
+  /// reporting a rebalance as unsafe.
+  @VisibleForTesting
+  protected Map<String, Long> getServersForcedOverDiskBudget(PreCheckContext preCheckContext) {
+    Map<String, Map<String, String>> currentAssignment = preCheckContext.getCurrentAssignment();
+    Map<String, Map<String, String>> targetAssignment = preCheckContext.getTargetAssignment();
+    TableConfig tableConfig = preCheckContext.getTableConfig();
+    RebalanceConfig rebalanceConfig = preCheckContext.getRebalanceConfig();
+    Logger tableRebalanceLogger = LoggerFactory.getLogger(getClass().getSimpleName() + '-'
+        + preCheckContext.getTableNameWithType() + '-' + preCheckContext.getRebalanceJobId());
+    List<String> segmentsToMove = SegmentAssignmentUtils.getSegmentsToMove(currentAssignment, targetAssignment);
+    int minAvailableReplicas = TableRebalancer.getMinAvailableReplicas(currentAssignment, targetAssignment,
+        segmentsToMove, rebalanceConfig.getMinAvailableReplicas(), tableRebalanceLogger);
+    if (minAvailableReplicas == TableRebalancer.ILLEGAL_MIN_AVAILABLE_REPLICAS) {
+      // The rebalance is going to fail on the config before it moves anything
+      return Map.of();
+    }
+    boolean enableStrictReplicaGroup = tableConfig.getRoutingConfig() != null
+        && RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE.equalsIgnoreCase(
+        tableConfig.getRoutingConfig().getInstanceSelectorType());
+    return TableRebalancer.getServersForcedOverDiskBudget(currentAssignment, targetAssignment, minAvailableReplicas,
+        enableStrictReplicaGroup, rebalanceConfig.getBatchSizePerServer(),
+        preCheckContext.getTableSubTypeSizeDetails(), tableRebalanceLogger);
+  }
+
+  /// Renders the servers and how far over their disk they would be pushed, largest first.
+  private static String formatBytesOverBudget(Map<String, Long> serverToBytesOverBudget) {
+    return serverToBytesOverBudget.entrySet().stream()
+        .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+        .map(entry -> entry.getKey() + " (" + DataSizeUtils.fromBytes(entry.getValue()) + ")")
+        .collect(Collectors.joining(", "));
   }
 
   private static void addIfOverThreshold(List<String> servers, String server, double utilizationRatio,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -1902,20 +1902,16 @@ public class TableRebalancer {
     ///
     /// The instances that do not fit are kept at the back rather than dropped, so that an assignment is still produced
     /// when none of them fits and the budget stays the only thing that decides whether it is applied.
-    List<Triple<String, String, Integer>> sortInstancesThatFitFirst(
+    List<Triple<String, String, Integer>> retainInstancesThatFit(
         List<Triple<String, String, Integer>> instancesInfo, Set<String> currentInstances,
         Set<String> targetInstances) {
       long requiredBytes = _instancePairToRequiredBytes.getOrDefault(Pair.of(currentInstances, targetInstances), 0L);
       List<Triple<String, String, Integer>> fits = new ArrayList<>(instancesInfo.size());
-      List<Triple<String, String, Integer>> doesNotFit = new ArrayList<>();
       for (Triple<String, String, Integer> instanceInfo : instancesInfo) {
         if (_remainingBytes.getOrDefault(instanceInfo.getLeft(), 0L) >= requiredBytes) {
           fits.add(instanceInfo);
-        } else {
-          doesNotFit.add(instanceInfo);
         }
       }
-      fits.addAll(doesNotFit);
       return fits;
     }
 
@@ -2564,8 +2560,12 @@ public class TableRebalancer {
             getSortedInstancesOnNumSegmentsToOffload(targetInstanceStateMap, nextInstanceStateMap,
                 numSegmentsToOffloadMap);
         if (stepBudget != null) {
-          // sort so that if there are instances with enough disk budget, they'll be picked
-          instancesInfo = stepBudget.sortInstancesThatFitFirst(instancesInfo, currentInstances, targetInstances);
+          // Keep only the instances with enough disk budget. Adding one without it would have the whole group of
+          // segments rejected when it is charged, holding back the instances that could have taken them in this step
+          instancesInfo = stepBudget.retainInstancesThatFit(instancesInfo, currentInstances, targetInstances);
+          // Fewer instances than the target assignment has is fine: the segments gain the rest in a later step, once
+          // the instances that are out of space have dropped what they owe
+          numInstancesToAdd = Math.min(numInstancesToAdd, instancesInfo.size());
         }
         for (int i = 0; i < numInstancesToAdd; i++) {
           Triple<String, String, Integer> instanceInfo = instancesInfo.get(i);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -592,6 +592,12 @@ public class TableRebalancer {
     //
     // NOTE: Monitor the segments to be moved from both the previous round and this round to ensure the moved segments
     //       in the previous round are also converged.
+    // Anchor the per-server disk ceiling to the assignment the rebalance starts from, before the first step runs. The
+    // step loop can recalculate the target assignment, so the ceiling itself is derived per step from this anchor and
+    // the target of that step.
+    DiskUsageBudget diskUsageBudget =
+        lowDiskMode ? DiskUsageBudget.create(currentAssignment, tableSubTypeSizeDetails) : null;
+
     List<String> oldSegmentsToMove = segmentsToMove;
     while (true) {
       boolean segmentsToMoveChanged = oldSegmentsToMove != segmentsToMove;
@@ -710,7 +716,7 @@ public class TableRebalancer {
             nextAssignment =
                 getNextAssignment(currentAssignment, targetAssignment, minAvailableReplicas, enableStrictReplicaGroup,
                     lowDiskMode, batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor,
-                    tableRebalanceLogger);
+                    tableRebalanceLogger, diskUsageBudget);
           } catch (Exception e) {
             String errorMsg =
                 "Caught exception while calculating the next assignment, aborting the rebalance: " + e.getMessage();
@@ -775,7 +781,7 @@ public class TableRebalancer {
         nextAssignment =
             getNextAssignment(currentAssignment, targetAssignment, minAvailableReplicas, enableStrictReplicaGroup,
                 lowDiskMode, batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor,
-                tableRebalanceLogger);
+                tableRebalanceLogger, diskUsageBudget);
       } catch (Exception e) {
         String errorMsg =
             "Caught exception while calculating the next assignment, aborting the rebalance: " + e.getMessage();
@@ -1662,7 +1668,20 @@ public class TableRebalancer {
       boolean lowDiskMode, int batchSizePerServer, Object2IntOpenHashMap<String> segmentPartitionIdMap,
       PartitionIdFetcher partitionIdFetcher, DataLossRiskAssessor dataLossRiskAssessor) {
     return getNextAssignment(currentAssignment, targetAssignment, minAvailableReplicas, enableStrictReplicaGroup,
-        lowDiskMode, batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor, LOGGER);
+        lowDiskMode, batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor, LOGGER,
+        null);
+  }
+
+  /// Uses the default LOGGER, with an explicit disk usage budget
+  @VisibleForTesting
+  static Map<String, Map<String, String>> getNextAssignment(Map<String, Map<String, String>> currentAssignment,
+      Map<String, Map<String, String>> targetAssignment, int minAvailableReplicas, boolean enableStrictReplicaGroup,
+      boolean lowDiskMode, int batchSizePerServer, Object2IntOpenHashMap<String> segmentPartitionIdMap,
+      PartitionIdFetcher partitionIdFetcher, DataLossRiskAssessor dataLossRiskAssessor,
+      @Nullable DiskUsageBudget diskUsageBudget) {
+    return getNextAssignment(currentAssignment, targetAssignment, minAvailableReplicas, enableStrictReplicaGroup,
+        lowDiskMode, batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor, LOGGER,
+        diskUsageBudget);
   }
 
   /// Returns the next assignment for the table based on the current assignment and the target assignment with regard to
@@ -1687,19 +1706,188 @@ public class TableRebalancer {
   private static Map<String, Map<String, String>> getNextAssignment(Map<String, Map<String, String>> currentAssignment,
       Map<String, Map<String, String>> targetAssignment, int minAvailableReplicas, boolean enableStrictReplicaGroup,
       boolean lowDiskMode, int batchSizePerServer, Object2IntOpenHashMap<String> segmentPartitionIdMap,
-      PartitionIdFetcher partitionIdFetcher, DataLossRiskAssessor dataLossRiskAssessor, Logger tableRebalanceLogger) {
+      PartitionIdFetcher partitionIdFetcher, DataLossRiskAssessor dataLossRiskAssessor, Logger tableRebalanceLogger,
+      @Nullable DiskUsageBudget diskUsageBudget) {
+    if (!lowDiskMode) {
+      return computeNextAssignment(currentAssignment, targetAssignment, minAvailableReplicas, enableStrictReplicaGroup,
+          false, batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor,
+          tableRebalanceLogger, null);
+    }
+
+    // We use DiskUsageBudget and StepDiskBudget here to keep track of per-server byte gain/loss and to guarantee the
+    // invariant of lowDiskMode where each server won't get more bytes than its net gain at any intermediate steps.
+    DiskUsageBudget budget =
+        diskUsageBudget != null ? diskUsageBudget : DiskUsageBudget.create(currentAssignment, null);
+    StepDiskBudget stepBudget = budget.forStep(currentAssignment, targetAssignment);
+    Map<String, Map<String, String>> nextAssignment =
+        computeNextAssignment(currentAssignment, targetAssignment, minAvailableReplicas, enableStrictReplicaGroup, true,
+            batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor, tableRebalanceLogger,
+            stepBudget);
+    if (!nextAssignment.equals(currentAssignment)) {
+      return nextAssignment;
+    }
+
+    // Can't progress while respecting the budget. This could happen if servers circular wait for others to drop first.
+    tableRebalanceLogger.warn("Cannot make progress in low disk mode without exceeding the disk usage a server "
+            + "started the rebalance with. Allowing the additions for this step, which temporarily increases the disk "
+            + "usage of these servers. Bytes each server could still take on: {}", stepBudget.getRemainingBytes());
+    return computeNextAssignment(currentAssignment, targetAssignment, minAvailableReplicas, enableStrictReplicaGroup,
+        true, batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor,
+        tableRebalanceLogger, null);
+  }
+
+  /// @param stepBudget bounds the disk each server may take on in this step, `null` to apply no bound
+  private static Map<String, Map<String, String>> computeNextAssignment(
+      Map<String, Map<String, String>> currentAssignment, Map<String, Map<String, String>> targetAssignment,
+      int minAvailableReplicas, boolean enableStrictReplicaGroup, boolean lowDiskMode, int batchSizePerServer,
+      Object2IntOpenHashMap<String> segmentPartitionIdMap, PartitionIdFetcher partitionIdFetcher,
+      DataLossRiskAssessor dataLossRiskAssessor, Logger tableRebalanceLogger,
+      @Nullable StepDiskBudget stepBudget) {
     return enableStrictReplicaGroup
         ? getNextStrictReplicaGroupAssignment(currentAssignment, targetAssignment, minAvailableReplicas, lowDiskMode,
-        batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor, tableRebalanceLogger)
+        batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor, tableRebalanceLogger,
+        stepBudget)
         : getNextNonStrictReplicaGroupAssignment(currentAssignment, targetAssignment, minAvailableReplicas,
-            lowDiskMode, batchSizePerServer, dataLossRiskAssessor);
+            lowDiskMode, batchSizePerServer, dataLossRiskAssessor, stepBudget);
+  }
+
+  /// Bounds the disk a server may use while a low disk mode rebalance is in flight.
+  ///
+  /// The ceiling for a server is `max(bytes it hosted when the rebalance started, bytes the target assignment places
+  /// on it)`, so a server whose net change is an increase may grow up to its final size and no further, and a server
+  /// whose net change is a decrease never goes above what it started with. Segments dropped in a step never fund
+  /// additions in that same step, since there is no guarantee that a server processes the drop before the addition.
+  ///
+  /// Anchoring `initialServerBytes` at the start of the rebalance is what makes this a bound rather than a ratchet -
+  /// deriving it from the assignment of the step in progress would let the ceiling climb every time it was exceeded.
+  /// Re-deriving it from a partially rebalanced assignment (a retried rebalance job, say) is still safe, because a
+  /// rebalance that respected the ceiling leaves every server at or below it, so the re-derived ceiling can only be
+  /// tighter.
+  ///
+  /// When no per-segment size is known every segment counts as one byte, which degenerates to bounding the number of
+  /// segments hosted rather than the bytes.
+  @VisibleForTesting
+  static class DiskUsageBudget {
+    private final Map<String, Long> _segmentSizeBytes;
+    private final long _defaultSegmentSizeBytes;
+    private final Map<String, Long> _initialServerBytes;
+
+    private DiskUsageBudget(Map<String, Long> segmentSizeBytes, long defaultSegmentSizeBytes,
+        Map<String, Long> initialServerBytes) {
+      _segmentSizeBytes = segmentSizeBytes;
+      _defaultSegmentSizeBytes = defaultSegmentSizeBytes;
+      _initialServerBytes = initialServerBytes;
+    }
+
+    /// @param initialAssignment the assignment the rebalance starts from, used to anchor the per-server ceiling
+    /// @param tableSizeDetails per-segment sizes, `null` to fall back to counting segments instead of bytes
+    static DiskUsageBudget create(Map<String, Map<String, String>> initialAssignment,
+        @Nullable TableSizeReader.TableSubTypeSizeDetails tableSizeDetails) {
+      Map<String, Long> segmentSizeBytes = new HashMap<>();
+      long totalKnownBytes = 0;
+      if (tableSizeDetails != null) {
+        for (Map.Entry<String, TableSizeReader.SegmentSizeDetails> entry : tableSizeDetails._segments.entrySet()) {
+          // The size a single replica takes up on disk, which is what one server pays for hosting the segment
+          long sizeBytes = entry.getValue()._maxReportedSizePerReplicaInBytes;
+          if (sizeBytes > 0) {
+            segmentSizeBytes.put(entry.getKey(), sizeBytes);
+            totalKnownBytes += sizeBytes;
+          }
+        }
+      }
+      // Segments whose size could not be read (missing from all servers, or still consuming) are charged the average
+      // size of the segments that could be read
+      long defaultSegmentSizeBytes =
+          segmentSizeBytes.isEmpty() ? 1L : Math.max(1L, totalKnownBytes / segmentSizeBytes.size());
+      Map<String, Long> initialServerBytes = new HashMap<>();
+      for (Map.Entry<String, Map<String, String>> entry : initialAssignment.entrySet()) {
+        long sizeBytes = segmentSizeBytes.getOrDefault(entry.getKey(), defaultSegmentSizeBytes);
+        for (String instance : entry.getValue().keySet()) {
+          initialServerBytes.merge(instance, sizeBytes, Long::sum);
+        }
+      }
+      return new DiskUsageBudget(segmentSizeBytes, defaultSegmentSizeBytes, initialServerBytes);
+    }
+
+    long getSegmentSizeBytes(String segmentName) {
+      return _segmentSizeBytes.getOrDefault(segmentName, _defaultSegmentSizeBytes);
+    }
+
+    Map<String, Long> getServerToHostedBytes(Map<String, Map<String, String>> assignment) {
+      Map<String, Long> serverToHostedBytes = new HashMap<>();
+      for (Map.Entry<String, Map<String, String>> entry : assignment.entrySet()) {
+        long sizeBytes = getSegmentSizeBytes(entry.getKey());
+        for (String instance : entry.getValue().keySet()) {
+          serverToHostedBytes.merge(instance, sizeBytes, Long::sum);
+        }
+      }
+      return serverToHostedBytes;
+    }
+
+    /// Returns the bytes each server may still take on in this step, i.e. `ceiling - currently hosted`.
+    StepDiskBudget forStep(Map<String, Map<String, String>> currentAssignment,
+        Map<String, Map<String, String>> targetAssignment) {
+      Map<String, Long> hostedBytes = getServerToHostedBytes(currentAssignment);
+      Map<String, Long> targetBytes = getServerToHostedBytes(targetAssignment);
+      Set<String> servers = new HashSet<>(_initialServerBytes.keySet());
+      servers.addAll(hostedBytes.keySet());
+      servers.addAll(targetBytes.keySet());
+      Map<String, Long> remainingBytes = new HashMap<>();
+      for (String server : servers) {
+        long ceilingBytes =
+            Math.max(_initialServerBytes.getOrDefault(server, 0L), targetBytes.getOrDefault(server, 0L));
+        remainingBytes.put(server, Math.max(0L, ceilingBytes - hostedBytes.getOrDefault(server, 0L)));
+      }
+      return new StepDiskBudget(this, remainingBytes);
+    }
+  }
+
+  /// The [DiskUsageBudget] left for a single rebalance step, drawn down as segments are assigned.
+  @VisibleForTesting
+  static class StepDiskBudget {
+    private final DiskUsageBudget _budget;
+    private final Map<String, Long> _remainingBytes;
+
+    private StepDiskBudget(DiskUsageBudget budget, Map<String, Long> remainingBytes) {
+      _budget = budget;
+      _remainingBytes = remainingBytes;
+    }
+
+    Map<String, Long> getRemainingBytes() {
+      return _remainingBytes;
+    }
+
+    long getSegmentSizeBytes(String segmentName) {
+      return _budget.getSegmentSizeBytes(segmentName);
+    }
+
+    /// Charges every server in `serversAdded` for hosting `segmentName`, and returns whether all of them had the
+    /// space for it. Nothing is charged when any one of them did not, so the segment can be left where it is.
+    boolean tryCharge(Set<String> serversAdded, String segmentName) {
+      return tryCharge(serversAdded, getSegmentSizeBytes(segmentName));
+    }
+
+    /// Charges every server in `serversAdded` `sizeBytes`, and returns whether all of them had the space for it.
+    /// Nothing is charged when any one of them did not, so the segments can be left where they are.
+    boolean tryCharge(Set<String> serversAdded, long sizeBytes) {
+      for (String server : serversAdded) {
+        if (_remainingBytes.getOrDefault(server, 0L) < sizeBytes) {
+          return false;
+        }
+      }
+      for (String server : serversAdded) {
+        _remainingBytes.merge(server, -sizeBytes, Long::sum);
+      }
+      return true;
+    }
   }
 
   private static Map<String, Map<String, String>> getNextStrictReplicaGroupAssignment(
       Map<String, Map<String, String>> currentAssignment, Map<String, Map<String, String>> targetAssignment,
       int minAvailableReplicas, boolean lowDiskMode, int batchSizePerServer,
       Object2IntOpenHashMap<String> segmentPartitionIdMap, PartitionIdFetcher partitionIdFetcher,
-      DataLossRiskAssessor dataLossRiskAssessor, Logger tableRebalanceLogger) {
+      DataLossRiskAssessor dataLossRiskAssessor, Logger tableRebalanceLogger,
+      @Nullable StepDiskBudget stepBudget) {
     Map<String, Map<String, String>> nextAssignment = new TreeMap<>();
     Map<String, Integer> numSegmentsToOffloadMap = getNumSegmentsToOffloadMap(currentAssignment, targetAssignment);
     Map<Pair<Set<String>, Set<String>>, Set<String>> assignmentMap = new HashMap<>();
@@ -1710,7 +1898,7 @@ public class TableRebalancer {
       // Directly update the nextAssignment with anyServerExhaustedBatchSize = false and return if batching is disabled
       updateNextAssignmentForPartitionIdStrictReplicaGroup(currentAssignment, targetAssignment, nextAssignment,
           false, minAvailableReplicas, lowDiskMode, numSegmentsToOffloadMap, assignmentMap,
-          availableInstancesMap, serverToNumSegmentsAddedSoFar, dataLossRiskAssessor);
+          availableInstancesMap, serverToNumSegmentsAddedSoFar, dataLossRiskAssessor, stepBudget);
       return nextAssignment;
     }
 
@@ -1755,7 +1943,7 @@ public class TableRebalancer {
         }
         updateNextAssignmentForPartitionIdStrictReplicaGroup(curAssignment, targetAssignment, nextAssignment,
             anyServerExhaustedBatchSize, minAvailableReplicas, lowDiskMode, numSegmentsToOffloadMap, assignmentMap,
-            availableInstancesMap, serverToNumSegmentsAddedSoFar, dataLossRiskAssessor);
+            availableInstancesMap, serverToNumSegmentsAddedSoFar, dataLossRiskAssessor, stepBudget);
       }
     }
 
@@ -1770,11 +1958,24 @@ public class TableRebalancer {
       boolean lowDiskMode, Map<String, Integer> numSegmentsToOffloadMap,
       Map<Pair<Set<String>, Set<String>>, Set<String>> assignmentMap,
       Map<Set<String>, Set<String>> availableInstancesMap, Map<String, Integer> serverToNumSegmentsAddedSoFar,
-      DataLossRiskAssessor dataLossRiskAssessor) {
+      DataLossRiskAssessor dataLossRiskAssessor, @Nullable StepDiskBudget stepBudget) {
     if (anyServerExhaustedBatchSize) {
       // Exhausted the batch size for at least 1 server, just copy over the remaining segments as is
       nextAssignment.putAll(currentAssignment);
     } else {
+      // Total size of each group of segments that share the same current and target instances, needed to charge the
+      // disk budget for a group as a whole. Computed up front so that the first segment of a group already knows how
+      // much space the whole group needs.
+      Map<Pair<Set<String>, Set<String>>, Long> groupToSizeBytes = new HashMap<>();
+      Map<Pair<Set<String>, Set<String>>, Boolean> groupToFitsDisk = new HashMap<>();
+      if (stepBudget != null) {
+        for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
+          groupToSizeBytes.merge(
+              Pair.of(entry.getValue().keySet(), targetAssignment.get(entry.getKey()).keySet()),
+              stepBudget.getSegmentSizeBytes(entry.getKey()), Long::sum);
+        }
+      }
+
       // Process all the partitionIds even if segmentsAddedSoFar becomes larger than batchSizePerServer
       // Can only do bestEfforts w.r.t. StrictReplicaGroup since a whole partition must be moved together for
       // maintaining consistency
@@ -1787,6 +1988,26 @@ public class TableRebalancer {
                 lowDiskMode, numSegmentsToOffloadMap, assignmentMap);
         Set<String> assignedInstances = assignment._instanceStateMap.keySet();
         Set<String> availableInstances = assignment._availableInstances;
+        // Strict replica group routing requires every segment that shares the same current and target instances to
+        // move together, so the disk budget has to be charged for such a group as a whole. The disk budget constraint
+        // makes the entire group either all move or all stay
+        if (stepBudget != null) {
+          Pair<Set<String>, Set<String>> group =
+              Pair.of(currentInstanceStateMap.keySet(), targetInstanceStateMap.keySet());
+          Boolean groupFitsDisk = groupToFitsDisk.get(group);
+          if (groupFitsDisk == null) {
+            Set<String> serversAdded =
+                getServersAddedInSingleSegmentAssignment(currentInstanceStateMap, assignment._instanceStateMap);
+            groupFitsDisk =
+                serversAdded.isEmpty() || stepBudget.tryCharge(serversAdded, groupToSizeBytes.getOrDefault(group, 0L));
+            groupToFitsDisk.put(group, groupFitsDisk);
+          }
+          if (!groupFitsDisk) {
+            // A later step picks the group up once the drops have freed up the space
+            nextAssignment.put(segmentName, currentInstanceStateMap);
+            continue;
+          }
+        }
         availableInstancesMap.compute(assignedInstances, (k, currentAvailableInstances) -> {
           if (currentAvailableInstances == null) {
             // First segment assigned to these instances, use the new assignment and update the available instances
@@ -1998,7 +2219,7 @@ public class TableRebalancer {
   private static Map<String, Map<String, String>> getNextNonStrictReplicaGroupAssignment(
       Map<String, Map<String, String>> currentAssignment, Map<String, Map<String, String>> targetAssignment,
       int minAvailableReplicas, boolean lowDiskMode, int batchSizePerServer,
-      DataLossRiskAssessor dataLossRiskAssessor) {
+      DataLossRiskAssessor dataLossRiskAssessor, @Nullable StepDiskBudget stepBudget) {
     Map<String, Integer> serverToNumSegmentsAddedSoFar = new HashMap<>();
     Map<String, Map<String, String>> nextAssignment = new TreeMap<>();
     Map<String, Integer> numSegmentsToOffloadMap = getNumSegmentsToOffloadMap(currentAssignment, targetAssignment);
@@ -2021,8 +2242,14 @@ public class TableRebalancer {
           }
         }
       }
-      if (anyServerExhaustedBatchSize) {
-        // Exhausted the batch size for at least 1 server, set to existing assignment
+      // Leave the segment where it is when one of the servers it would be added to cannot take on its size without
+      // going over the disk it started the rebalance with. A later step picks it up once the drops have freed up the
+      // space. Note that tryCharge must not run once the batch size is known to be exhausted, as the segment is not
+      // going to be moved in that case.
+      boolean anyServerOutOfDisk = !anyServerExhaustedBatchSize && stepBudget != null
+          && !serversAddedForSegment.isEmpty() && !stepBudget.tryCharge(serversAddedForSegment, segmentName);
+      if (anyServerExhaustedBatchSize || anyServerOutOfDisk) {
+        // Exhausted the batch size or the disk budget for at least 1 server, set to existing assignment
         nextAssignment.put(segmentName, currentInstanceStateMap);
       } else {
         // Add the next assignment and update the segments added so far counts

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -2428,17 +2428,32 @@ public class TableRebalancer {
   /// so with `batchSizePerServer` enabled and strict replica group routing the segments are grouped more coarsely than
   /// the rebalance groups them, which changes the pacing of the moves but not the bounds themselves.
   ///
-  /// @return server to the most bytes it would be pushed over its bound by, empty when the rebalance can complete
-  ///         within the bound of every server
-  public static Map<String, Long> getServersForcedOverDiskBudget(Map<String, Map<String, String>> currentAssignment,
+  /// @return `null` when the replay could not be finished, which establishes nothing and must not be read as safe;
+  ///         an empty map when the rebalance was replayed to the target assignment inside every server's bound; and
+  ///         otherwise the servers that would be pushed over their bound, mapped to the bytes they would go over by
+  @Nullable
+  public static Map<String, Long> getServersForcedOverDiskBudget(
+      Map<String, Map<String, String>> currentAssignment, Map<String, Map<String, String>> targetAssignment,
+      int minAvailableReplicas, boolean enableStrictReplicaGroup, int batchSizePerServer,
+      @Nullable TableSizeReader.TableSubTypeSizeDetails tableSizeDetails, Logger tableRebalanceLogger) {
+    return getServersForcedOverDiskBudget(currentAssignment, targetAssignment, minAvailableReplicas,
+        enableStrictReplicaGroup, batchSizePerServer, tableSizeDetails, tableRebalanceLogger,
+        MAX_DISK_BUDGET_REPLAY_STEPS);
+  }
+
+  /// @param maxSteps how many steps to replay before giving up, so that the giving-up path can be tested without
+  ///                 building an assignment that genuinely needs tens of thousands of steps
+  @Nullable
+  @VisibleForTesting
+  static Map<String, Long> getServersForcedOverDiskBudget(Map<String, Map<String, String>> currentAssignment,
       Map<String, Map<String, String>> targetAssignment, int minAvailableReplicas, boolean enableStrictReplicaGroup,
       int batchSizePerServer, @Nullable TableSizeReader.TableSubTypeSizeDetails tableSizeDetails,
-      Logger tableRebalanceLogger) {
+      Logger tableRebalanceLogger, int maxSteps) {
     DiskUsageBudget diskUsageBudget = DiskUsageBudget.create(currentAssignment, tableSizeDetails);
     Object2IntOpenHashMap<String> segmentPartitionIdMap = new Object2IntOpenHashMap<>();
     Map<String, Long> serverToBytesOverBudget = new TreeMap<>();
     Map<String, Map<String, String>> assignment = currentAssignment;
-    for (int step = 1; step <= MAX_DISK_BUDGET_REPLAY_STEPS; step++) {
+    for (int step = 1; step <= maxSteps; step++) {
       if (assignment.equals(targetAssignment)) {
         return serverToBytesOverBudget;
       }
@@ -2450,12 +2465,14 @@ public class TableRebalancer {
                 batchSizePerServer, segmentPartitionIdMap, DEFAULT_PARTITION_ID_FETCHER, new NoOpRiskAssessor(),
                 tableRebalanceLogger, diskUsageBudget);
       } catch (Exception e) {
+        // What was found up to here is incomplete, so it cannot be reported as a rebalance that holds the bound
         tableRebalanceLogger.warn("Caught exception while replaying the rebalance to check the low disk mode disk "
-            + "usage, reporting what was found up to step {}", step, e);
-        return serverToBytesOverBudget;
+            + "usage at step {}, cannot tell whether the disk budget can be held", step, e);
+        return null;
       }
       if (nextAssignment.equals(assignment)) {
-        // The rebalance cannot progress at all, with or without the bounds. Nothing more to find
+        // The rebalance cannot progress at all, with or without the bounds, so there is nothing further to find and
+        // whatever was found so far is the whole answer
         return serverToBytesOverBudget;
       }
       getServerToAddedBytes(assignment, nextAssignment, diskUsageBudget).forEach((server, addedBytes) -> {
@@ -2466,9 +2483,9 @@ public class TableRebalancer {
       });
       assignment = nextAssignment;
     }
-    tableRebalanceLogger.warn("Gave up replaying the rebalance to check the low disk mode disk usage after {} steps",
-        MAX_DISK_BUDGET_REPLAY_STEPS);
-    return serverToBytesOverBudget;
+    tableRebalanceLogger.warn("Gave up replaying the rebalance to check the low disk mode disk usage after {} steps, "
+        + "cannot tell whether the disk budget can be held", maxSteps);
+    return null;
   }
 
   /// Returns the bytes each server is assigned on top of what it already hosts.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -143,6 +143,14 @@ public class TableRebalancer {
   private static final int TABLE_SIZE_READER_TIMEOUT_MS = 30_000;
   private static final int STREAM_PARTITION_OFFSET_READ_TIMEOUT_MS = 10_000;
   private static final AtomicInteger REBALANCE_JOB_COUNTER = new AtomicInteger(0);
+  /// Returned by [#getMinAvailableReplicas] when `minReplicasToKeepUpForNoDowntime` is not less than the replication
+  @VisibleForTesting
+  static final int ILLEGAL_MIN_AVAILABLE_REPLICAS = -1;
+  /// Backstop for [#getServersForcedOverDiskBudget]. Every step brings at least one segment replica closer to the
+  /// target assignment, so the replay terminates well within this on any real assignment
+  private static final int MAX_DISK_BUDGET_REPLAY_STEPS = 10_000;
+  /// Used by [#getServersForcedOverDiskBudget], which does not read the segment partition ids
+  private static final PartitionIdFetcher DEFAULT_PARTITION_ID_FETCHER = segmentName -> 0;
   private final HelixManager _helixManager;
   private final HelixDataAccessor _helixDataAccessor;
   private final TableRebalanceObserver _tableRebalanceObserver;
@@ -515,36 +523,15 @@ public class TableRebalancer {
     //    current instances as this is the best we can do, and can help the table get out of this state.
     // 2. Only check the segments to be moved because we don't need to maintain available replicas for segments not
     //    being moved, including segments with all replicas OFFLINE (error segments during consumption).
-    int numReplicas = Integer.MAX_VALUE;
-    for (String segment : segmentsToMove) {
-      numReplicas = Math.min(targetAssignment.get(segment).size(), numReplicas);
-    }
-    int minAvailableReplicas;
-    if (minReplicasToKeepUpForNoDowntime >= 0) {
-      // For non-negative value, use it as min available replicas
-      if (minReplicasToKeepUpForNoDowntime >= numReplicas) {
-        onReturnFailure("Illegal config for minReplicasToKeepUpForNoDowntime: " + minReplicasToKeepUpForNoDowntime
-                + ", must be less than number of replicas: " + numReplicas + ", aborting the rebalance", null,
-            tableRebalanceLogger);
-        return new RebalanceResult(rebalanceJobId, RebalanceResult.Status.FAILED,
-            "Illegal min available replicas config", instancePartitionsMap, tierToInstancePartitionsMap,
-            targetAssignment, preChecksResult, summaryResult);
-      }
-      minAvailableReplicas = minReplicasToKeepUpForNoDowntime;
-    } else {
-      // For negative value, use it as max unavailable replicas
-      minAvailableReplicas = Math.max(numReplicas + minReplicasToKeepUpForNoDowntime, 0);
-    }
-
-    int numCurrentAssignmentReplicas = Integer.MAX_VALUE;
-    for (String segment : segmentsToMove) {
-      numCurrentAssignmentReplicas = Math.min(currentAssignment.get(segment).size(), numCurrentAssignmentReplicas);
-    }
-    if (minAvailableReplicas > numCurrentAssignmentReplicas) {
-      tableRebalanceLogger.warn("minAvailableReplicas: {} larger than existing number of replicas: {}, "
-              + "resetting minAvailableReplicas to {}", minAvailableReplicas, numCurrentAssignmentReplicas,
-          numCurrentAssignmentReplicas);
-      minAvailableReplicas = numCurrentAssignmentReplicas;
+    int minAvailableReplicas = getMinAvailableReplicas(currentAssignment, targetAssignment, segmentsToMove,
+        minReplicasToKeepUpForNoDowntime, tableRebalanceLogger);
+    if (minAvailableReplicas == ILLEGAL_MIN_AVAILABLE_REPLICAS) {
+      onReturnFailure("Illegal config for minReplicasToKeepUpForNoDowntime: " + minReplicasToKeepUpForNoDowntime
+              + ", must be less than number of replicas: " + getMinNumReplicas(targetAssignment, segmentsToMove)
+              + ", aborting the rebalance", null, tableRebalanceLogger);
+      return new RebalanceResult(rebalanceJobId, RebalanceResult.Status.FAILED,
+          "Illegal min available replicas config", instancePartitionsMap, tierToInstancePartitionsMap,
+          targetAssignment, preChecksResult, summaryResult);
     }
 
     DataLossRiskAssessor dataLossRiskAssessor;
@@ -1796,9 +1783,19 @@ public class TableRebalancer {
         }
       }
       // Segments whose size could not be read (missing from all servers, or still consuming) are charged the average
-      // size of the segments that could be read
-      long defaultSegmentSizeBytes =
-          segmentSizeBytes.isEmpty() ? 1L : Math.max(1L, totalKnownBytes / segmentSizeBytes.size());
+      // size of the segments that could be read. When no per-segment size is available at all, fall back to the
+      // average over the whole table, which is the same estimate the disk utilization pre-check works with. Failing
+      // that, charge every segment one byte, which turns the budget into a bound on the number of segments hosted
+      long defaultSegmentSizeBytes;
+      if (!segmentSizeBytes.isEmpty()) {
+        defaultSegmentSizeBytes = Math.max(1L, totalKnownBytes / segmentSizeBytes.size());
+      } else if (tableSizeDetails != null && tableSizeDetails._reportedSizePerReplicaInBytes > 0
+          && !initialAssignment.isEmpty()) {
+        defaultSegmentSizeBytes =
+            Math.max(1L, tableSizeDetails._reportedSizePerReplicaInBytes / initialAssignment.size());
+      } else {
+        defaultSegmentSizeBytes = 1L;
+      }
       Map<String, Long> initialServerBytes = new HashMap<>();
       for (Map.Entry<String, Map<String, String>> entry : initialAssignment.entrySet()) {
         long sizeBytes = segmentSizeBytes.getOrDefault(entry.getKey(), defaultSegmentSizeBytes);
@@ -2305,6 +2302,126 @@ public class TableRebalancer {
     for (String newInstance : newInstances) {
       numSegmentsToOffloadMap.merge(newInstance, 1, Integer::sum);
     }
+  }
+
+  /// Returns the minimum available replicas the rebalance has to keep up, derived from
+  /// `minReplicasToKeepUpForNoDowntime` and the replication of the segments to be moved. Shared by the rebalance and
+  /// by the pre-checks so that the two cannot drift apart.
+  ///
+  /// NOTE:
+  /// 1. The calculation is based on the number of replicas of the target assignment. In case of increasing the number
+  ///    of replicas for the current assignment, the current instance state map might not have enough replicas to reach
+  ///    the minimum available replicas requirement. In this scenario we don't want to fail the check, but keep all the
+  ///    current instances as this is the best we can do, and can help the table get out of this state.
+  /// 2. Only check the segments to be moved because we don't need to maintain available replicas for segments not
+  ///    being moved, including segments with all replicas OFFLINE (error segments during consumption).
+  ///
+  /// @return the minimum available replicas, or [#ILLEGAL_MIN_AVAILABLE_REPLICAS] when
+  ///         `minReplicasToKeepUpForNoDowntime` is not less than the replication of the segments to be moved
+  @VisibleForTesting
+  static int getMinAvailableReplicas(Map<String, Map<String, String>> currentAssignment,
+      Map<String, Map<String, String>> targetAssignment, List<String> segmentsToMove,
+      int minReplicasToKeepUpForNoDowntime, Logger tableRebalanceLogger) {
+    int numReplicas = getMinNumReplicas(targetAssignment, segmentsToMove);
+    int minAvailableReplicas;
+    if (minReplicasToKeepUpForNoDowntime >= 0) {
+      // For non-negative value, use it as min available replicas
+      if (minReplicasToKeepUpForNoDowntime >= numReplicas) {
+        return ILLEGAL_MIN_AVAILABLE_REPLICAS;
+      }
+      minAvailableReplicas = minReplicasToKeepUpForNoDowntime;
+    } else {
+      // For negative value, use it as max unavailable replicas
+      minAvailableReplicas = Math.max(numReplicas + minReplicasToKeepUpForNoDowntime, 0);
+    }
+
+    int numCurrentAssignmentReplicas = getMinNumReplicas(currentAssignment, segmentsToMove);
+    if (minAvailableReplicas > numCurrentAssignmentReplicas) {
+      tableRebalanceLogger.warn("minAvailableReplicas: {} larger than existing number of replicas: {}, "
+              + "resetting minAvailableReplicas to {}", minAvailableReplicas, numCurrentAssignmentReplicas,
+          numCurrentAssignmentReplicas);
+      minAvailableReplicas = numCurrentAssignmentReplicas;
+    }
+    return minAvailableReplicas;
+  }
+
+  private static int getMinNumReplicas(Map<String, Map<String, String>> assignment, List<String> segments) {
+    int numReplicas = Integer.MAX_VALUE;
+    for (String segment : segments) {
+      numReplicas = Math.min(assignment.get(segment).size(), numReplicas);
+    }
+    return numReplicas;
+  }
+
+  /// Replays a low disk mode rebalance to find the servers it cannot keep within the disk they start with.
+  ///
+  /// Low disk mode bounds the disk each server may take on to the larger of what it hosts when the rebalance starts
+  /// and what the target assignment places on it. When no progress at all is possible within those bounds - servers
+  /// circularly waiting for one another to drop first - the rebalance relaxes them for a step rather than stalling,
+  /// which is the only way a server can end up over its bound. This runs [#getNextAssignment] over the whole rebalance
+  /// up front to find out whether that happens, and for which servers, before a single segment is moved.
+  ///
+  /// The replay is exact for the assignment it is given, with one caveat: it does not read the segment partition ids,
+  /// so with `batchSizePerServer` enabled and strict replica group routing the segments are grouped more coarsely than
+  /// the rebalance groups them, which changes the pacing of the moves but not the bounds themselves.
+  ///
+  /// @return server to the most bytes it would be pushed over its bound by, empty when the rebalance can complete
+  ///         within the bound of every server
+  public static Map<String, Long> getServersForcedOverDiskBudget(Map<String, Map<String, String>> currentAssignment,
+      Map<String, Map<String, String>> targetAssignment, int minAvailableReplicas, boolean enableStrictReplicaGroup,
+      int batchSizePerServer, @Nullable TableSizeReader.TableSubTypeSizeDetails tableSizeDetails,
+      Logger tableRebalanceLogger) {
+    DiskUsageBudget diskUsageBudget = DiskUsageBudget.create(currentAssignment, tableSizeDetails);
+    Object2IntOpenHashMap<String> segmentPartitionIdMap = new Object2IntOpenHashMap<>();
+    Map<String, Long> serverToBytesOverBudget = new TreeMap<>();
+    Map<String, Map<String, String>> assignment = currentAssignment;
+    for (int step = 1; step <= MAX_DISK_BUDGET_REPLAY_STEPS; step++) {
+      if (assignment.equals(targetAssignment)) {
+        return serverToBytesOverBudget;
+      }
+      Map<String, Long> remainingBytes = diskUsageBudget.forStep(assignment, targetAssignment).getRemainingBytes();
+      Map<String, Map<String, String>> nextAssignment;
+      try {
+        nextAssignment =
+            getNextAssignment(assignment, targetAssignment, minAvailableReplicas, enableStrictReplicaGroup, true,
+                batchSizePerServer, segmentPartitionIdMap, DEFAULT_PARTITION_ID_FETCHER, new NoOpRiskAssessor(),
+                tableRebalanceLogger, diskUsageBudget);
+      } catch (Exception e) {
+        tableRebalanceLogger.warn("Caught exception while replaying the rebalance to check the low disk mode disk "
+            + "usage, reporting what was found up to step {}", step, e);
+        return serverToBytesOverBudget;
+      }
+      if (nextAssignment.equals(assignment)) {
+        // The rebalance cannot progress at all, with or without the bounds. Nothing more to find
+        return serverToBytesOverBudget;
+      }
+      getServerToAddedBytes(assignment, nextAssignment, diskUsageBudget).forEach((server, addedBytes) -> {
+        long bytesOverBudget = addedBytes - remainingBytes.getOrDefault(server, 0L);
+        if (bytesOverBudget > 0) {
+          serverToBytesOverBudget.merge(server, bytesOverBudget, Math::max);
+        }
+      });
+      assignment = nextAssignment;
+    }
+    tableRebalanceLogger.warn("Gave up replaying the rebalance to check the low disk mode disk usage after {} steps",
+        MAX_DISK_BUDGET_REPLAY_STEPS);
+    return serverToBytesOverBudget;
+  }
+
+  /// Returns the bytes each server is assigned on top of what it already hosts.
+  private static Map<String, Long> getServerToAddedBytes(Map<String, Map<String, String>> currentAssignment,
+      Map<String, Map<String, String>> nextAssignment, DiskUsageBudget diskUsageBudget) {
+    Map<String, Long> serverToAddedBytes = new HashMap<>();
+    for (Map.Entry<String, Map<String, String>> entry : nextAssignment.entrySet()) {
+      Map<String, String> currentInstanceStateMap = currentAssignment.get(entry.getKey());
+      long sizeBytes = diskUsageBudget.getSegmentSizeBytes(entry.getKey());
+      for (String instance : entry.getValue().keySet()) {
+        if (currentInstanceStateMap == null || !currentInstanceStateMap.containsKey(instance)) {
+          serverToAddedBytes.merge(instance, sizeBytes, Long::sum);
+        }
+      }
+    }
+    return serverToAddedBytes;
   }
 
   /// Returns the next assignment for a segment based on the current instance state map and the target instance state

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -579,9 +579,9 @@ public class TableRebalancer {
     //
     // NOTE: Monitor the segments to be moved from both the previous round and this round to ensure the moved segments
     //       in the previous round are also converged.
-    // Anchor the per-server disk ceiling to the assignment the rebalance starts from, before the first step runs. The
-    // step loop can recalculate the target assignment, so the ceiling itself is derived per step from this anchor and
-    // the target of that step.
+
+    // For low disk mode, capture per-server hosted bytes before we start assignments. It will be used to derive the
+    // ceiling of how many bytes each server can only add on, per target assignment.
     DiskUsageBudget diskUsageBudget =
         lowDiskMode ? DiskUsageBudget.create(currentAssignment, tableSubTypeSizeDetails) : null;
 
@@ -1654,9 +1654,11 @@ public class TableRebalancer {
       Map<String, Map<String, String>> targetAssignment, int minAvailableReplicas, boolean enableStrictReplicaGroup,
       boolean lowDiskMode, int batchSizePerServer, Object2IntOpenHashMap<String> segmentPartitionIdMap,
       PartitionIdFetcher partitionIdFetcher, DataLossRiskAssessor dataLossRiskAssessor) {
+    // Anchor the budget to the assignment this call starts from, which is never above the ceiling anchored at the
+    // start of the rebalance. Without per-segment sizes it bounds the number of segments hosted instead of the bytes
     return getNextAssignment(currentAssignment, targetAssignment, minAvailableReplicas, enableStrictReplicaGroup,
         lowDiskMode, batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor, LOGGER,
-        null);
+        lowDiskMode ? DiskUsageBudget.create(currentAssignment, null) : null);
   }
 
   /// Uses the default LOGGER, with an explicit disk usage budget
@@ -1703,9 +1705,8 @@ public class TableRebalancer {
 
     // We use DiskUsageBudget and StepDiskBudget here to keep track of per-server byte gain/loss and to guarantee the
     // invariant of lowDiskMode where each server won't get more bytes than its net gain at any intermediate steps.
-    DiskUsageBudget budget =
-        diskUsageBudget != null ? diskUsageBudget : DiskUsageBudget.create(currentAssignment, null);
-    StepDiskBudget stepBudget = budget.forStep(currentAssignment, targetAssignment);
+    Preconditions.checkState(diskUsageBudget != null, "Low disk mode requires a disk usage budget");
+    StepDiskBudget stepBudget = diskUsageBudget.forStep(currentAssignment, targetAssignment);
     Map<String, Map<String, String>> nextAssignment =
         computeNextAssignment(currentAssignment, targetAssignment, minAvailableReplicas, enableStrictReplicaGroup, true,
             batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor, tableRebalanceLogger,
@@ -1740,16 +1741,18 @@ public class TableRebalancer {
 
   /// Bounds the disk a server may use while a low disk mode rebalance is in flight.
   ///
-  /// The ceiling for a server is `max(bytes it hosted when the rebalance started, bytes the target assignment places
-  /// on it)`, so a server whose net change is an increase may grow up to its final size and no further, and a server
-  /// whose net change is a decrease never goes above what it started with. Segments dropped in a step never fund
-  /// additions in that same step, since there is no guarantee that a server processes the drop before the addition.
+  /// If a server results in net byte loss, its ceiling is as many bytes as it originally hosted.
+  /// If a server results in net byte gain, its ceiling is as many bytes as it will eventually host.
   ///
-  /// Anchoring `initialServerBytes` at the start of the rebalance is what makes this a bound rather than a ratchet -
-  /// deriving it from the assignment of the step in progress would let the ceiling climb every time it was exceeded.
-  /// Re-deriving it from a partially rebalanced assignment (a retried rebalance job, say) is still safe, because a
-  /// rebalance that respected the ceiling leaves every server at or below it, so the re-derived ceiling can only be
-  /// tighter.
+  /// This invariant helps us guarantee that a rebalance won't introduce bytes more than necessary on the disk at any
+  /// moment during the rebalance. Thus, rebalance can safely run as long as we know the target assignment won't go
+  /// beyond their disk utilization (this can be guard by either pre-check or resource utilization checker etc.)
+  ///
+  /// In the case when new segments appear in ideal state by external sources (e.g. segment upload, consuming segment
+  /// committed), there are two cases:
+  /// 1. They are added to the ideal state as the target assignment. This case the rebalance steps outcome won't change
+  /// 2. They are added to the ideal state that's different to their target assignments. For example when strict
+  /// replica routing is in place. This case, it might lead to a different computeNextAssignment result.
   ///
   /// When no per-segment size is known every segment counts as one byte, which degenerates to bounding the number of
   /// segments hosted rather than the bytes.
@@ -1757,13 +1760,15 @@ public class TableRebalancer {
   static class DiskUsageBudget {
     private final Map<String, Long> _segmentSizeBytes;
     private final long _defaultSegmentSizeBytes;
-    private final Map<String, Long> _initialServerBytes;
+    private final Map<String, Long> _anchorServerBytes;
+    private final Set<String> _accountedSegments;
 
     private DiskUsageBudget(Map<String, Long> segmentSizeBytes, long defaultSegmentSizeBytes,
-        Map<String, Long> initialServerBytes) {
+        Map<String, Long> anchorServerBytes, Set<String> accountedSegments) {
       _segmentSizeBytes = segmentSizeBytes;
       _defaultSegmentSizeBytes = defaultSegmentSizeBytes;
-      _initialServerBytes = initialServerBytes;
+      _anchorServerBytes = anchorServerBytes;
+      _accountedSegments = accountedSegments;
     }
 
     /// @param initialAssignment the assignment the rebalance starts from, used to anchor the per-server ceiling
@@ -1803,11 +1808,27 @@ public class TableRebalancer {
           initialServerBytes.merge(instance, sizeBytes, Long::sum);
         }
       }
-      return new DiskUsageBudget(segmentSizeBytes, defaultSegmentSizeBytes, initialServerBytes);
+      return new DiskUsageBudget(segmentSizeBytes, defaultSegmentSizeBytes, initialServerBytes,
+          new HashSet<>(initialAssignment.keySet()));
     }
 
     long getSegmentSizeBytes(String segmentName) {
       return _segmentSizeBytes.getOrDefault(segmentName, _defaultSegmentSizeBytes);
+    }
+
+    /// Adds the segments that appeared since the anchor was taken - an uploaded segment, or a new consuming segment -
+    /// to the anchor of the servers hosting them.
+    ///
+    /// With this, this segment wouldn't be account for the budget if it doesn't need to be moved at all.
+    private void accountForNewSegments(Map<String, Map<String, String>> currentAssignment) {
+      for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
+        if (_accountedSegments.add(entry.getKey())) {
+          long sizeBytes = getSegmentSizeBytes(entry.getKey());
+          for (String instance : entry.getValue().keySet()) {
+            _anchorServerBytes.merge(instance, sizeBytes, Long::sum);
+          }
+        }
+      }
     }
 
     Map<String, Long> getServerToHostedBytes(Map<String, Map<String, String>> assignment) {
@@ -1821,32 +1842,42 @@ public class TableRebalancer {
       return serverToHostedBytes;
     }
 
+    /// Totals the budgeted bytes of the segments sharing each pair of current and target instances, over whichever
+    /// part of the assignment it is given. Those segments are all assigned the same instances, so an instance added
+    /// for one of them takes on all of them.
+    Map<Pair<Set<String>, Set<String>>, Long> getInstancePairToBytes(
+        Map<String, Map<String, String>> currentAssignment, Map<String, Map<String, String>> targetAssignment) {
+      Map<Pair<Set<String>, Set<String>>, Long> instancePairToBytes = new HashMap<>();
+      for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
+        Map<String, String> targetInstanceStateMap = targetAssignment.get(entry.getKey());
+        if (targetInstanceStateMap != null) {
+          instancePairToBytes.merge(Pair.of(entry.getValue().keySet(), targetInstanceStateMap.keySet()),
+              getSegmentSizeBytes(entry.getKey()), Long::sum);
+        }
+      }
+      return instancePairToBytes;
+    }
+
     /// Returns the bytes each server may still take on in this step, i.e. `ceiling - currently hosted`.
     StepDiskBudget forStep(Map<String, Map<String, String>> currentAssignment,
         Map<String, Map<String, String>> targetAssignment) {
+      accountForNewSegments(currentAssignment);
       Map<String, Long> hostedBytes = getServerToHostedBytes(currentAssignment);
       Map<String, Long> targetBytes = getServerToHostedBytes(targetAssignment);
-      Set<String> servers = new HashSet<>(_initialServerBytes.keySet());
+      Set<String> servers = new HashSet<>(_anchorServerBytes.keySet());
       servers.addAll(hostedBytes.keySet());
       servers.addAll(targetBytes.keySet());
       Map<String, Long> remainingBytes = new HashMap<>();
       for (String server : servers) {
         long ceilingBytes =
-            Math.max(_initialServerBytes.getOrDefault(server, 0L), targetBytes.getOrDefault(server, 0L));
+            Math.max(_anchorServerBytes.getOrDefault(server, 0L), targetBytes.getOrDefault(server, 0L));
         remainingBytes.put(server, Math.max(0L, ceilingBytes - hostedBytes.getOrDefault(server, 0L)));
       }
       // Segments that share a current and target instance pair are all assigned the same instances, so a newly added
       // instance takes on all of them. Total their size up so that the instances to add can be picked with that in
       // mind rather than only on the number of segments to offload
-      Map<Pair<Set<String>, Set<String>>, Long> instancePairToRequiredBytes = new HashMap<>();
-      for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
-        Map<String, String> targetInstanceStateMap = targetAssignment.get(entry.getKey());
-        if (targetInstanceStateMap != null) {
-          instancePairToRequiredBytes.merge(Pair.of(entry.getValue().keySet(), targetInstanceStateMap.keySet()),
-              getSegmentSizeBytes(entry.getKey()), Long::sum);
-        }
-      }
-      return new StepDiskBudget(this, remainingBytes, instancePairToRequiredBytes);
+      return new StepDiskBudget(this, remainingBytes,
+          getInstancePairToBytes(currentAssignment, targetAssignment));
     }
   }
 
@@ -1855,6 +1886,8 @@ public class TableRebalancer {
   static class StepDiskBudget {
     private final DiskUsageBudget _budget;
     private final Map<String, Long> _remainingBytes;
+    // this is to record for each strict replica group, how many bytes they contribute altogether since they'll be
+    // moved together
     private final Map<Pair<Set<String>, Set<String>>, Long> _instancePairToRequiredBytes;
 
     private StepDiskBudget(DiskUsageBudget budget, Map<String, Long> remainingBytes,
@@ -1865,13 +1898,7 @@ public class TableRebalancer {
     }
 
     /// Moves the instances that cannot take on all the segments sharing this current and target instance pair to the
-    /// back of the list, keeping the order within each part.
-    ///
-    /// `numSegmentsToOffloadMap`, which orders the list to begin with, counts segments while the budget counts bytes.
-    /// With unevenly sized segments the instance that is due to receive the most segments is regularly the one with
-    /// the least room, so picking purely on that count lands on an instance the budget then has to reject - and
-    /// rejecting it strands whatever room the other instances of the target assignment have. Ordering by what fits
-    /// first is what lets those instances be used.
+    /// back of the list so that they will be picked as the next step first.
     ///
     /// The instances that do not fit are kept at the back rather than dropped, so that an assignment is still produced
     /// when none of them fits and the budget stays the only thing that decides whether it is applied.
@@ -1894,6 +1921,11 @@ public class TableRebalancer {
 
     Map<String, Long> getRemainingBytes() {
       return _remainingBytes;
+    }
+
+    Map<Pair<Set<String>, Set<String>>, Long> getInstancePairToBytes(
+        Map<String, Map<String, String>> currentAssignment, Map<String, Map<String, String>> targetAssignment) {
+      return _budget.getInstancePairToBytes(currentAssignment, targetAssignment);
     }
 
     long getSegmentSizeBytes(String segmentName) {
@@ -2002,18 +2034,11 @@ public class TableRebalancer {
       // Exhausted the batch size for at least 1 server, just copy over the remaining segments as is
       nextAssignment.putAll(currentAssignment);
     } else {
-      // Total size of each group of segments that share the same current and target instances, needed to charge the
-      // disk budget for a group as a whole. Computed up front so that the first segment of a group already knows how
-      // much space the whole group needs.
-      Map<Pair<Set<String>, Set<String>>, Long> groupToSizeBytes = new HashMap<>();
+      // Build this map so later on we can skip updating the entire replica group if the group's total segment size
+      // doesn't fit in the instances disk budget
+      Map<Pair<Set<String>, Set<String>>, Long> groupToSizeBytes = stepBudget == null ? Map.of()
+          : stepBudget.getInstancePairToBytes(currentAssignment, targetAssignment);
       Map<Pair<Set<String>, Set<String>>, Boolean> groupToFitsDisk = new HashMap<>();
-      if (stepBudget != null) {
-        for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
-          groupToSizeBytes.merge(
-              Pair.of(entry.getValue().keySet(), targetAssignment.get(entry.getKey()).keySet()),
-              stepBudget.getSegmentSizeBytes(entry.getKey()), Long::sum);
-        }
-      }
 
       // Process all the partitionIds even if segmentsAddedSoFar becomes larger than batchSizePerServer
       // Can only do bestEfforts w.r.t. StrictReplicaGroup since a whole partition must be moved together for
@@ -2042,7 +2067,7 @@ public class TableRebalancer {
             groupToFitsDisk.put(group, groupFitsDisk);
           }
           if (!groupFitsDisk) {
-            // A later step picks the group up once the drops have freed up the space
+            // A later step picks the group up once the drops have freed up the space, skip for now
             nextAssignment.put(segmentName, currentInstanceStateMap);
             continue;
           }
@@ -2539,6 +2564,7 @@ public class TableRebalancer {
             getSortedInstancesOnNumSegmentsToOffload(targetInstanceStateMap, nextInstanceStateMap,
                 numSegmentsToOffloadMap);
         if (stepBudget != null) {
+          // sort so that if there are instances with enough disk budget, they'll be picked
           instancesInfo = stepBudget.sortInstancesThatFitFirst(instancesInfo, currentInstances, targetInstances);
         }
         for (int i = 0; i < numInstancesToAdd; i++) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -1835,7 +1835,18 @@ public class TableRebalancer {
             Math.max(_initialServerBytes.getOrDefault(server, 0L), targetBytes.getOrDefault(server, 0L));
         remainingBytes.put(server, Math.max(0L, ceilingBytes - hostedBytes.getOrDefault(server, 0L)));
       }
-      return new StepDiskBudget(this, remainingBytes);
+      // Segments that share a current and target instance pair are all assigned the same instances, so a newly added
+      // instance takes on all of them. Total their size up so that the instances to add can be picked with that in
+      // mind rather than only on the number of segments to offload
+      Map<Pair<Set<String>, Set<String>>, Long> instancePairToRequiredBytes = new HashMap<>();
+      for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
+        Map<String, String> targetInstanceStateMap = targetAssignment.get(entry.getKey());
+        if (targetInstanceStateMap != null) {
+          instancePairToRequiredBytes.merge(Pair.of(entry.getValue().keySet(), targetInstanceStateMap.keySet()),
+              getSegmentSizeBytes(entry.getKey()), Long::sum);
+        }
+      }
+      return new StepDiskBudget(this, remainingBytes, instancePairToRequiredBytes);
     }
   }
 
@@ -1844,10 +1855,41 @@ public class TableRebalancer {
   static class StepDiskBudget {
     private final DiskUsageBudget _budget;
     private final Map<String, Long> _remainingBytes;
+    private final Map<Pair<Set<String>, Set<String>>, Long> _instancePairToRequiredBytes;
 
-    private StepDiskBudget(DiskUsageBudget budget, Map<String, Long> remainingBytes) {
+    private StepDiskBudget(DiskUsageBudget budget, Map<String, Long> remainingBytes,
+        Map<Pair<Set<String>, Set<String>>, Long> instancePairToRequiredBytes) {
       _budget = budget;
       _remainingBytes = remainingBytes;
+      _instancePairToRequiredBytes = instancePairToRequiredBytes;
+    }
+
+    /// Moves the instances that cannot take on all the segments sharing this current and target instance pair to the
+    /// back of the list, keeping the order within each part.
+    ///
+    /// `numSegmentsToOffloadMap`, which orders the list to begin with, counts segments while the budget counts bytes.
+    /// With unevenly sized segments the instance that is due to receive the most segments is regularly the one with
+    /// the least room, so picking purely on that count lands on an instance the budget then has to reject - and
+    /// rejecting it strands whatever room the other instances of the target assignment have. Ordering by what fits
+    /// first is what lets those instances be used.
+    ///
+    /// The instances that do not fit are kept at the back rather than dropped, so that an assignment is still produced
+    /// when none of them fits and the budget stays the only thing that decides whether it is applied.
+    List<Triple<String, String, Integer>> sortInstancesThatFitFirst(
+        List<Triple<String, String, Integer>> instancesInfo, Set<String> currentInstances,
+        Set<String> targetInstances) {
+      long requiredBytes = _instancePairToRequiredBytes.getOrDefault(Pair.of(currentInstances, targetInstances), 0L);
+      List<Triple<String, String, Integer>> fits = new ArrayList<>(instancesInfo.size());
+      List<Triple<String, String, Integer>> doesNotFit = new ArrayList<>();
+      for (Triple<String, String, Integer> instanceInfo : instancesInfo) {
+        if (_remainingBytes.getOrDefault(instanceInfo.getLeft(), 0L) >= requiredBytes) {
+          fits.add(instanceInfo);
+        } else {
+          doesNotFit.add(instanceInfo);
+        }
+      }
+      fits.addAll(doesNotFit);
+      return fits;
     }
 
     Map<String, Long> getRemainingBytes() {
@@ -1919,7 +1961,7 @@ public class TableRebalancer {
         Map<String, String> firstEntryInstanceStateMap = firstEntry.getValue();
         SingleSegmentAssignment firstAssignment =
             getNextSingleSegmentAssignment(firstEntryInstanceStateMap, targetAssignment.get(firstEntry.getKey()),
-                minAvailableReplicas, lowDiskMode, numSegmentsToOffloadMap, assignmentMap);
+                minAvailableReplicas, lowDiskMode, numSegmentsToOffloadMap, assignmentMap, stepBudget);
         Set<String> serversAdded = getServersAddedInSingleSegmentAssignment(firstEntryInstanceStateMap,
             firstAssignment._instanceStateMap);
         boolean anyServerExhaustedBatchSize = false;
@@ -1982,7 +2024,7 @@ public class TableRebalancer {
         Map<String, String> targetInstanceStateMap = targetAssignment.get(segmentName);
         SingleSegmentAssignment assignment =
             getNextSingleSegmentAssignment(currentInstanceStateMap, targetInstanceStateMap, minAvailableReplicas,
-                lowDiskMode, numSegmentsToOffloadMap, assignmentMap);
+                lowDiskMode, numSegmentsToOffloadMap, assignmentMap, stepBudget);
         Set<String> assignedInstances = assignment._instanceStateMap.keySet();
         Set<String> availableInstances = assignment._availableInstances;
         // Strict replica group routing requires every segment that shares the same current and target instances to
@@ -2227,7 +2269,7 @@ public class TableRebalancer {
       Map<String, String> targetInstanceStateMap = targetAssignment.get(segmentName);
       Map<String, String> nextInstanceStateMap =
           getNextSingleSegmentAssignment(currentInstanceStateMap, targetInstanceStateMap, minAvailableReplicas,
-              lowDiskMode, numSegmentsToOffloadMap, assignmentMap)._instanceStateMap;
+              lowDiskMode, numSegmentsToOffloadMap, assignmentMap, stepBudget)._instanceStateMap;
       Set<String> serversAddedForSegment = getServersAddedInSingleSegmentAssignment(currentInstanceStateMap,
           nextInstanceStateMap);
       boolean anyServerExhaustedBatchSize = false;
@@ -2432,7 +2474,8 @@ public class TableRebalancer {
   @VisibleForTesting
   static SingleSegmentAssignment getNextSingleSegmentAssignment(Map<String, String> currentInstanceStateMap,
       Map<String, String> targetInstanceStateMap, int minAvailableReplicas, boolean lowDiskMode,
-      Map<String, Integer> numSegmentsToOffloadMap, Map<Pair<Set<String>, Set<String>>, Set<String>> assignmentMap) {
+      Map<String, Integer> numSegmentsToOffloadMap, Map<Pair<Set<String>, Set<String>>, Set<String>> assignmentMap,
+      @Nullable StepDiskBudget stepBudget) {
     Map<String, String> nextInstanceStateMap = new TreeMap<>();
 
     // Assign the segment the same way as other segments if the current and target instances are the same. We need this
@@ -2495,6 +2538,9 @@ public class TableRebalancer {
         List<Triple<String, String, Integer>> instancesInfo =
             getSortedInstancesOnNumSegmentsToOffload(targetInstanceStateMap, nextInstanceStateMap,
                 numSegmentsToOffloadMap);
+        if (stepBudget != null) {
+          instancesInfo = stepBudget.sortInstancesThatFitFirst(instancesInfo, currentInstances, targetInstances);
+        }
         for (int i = 0; i < numInstancesToAdd; i++) {
           Triple<String, String, Integer> instanceInfo = instancesInfo.get(i);
           nextInstanceStateMap.put(instanceInfo.getLeft(), instanceInfo.getMiddle());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreCheckerTest.java
@@ -176,6 +176,30 @@ public class DefaultRebalancePreCheckerTest {
         THRESHOLD);
   }
 
+  /// `lowDiskMode` is not a blanket guarantee: when the rebalance cannot progress at all within the disk the servers
+  /// start with, it goes over rather than stalling. The pre-check replays the rebalance to find that out instead of
+  /// assuming `lowDiskMode` always avoids the transient usage. No reachable rebalance has been found that trips it -
+  /// see `DefaultRebalancePreChecker#getServersForcedOverDiskBudget` - so the replay is stubbed out here to cover the
+  /// reporting.
+  @Test
+  public void testOverThresholdDuringRebalanceIsAnErrorWhenLowDiskModeCannotAvoidIt() {
+    setDiskUsage(100L, 320L);
+    DefaultRebalancePreChecker preChecker = new DefaultRebalancePreChecker() {
+      @Override
+      protected Map<String, Long> getServersForcedOverDiskBudget(PreCheckContext preCheckContext) {
+        return Map.of(SERVER_1, 150L);
+      }
+    };
+    RebalancePreCheckerResult result = preChecker.checkDiskUtilization(
+        getPreCheckContext(lowDiskMode(), CURRENT_ASSIGNMENT, TARGET_ASSIGNMENT), THRESHOLD);
+    assertEquals(result.getPreCheckStatus(), PreCheckStatus.ERROR);
+    assertEquals(result.getMessage(),
+        "UNSAFE. Servers with unsafe disk utilization DURING rebalance (>=50%): " + SERVER_1 + " (52%). lowDiskMode "
+            + "cannot avoid it for this target assignment: the rebalance cannot make progress without going over the "
+            + "disk these servers start with, by up to " + SERVER_1 + " (150B). Rebalance to a target assignment that "
+            + "frees up space on them first, or add capacity");
+  }
+
   private static RebalanceConfig lowDiskMode() {
     RebalanceConfig rebalanceConfig = new RebalanceConfig();
     rebalanceConfig.setLowDiskMode(true);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreCheckerTest.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pinot.controller.helix.core.rebalance;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import org.apache.pinot.common.restlet.resources.DiskUsageInfo;
 import org.apache.pinot.common.restlet.resources.RebalanceConfig;
 import org.apache.pinot.common.restlet.resources.RebalancePreCheckerResult;
@@ -176,28 +178,86 @@ public class DefaultRebalancePreCheckerTest {
         THRESHOLD);
   }
 
-  /// `lowDiskMode` is not a blanket guarantee: when the rebalance cannot progress at all within the disk the servers
+  /// `lowDiskMode` is not a blanket guarantee: where the rebalance cannot progress at all within the disk the servers
   /// start with, it goes over rather than stalling. The pre-check replays the rebalance to find that out instead of
-  /// assuming `lowDiskMode` always avoids the transient usage. No reachable rebalance has been found that trips it -
-  /// see `DefaultRebalancePreChecker#getServersForcedOverDiskBudget` - so the replay is stubbed out here to cover the
-  /// reporting.
+  /// assuming `lowDiskMode` always avoids the transient usage.
+  ///
+  /// Driven through the real [DefaultRebalancePreChecker] with an assignment that genuinely needs the budget given up,
+  /// rather than by stubbing the replay, so that a wiring mistake between [PreCheckContext], the routing mode,
+  /// batching, the segment sizes and the replay shows up here.
   @Test
   public void testOverThresholdDuringRebalanceIsAnErrorWhenLowDiskModeCannotAvoidIt() {
-    setDiskUsage(100L, 320L);
-    DefaultRebalancePreChecker preChecker = new DefaultRebalancePreChecker() {
-      @Override
-      protected Map<String, Long> getServersForcedOverDiskBudget(PreCheckContext preCheckContext) {
-        return Map.of(SERVER_1, 150L);
-      }
+    // host05 starts on 2041 MiB and the target places 1523 MiB on it, so its ceiling is what it started with. It is
+    // pinned with segments it cannot drop without going below three available replicas, and a step arrives where it is
+    // the only place left to put a segment and has nothing spare
+    String[][] groups = {
+        {"host00,host01,host02,host03", "host02,host04,host05,host06", "0,1,2,3,4,5,6,7,8,9"},
+        {"host00,host02,host06", "host00,host03,host05,host06", "10,11,12"},
+        {"host00,host01,host03,host06", "host01,host02,host03,host05", "13,14,15"},
+        {"host02,host04,host05,host06", "host00,host01,host03,host04", "16,17,18,19,20,21,22,23"},
+        {"host01,host02,host03,host04", "host00,host02,host05,host06", "24,25,26,27,28,29,30,31,32"}
     };
-    RebalancePreCheckerResult result = preChecker.checkDiskUtilization(
-        getPreCheckContext(lowDiskMode(), CURRENT_ASSIGNMENT, TARGET_ASSIGNMENT), THRESHOLD);
-    assertEquals(result.getPreCheckStatus(), PreCheckStatus.ERROR);
-    assertEquals(result.getMessage(),
-        "UNSAFE. Servers with unsafe disk utilization DURING rebalance (>=50%): " + SERVER_1 + " (52%). lowDiskMode "
-            + "cannot avoid it for this target assignment: the rebalance cannot make progress without going over the "
-            + "disk these servers start with, by up to " + SERVER_1 + " (150B). Rebalance to a target assignment that "
-            + "frees up space on them first, or add capacity");
+    long[] sizesInMib = {
+        31, 12, 17, 9, 16, 14, 431, 664, 23, 23, 23, 20, 12, 12, 28, 9, 29, 1162, 768, 14, 15, 31, 8, 14, 21, 9, 14,
+        25, 15, 25, 18, 24, 28
+    };
+    Map<String, Map<String, String>> current = new HashMap<>();
+    Map<String, Map<String, String>> target = new HashMap<>();
+    TableSizeReader.TableSubTypeSizeDetails tableSizeDetails = new TableSizeReader.TableSubTypeSizeDetails();
+    for (String[] group : groups) {
+      for (String index : group[2].split(",")) {
+        String segment = String.format("segment%03d", Integer.parseInt(index));
+        current.put(segment, instanceStateMap(group[0].split(",")));
+        target.put(segment, instanceStateMap(group[1].split(",")));
+        TableSizeReader.SegmentSizeDetails segmentSizeDetails = new TableSizeReader.SegmentSizeDetails();
+        segmentSizeDetails._maxReportedSizePerReplicaInBytes =
+            sizesInMib[Integer.parseInt(index)] * 1024 * 1024;
+        tableSizeDetails._segments.put(segment, segmentSizeDetails);
+      }
+    }
+
+    // The size check works off the average segment size, which comes from the per-replica table size
+    long mib = 1024L * 1024;
+    long tableSizePerReplicaMib = 0;
+    for (long sizeInMib : sizesInMib) {
+      tableSizePerReplicaMib += sizeInMib;
+    }
+    tableSizeDetails._reportedSizePerReplicaInBytes = tableSizePerReplicaMib * mib;
+
+    // host05 takes on 25 segments and sheds 8, at an average of 108 MiB each, so on 20 GiB of disk it crosses 50%
+    // during the rebalance (7800 + 2700 = 52%) and comes back under it after (9636 = 48%). That is the branch the
+    // replay guards. The others are given enough room never to be flagged
+    long now = System.currentTimeMillis();
+    Map<String, DiskUsageInfo> diskUsage = new HashMap<>();
+    for (int i = 0; i <= 6; i++) {
+      String server = String.format("host%02d", i);
+      diskUsage.put(server, "host05".equals(server)
+          ? new DiskUsageInfo(server, "", 20_000L * mib, 7_800L * mib, now)
+          : new DiskUsageInfo(server, "", 400_000L * mib, 1_000L * mib, now));
+    }
+    ResourceUtilizationInfo.setDiskUsageInfo(diskUsage);
+
+    RebalanceConfig rebalanceConfig = lowDiskMode();
+    rebalanceConfig.setMinAvailableReplicas(3);
+    rebalanceConfig.setBatchSizePerServer(1);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
+    RebalancePreCheckerResult result = _preChecker.checkDiskUtilization(
+        new PreCheckContext("jobId", tableConfig.getTableName(), tableConfig, current, target, tableSizeDetails,
+            rebalanceConfig, null, null), 0.5);
+
+    System.out.println("diskUtilization: " + result.getPreCheckStatus() + " — " + result.getMessage());
+    assertEquals(result.getPreCheckStatus(), PreCheckStatus.ERROR, result.getMessage());
+    assertTrue(result.getMessage().contains("lowDiskMode cannot avoid it for this target assignment"),
+        result.getMessage());
+    assertTrue(result.getMessage().contains("host05"), result.getMessage());
+  }
+
+  private static Map<String, String> instanceStateMap(String... instances) {
+    Map<String, String> instanceStateMap = new TreeMap<>();
+    for (String instance : instances) {
+      instanceStateMap.put(instance, ONLINE);
+    }
+    return instanceStateMap;
   }
 
   private static RebalanceConfig lowDiskMode() {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/LowDiskModeRebalanceSimulatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/LowDiskModeRebalanceSimulatorTest.java
@@ -97,22 +97,20 @@ public class LowDiskModeRebalanceSimulatorTest {
             scenario._name + ": went outside the budget while segments were being added" + result.report());
         continue;
       }
-      Set<String> reported = TableRebalancer.getServersForcedOverDiskBudget(scenario._currentAssignment,
-          scenario._targetAssignment, scenario._minAvailableReplicas, scenario._enableStrictReplicaGroup,
-          scenario._batchSizePerServer, toTableSizeDetails(scenario._segmentSizeBytes),
-          LoggerFactory.getLogger(getClass())).keySet();
-      // Asserting what the pre-check reports, and not only that it agrees with the rebalance, is what makes this fail
-      // when a change starts giving the budget up on a shape that used to hold: the equality on its own passes a
-      // rebalance that goes over and says so.
-      if (scenario._withinBudget) {
-        assertEquals(reported, Set.of(),
-            scenario._name + ": the pre-check says the budget cannot be held for a shape that it should"
-                + result.report());
-      } else {
-        assertTrue(!reported.isEmpty(), scenario._name + ": expected the pre-check to report a server, so that the "
-            + "case where it does is covered. If a change made this shape hold, clear its withinBudget flag"
-            + result.report());
-      }
+      Map<String, Long> serversForcedOverBudget = TableRebalancer.getServersForcedOverDiskBudget(
+          scenario._currentAssignment, scenario._targetAssignment, scenario._minAvailableReplicas,
+          scenario._enableStrictReplicaGroup, scenario._batchSizePerServer,
+          toTableSizeDetails(scenario._segmentSizeBytes), LoggerFactory.getLogger(getClass()));
+      // A replay that could not be finished establishes nothing, so it must never reach the assertions below as if it
+      // had found the rebalance safe
+      assertTrue(serversForcedOverBudget != null, scenario._name + ": the replay could not be finished" + result
+          .report());
+      assertEquals(serversForcedOverBudget.isEmpty(), scenario._withinBudget,
+          scenario._name + ": unexpected replay result " + serversForcedOverBudget + result.report());
+      Set<String> reported = serversForcedOverBudget.keySet();
+      // Asserting the outcome above, and not only that it agrees with the rebalance, is what makes this fail when a
+      // change starts giving the budget up on a shape that used to hold: agreement on its own passes a rebalance that
+      // goes over and says so. If a change made the known-over shape hold, clear its withinBudget flag.
       assertEquals(result._serversOverBudget, reported,
           scenario._name + ": the servers that went over the budget are not the ones the pre-check named"
               + result.report());
@@ -131,6 +129,26 @@ public class LowDiskModeRebalanceSimulatorTest {
             scenario._name + ": split a group of segments across instances" + result.report());
       }
     }
+  }
+
+  /// A replay that does not reach the target assignment has established nothing, and must say so rather than return
+  /// the same "no server goes over" answer as a replay that completed. Driven by capping the steps rather than by
+  /// building an assignment that genuinely needs tens of thousands of them.
+  @Test
+  public void testReplayThatRunsOutOfStepsIsInconclusiveRatherThanSafe() {
+    Scenario scenario = scenarios().stream().filter(s -> s._injectAtStep == 0).findFirst().orElseThrow();
+    for (int maxSteps : List.of(1, 2)) {
+      assertEquals(TableRebalancer.getServersForcedOverDiskBudget(scenario._currentAssignment,
+              scenario._targetAssignment, scenario._minAvailableReplicas, scenario._enableStrictReplicaGroup,
+              scenario._batchSizePerServer, toTableSizeDetails(scenario._segmentSizeBytes),
+              LoggerFactory.getLogger(getClass()), maxSteps), null,
+          "a replay capped at " + maxSteps + " steps cannot have established that the budget holds");
+    }
+    // The same replay run to completion does establish it, so the result above is about the cap and nothing else
+    assertEquals(TableRebalancer.getServersForcedOverDiskBudget(scenario._currentAssignment,
+        scenario._targetAssignment, scenario._minAvailableReplicas, scenario._enableStrictReplicaGroup,
+        scenario._batchSizePerServer, toTableSizeDetails(scenario._segmentSizeBytes),
+        LoggerFactory.getLogger(getClass())), Map.of());
   }
 
   // ---------------------------------------------------------------------------------------------------------------

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/LowDiskModeRebalanceSimulatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/LowDiskModeRebalanceSimulatorTest.java
@@ -252,16 +252,226 @@ public class LowDiskModeRebalanceSimulatorTest {
     return SegmentAssignmentUtils.getInstanceStateMap(List.of(instances), ONLINE);
   }
 
-  /// A strict replica group rebalance that the disk budget genuinely cannot carry out, found by
-  /// [#testStrictReplicaGroupRandomGroupStructureSearch] and pinned here so it stays covered.
+  /// Searches broadly for rebalances the disk budget cannot carry out, i.e. the ones the disk utilization pre-check
+  /// has to report. Randomizes everything that feeds the budget: strict and non strict routing, batching on and off,
+  /// the minimum available replicas, how many replicas a group currently sits at, group sizes, and four different
+  /// segment size distributions including one where a single segment dominates its whole group.
   ///
-  /// At the blocking step `host02` has 318 MiB free under its own ceiling, but the group it has to take on is 6
-  /// segments totalling roughly 1.2 GiB and strict replica group routing requires all of them to move together, so it
-  /// does not fit. Every other movable group is blocked the same way, so the rebalance relaxes the budget rather than
-  /// stalling and `host02` ends up 36% over the disk it started with. Positive-but-insufficient headroom is what makes
-  /// this reachable in strict mode and not in the per-segment case.
+  /// The property asserted is not that a rebalance can always stay within the budget - it cannot, and relaxing the
+  /// budget rather than stalling is the deliberate behaviour - but that the pre-check replay reports exactly the
+  /// servers that end up over. A relaxation the pre-check does not predict would be a silent over-allocation.
   @Test
-  public void testStrictReplicaGroupCanBeForcedOverTheDiskBudget() {
+  public void testSearchForRebalancesTheBudgetCannotCarryOut() {
+    Random random = new Random(2027);
+    List<SimResult> relaxed = new ArrayList<>();
+    List<String> mismatches = new ArrayList<>();
+    int numTrials = 30000;
+    int numRun = 0;
+    for (int trial = 0; trial < numTrials; trial++) {
+      int numServers = 3 + random.nextInt(8);
+      int replication = 2 + random.nextInt(3);
+      int minAvailableReplicas = 1 + random.nextInt(replication - 1);
+      int numGroups = 2 + random.nextInt(7);
+      boolean enableStrictReplicaGroup = random.nextBoolean();
+      int batchSizePerServer = List.of(RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, 1, 2, 5, 20)
+          .get(random.nextInt(5));
+      int sizeRegime = random.nextInt(4);
+      List<String> allServers = servers(0, numServers);
+
+      Map<String, Map<String, String>> current = new TreeMap<>();
+      Map<String, Map<String, String>> target = new TreeMap<>();
+      Map<String, Long> sizes = new TreeMap<>();
+      int segmentId = 0;
+      for (int group = 0; group < numGroups; group++) {
+        // A group that already sits at the minimum available replicas cannot drop anything, which is what forces it
+        // to depend on an addition landing somewhere
+        int numCurrentInstances = minAvailableReplicas + random.nextInt(replication - minAvailableReplicas + 1);
+        List<String> currentInstances = pickServers(allServers, numCurrentInstances, random);
+        List<String> targetInstances = pickServers(allServers, replication, random);
+        int numSegmentsInGroup = 1 + random.nextInt(10);
+        List<String> groupSegments = new ArrayList<>();
+        for (int i = 0; i < numSegmentsInGroup; i++) {
+          String segment = String.format("segment%04d", segmentId++);
+          groupSegments.add(segment);
+          current.put(segment, SegmentAssignmentUtils.getInstanceStateMap(currentInstances, ONLINE));
+          target.put(segment, SegmentAssignmentUtils.getInstanceStateMap(targetInstances, ONLINE));
+        }
+        sizes.putAll(sizesForRegime(groupSegments, sizeRegime, random));
+      }
+      List<String> segmentsToMove = SegmentAssignmentUtils.getSegmentsToMove(current, target);
+      if (segmentsToMove.isEmpty() || TableRebalancer.getMinAvailableReplicas(current, target, segmentsToMove,
+          minAvailableReplicas, LoggerFactory.getLogger(getClass())) != minAvailableReplicas) {
+        continue;
+      }
+      numRun++;
+
+      String name = String.format(
+          "trial %d: servers=%d replication=%d minAvail=%d groups=%d strict=%s batch=%d sizes=%d", trial, numServers,
+          replication, minAvailableReplicas, numGroups, enableStrictReplicaGroup, batchSizePerServer, sizeRegime);
+      SimResult result = simulate(new Scenario(name, current, target, minAvailableReplicas, enableStrictReplicaGroup,
+          batchSizePerServer, sizes));
+      Set<String> observed = new TreeSet<>();
+      result.relaxedSteps().forEach(step -> observed.addAll(step._deferralRelaxedFor));
+      if (observed.isEmpty()) {
+        continue;
+      }
+      relaxed.add(result);
+      // The pre-check has to predict it, from the same starting point, before anything moves
+      Map<String, Long> reported = TableRebalancer.getServersForcedOverDiskBudget(current, target,
+          minAvailableReplicas, enableStrictReplicaGroup, batchSizePerServer, toTableSizeDetails(sizes),
+          LoggerFactory.getLogger(getClass()));
+      if (!reported.keySet().equals(observed)) {
+        mismatches.add(name + ": rebalance went over on " + observed + " but the pre-check reported " + reported);
+      }
+    }
+
+    System.out.printf("%nSearched %d of %d generated scenarios (the rest were configs the rebalance would reject)%n",
+        numRun, numTrials);
+    System.out.printf("  rebalances the budget could not carry out: %d%n", relaxed.size());
+    if (!relaxed.isEmpty()) {
+      relaxed.sort((a, b) -> Double.compare(b.worstAmplification(), a.worstAmplification()));
+      System.out.printf("  worst amplification among them: %.2fx%n", relaxed.get(0).worstAmplification());
+      for (SimResult result : relaxed.subList(0, Math.min(8, relaxed.size()))) {
+        System.out.printf("    %-92s worst %s: bound %s, peak %s%n", result._scenario._name, result.worstServer(),
+            formatUnits(result.bound(result.worstServer()), result._scenario),
+            formatUnits(result._maxAfter.get(result.worstServer()), result._scenario));
+      }
+      System.out.println(relaxed.get(0).report());
+      dumpScenario(relaxed.get(0)._scenario);
+    }
+    assertEquals(mismatches, List.of(), "the pre-check must report every rebalance that goes over the disk budget");
+  }
+
+  /// Enumerates every small rebalance exhaustively, rather than sampling. A rebalance the budget cannot carry out is
+  /// a rare structure, so random generation is the wrong instrument for it: if a minimal one exists it should show up
+  /// among 4 servers, 3 groups sitting at the minimum available replicas, and a handful of group sizes.
+  @Test
+  public void testExhaustiveSmallSearchForRebalancesTheBudgetCannotCarryOut() {
+    List<String> allServers = servers(0, 4);
+    List<Long> groupSizes = List.of(1L, 3L, 10L, 40L);
+    List<SimResult> relaxed = new ArrayList<>();
+    List<String> mismatches = new ArrayList<>();
+    int numRun = 0;
+    for (int replication : List.of(2, 3)) {
+      // Every (single current instance, target instance set) a group can have
+      List<List<List<String>>> groupShapes = new ArrayList<>();
+      for (String currentInstance : allServers) {
+        for (List<String> targetInstances : combinations(allServers, replication)) {
+          groupShapes.add(List.of(List.of(currentInstance), targetInstances));
+        }
+      }
+      int numShapes = groupShapes.size();
+      for (int a = 0; a < numShapes; a++) {
+        for (int b = a; b < numShapes; b++) {
+          for (int c = b; c < numShapes; c++) {
+            for (long sizeA : groupSizes) {
+              for (long sizeB : groupSizes) {
+                for (long sizeC : groupSizes) {
+                  List<List<List<String>>> shapes = List.of(groupShapes.get(a), groupShapes.get(b),
+                      groupShapes.get(c));
+                  List<Long> sizesPerGroup = List.of(sizeA, sizeB, sizeC);
+                  Map<String, Map<String, String>> current = new TreeMap<>();
+                  Map<String, Map<String, String>> target = new TreeMap<>();
+                  Map<String, Long> sizes = new TreeMap<>();
+                  for (int group = 0; group < 3; group++) {
+                    String segment = "segment" + group;
+                    current.put(segment,
+                        SegmentAssignmentUtils.getInstanceStateMap(shapes.get(group).get(0), ONLINE));
+                    target.put(segment,
+                        SegmentAssignmentUtils.getInstanceStateMap(shapes.get(group).get(1), ONLINE));
+                    sizes.put(segment, sizesPerGroup.get(group));
+                  }
+                  List<String> segmentsToMove = SegmentAssignmentUtils.getSegmentsToMove(current, target);
+                  if (segmentsToMove.isEmpty() || TableRebalancer.getMinAvailableReplicas(current, target,
+                      segmentsToMove, 1, LoggerFactory.getLogger(getClass())) != 1) {
+                    continue;
+                  }
+                  for (boolean enableStrictReplicaGroup : List.of(false, true)) {
+                    numRun++;
+                    String name = String.format("replication=%d shapes=%s sizes=%s strict=%s", replication, shapes,
+                        sizesPerGroup, enableStrictReplicaGroup);
+                    SimResult result = simulate(new Scenario(name, current, target, 1, enableStrictReplicaGroup,
+                        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, sizes));
+                    Set<String> observed = new TreeSet<>();
+                    result.relaxedSteps().forEach(step -> observed.addAll(step._deferralRelaxedFor));
+                    if (observed.isEmpty()) {
+                      continue;
+                    }
+                    relaxed.add(result);
+                    Map<String, Long> reported = TableRebalancer.getServersForcedOverDiskBudget(current, target, 1,
+                        enableStrictReplicaGroup, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER,
+                        toTableSizeDetails(sizes), LoggerFactory.getLogger(getClass()));
+                    if (!reported.keySet().equals(observed)) {
+                      mismatches.add(name + ": went over on " + observed + " but pre-check reported " + reported);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    System.out.printf("%nExhaustively ran %d small rebalances%n", numRun);
+    System.out.printf("  rebalances the budget could not carry out: %d%n", relaxed.size());
+    if (!relaxed.isEmpty()) {
+      relaxed.sort((a, b) -> Double.compare(b.worstAmplification(), a.worstAmplification()));
+      System.out.println(relaxed.get(0).report());
+      dumpScenario(relaxed.get(0)._scenario);
+    }
+    assertEquals(mismatches, List.of(), "the pre-check must report every rebalance that goes over the disk budget");
+  }
+
+  /// All the subsets of `items` of exactly `size`, in a stable order.
+  private static List<List<String>> combinations(List<String> items, int size) {
+    List<List<String>> combinations = new ArrayList<>();
+    if (size == 0) {
+      combinations.add(List.of());
+      return combinations;
+    }
+    for (int i = 0; i <= items.size() - size; i++) {
+      for (List<String> rest : combinations(items.subList(i + 1, items.size()), size - 1)) {
+        List<String> combination = new ArrayList<>();
+        combination.add(items.get(i));
+        combination.addAll(rest);
+        combinations.add(combination);
+      }
+    }
+    return combinations;
+  }
+
+  /// Segment sizes under one of several distributions, so that the search is not limited to one shape of skew.
+  private static Map<String, Long> sizesForRegime(List<String> segments, int sizeRegime, Random random) {
+    Map<String, Long> sizes = new TreeMap<>();
+    long mib = 1024L * 1024;
+    switch (sizeRegime) {
+      case 0 -> segments.forEach(segment -> sizes.put(segment, 64 * mib));
+      case 1 -> segments.forEach(segment -> sizes.put(segment,
+          random.nextInt(10) < 8 ? (8 + random.nextInt(24)) * mib : (320 + random.nextInt(960)) * mib));
+      case 2 -> {
+        // One segment dominates the group, so the group only fits where there is a lot of room
+        segments.forEach(segment -> sizes.put(segment, (4 + random.nextInt(12)) * mib));
+        sizes.put(segments.get(random.nextInt(segments.size())), (1024 + random.nextInt(3072)) * mib);
+      }
+      default -> segments.forEach(
+          segment -> sizes.put(segment, (long) Math.pow(2, 3 + random.nextInt(9)) * mib));
+    }
+    return sizes;
+  }
+
+  /// Regression test for a strict replica group rebalance that used to be pushed over the disk budget, found by
+  /// [#testStrictReplicaGroupRandomGroupStructureSearch].
+  ///
+  /// Before the instances to add were picked with the budget in mind, this stalled at a step where three of the four
+  /// groups still had an instance in their target assignment with room for them - `host01` had exactly the 2242 MiB
+  /// that one group needed, `host04` had room for another and `host00` for the third - but the instances were picked
+  /// purely on the number of segments to offload, which landed on `host00` (2186 MiB free, 56 MiB short), `host02`
+  /// (318 MiB free) and `host02` again. All three were rejected by the budget, none of the instances that fit was
+  /// tried, and with nothing able to move the budget was relaxed and `host02` went 36% over the disk it started with.
+  ///
+  /// A correct sequence existed the whole time; only the choice of instance was blind to the budget.
+  @Test
+  public void testStrictReplicaGroupStaysWithinTheDiskBudget() {
     Map<String, Map<String, String>> current = new TreeMap<>();
     Map<String, Map<String, String>> target = new TreeMap<>();
     Map<String, Long> sizes = new TreeMap<>();
@@ -330,18 +540,18 @@ public class LowDiskModeRebalanceSimulatorTest {
     assertEquals(TableRebalancer.getMinAvailableReplicas(current, target,
         SegmentAssignmentUtils.getSegmentsToMove(current, target), 1, LoggerFactory.getLogger(getClass())), 1);
 
-    SimResult result = simulate(new Scenario("Strict replica group forced over the disk budget", current, target, 1,
-        true, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, sizes));
+    SimResult result = simulate(new Scenario("Strict replica group within the disk budget", current, target, 1, true,
+        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, sizes));
     System.out.println(result.report());
-    assertTrue(result.hasSteadyStateViolation(), "expected the budget to be relaxed and a server to go over");
+    assertFalse(result.hasSteadyStateViolation(), "no server may hold more than max(initial, target)");
+    assertFalse(result.hasInStepViolation(), "no server may exceed max(initial, target) mid-step either");
+    assertTrue(result.relaxedSteps().isEmpty(), "the budget should not have to be relaxed for this assignment");
     assertEquals(result._groupSplits, Set.of(), "groups must still be moved together");
 
-    // The pre-check has to report it, before anything is moved
-    Map<String, Long> reported = TableRebalancer.getServersForcedOverDiskBudget(current, target, 1, true,
+    // And the pre-check must agree that it is safe
+    assertEquals(TableRebalancer.getServersForcedOverDiskBudget(current, target, 1, true,
         RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, toTableSizeDetails(sizes),
-        LoggerFactory.getLogger(getClass()));
-    System.out.println("Pre-check reports servers forced over their disk budget: " + reported);
-    assertTrue(reported.containsKey("host02"), "expected host02 to be reported, got " + reported);
+        LoggerFactory.getLogger(getClass())), Map.of());
   }
 
   /// The argument that the disk budget can never be the only thing blocking a step does not carry over to strict
@@ -360,7 +570,7 @@ public class LowDiskModeRebalanceSimulatorTest {
     List<String> splits = new ArrayList<>();
     List<SimResult> all = new ArrayList<>();
     int numSkippedAsIllegal = 0;
-    for (int trial = 0; trial < 3000; trial++) {
+    for (int trial = 0; trial < 20000; trial++) {
       int numServers = 3 + random.nextInt(6);
       int replication = 2 + random.nextInt(2);
       int numGroups = 2 + random.nextInt(5);
@@ -403,6 +613,7 @@ public class LowDiskModeRebalanceSimulatorTest {
     violations.sort((a, b) -> Double.compare(b.worstAmplification(), a.worstAmplification()));
     System.out.println();
     System.out.println(summarize("Strict replica group random group structures", all, violations));
+    assertEquals(relaxed.size(), 0, "the budget should not have to be relaxed for any of these assignments");
     System.out.printf("  skipped as illegal minAvailableReplicas: %d%n", numSkippedAsIllegal);
     if (!relaxed.isEmpty()) {
       System.out.printf("%nFOUND %d scenarios where the budget had to be relaxed. Worst:%n", relaxed.size());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/LowDiskModeRebalanceSimulatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/LowDiskModeRebalanceSimulatorTest.java
@@ -29,9 +29,11 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 import org.apache.pinot.common.restlet.resources.RebalanceConfig;
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentUtils;
 import org.apache.pinot.controller.util.TableSizeReader;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -202,6 +204,316 @@ public class LowDiskModeRebalanceSimulatorTest {
     assertFalse(result.hasSteadyStateViolation(), "no server may hold more than max(initial, target)");
     assertFalse(result.hasInStepViolation(), "no server may exceed max(initial, target) mid-step either");
     assertTrue(result.relaxedSteps().isEmpty(), "the budget should not have to be relaxed for this shape");
+  }
+
+  /// Exercises the escape hatch: when nothing can move within the budget, the rebalance relaxes it for a step rather
+  /// than stalling, and the replay the pre-check uses reports exactly the servers that go over.
+  ///
+  /// hostA and hostB both start at their ceiling and each has to take on a segment from the other, while the segments
+  /// that would free up their space cannot move at all - single replica, single target instance, so no addition is
+  /// ever attempted for them and `minAvailableReplicas = 1` forbids dropping the only replica.
+  ///
+  /// NOTE: this is not a state a real rebalance reaches. `TableRebalancer#getMinAvailableReplicas` rejects
+  /// `minAvailableReplicas = 1` when a segment being moved has a single target replica, so a rebalance would fail on
+  /// the config before getting here. It is kept because it is the only known way to drive the relaxation, and it
+  /// pins down what the replay reports when it happens.
+  @Test
+  public void testRelaxingTheBudgetIsReportedByTheReplay() {
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+    // Each needs a second replica on the other host, which is already at its ceiling
+    currentAssignment.put("needsReplicaOnB", instanceStateMap("hostA"));
+    currentAssignment.put("needsReplicaOnA", instanceStateMap("hostB"));
+    // These would free up the space, but cannot be moved while keeping 1 replica available
+    currentAssignment.put("stuckOnA", instanceStateMap("hostA"));
+    currentAssignment.put("stuckOnB", instanceStateMap("hostB"));
+
+    Map<String, Map<String, String>> targetAssignment = new TreeMap<>();
+    targetAssignment.put("needsReplicaOnB", instanceStateMap("hostA", "hostB"));
+    targetAssignment.put("needsReplicaOnA", instanceStateMap("hostB", "hostA"));
+    targetAssignment.put("stuckOnA", instanceStateMap("hostC"));
+    targetAssignment.put("stuckOnB", instanceStateMap("hostC"));
+
+    SimResult result = simulate(new Scenario("Cannot stay within the disk each server starts with", currentAssignment,
+        targetAssignment, 1, false, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER));
+    System.out.println(result.report());
+    // hostA and hostB each start with 2 segments and the target places 2 on them, so neither may ever hold 3
+    assertTrue(result.hasSteadyStateViolation(), "expected the rebalance to be forced over the bound");
+    assertEquals(result._maxAfter.get("hostA"), (Long) 3L);
+    assertEquals(result._maxAfter.get("hostB"), (Long) 3L);
+
+    // The pre-check must report exactly those two servers, before anything is moved
+    Map<String, Long> reported = TableRebalancer.getServersForcedOverDiskBudget(currentAssignment, targetAssignment, 1,
+        false, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, null, LoggerFactory.getLogger(getClass()));
+    System.out.println("Pre-check reports servers forced over their disk budget: " + reported);
+    assertEquals(reported, Map.of("hostA", 1L, "hostB", 1L));
+  }
+
+  private static Map<String, String> instanceStateMap(String... instances) {
+    return SegmentAssignmentUtils.getInstanceStateMap(List.of(instances), ONLINE);
+  }
+
+  /// A strict replica group rebalance that the disk budget genuinely cannot carry out, found by
+  /// [#testStrictReplicaGroupRandomGroupStructureSearch] and pinned here so it stays covered.
+  ///
+  /// At the blocking step `host02` has 318 MiB free under its own ceiling, but the group it has to take on is 6
+  /// segments totalling roughly 1.2 GiB and strict replica group routing requires all of them to move together, so it
+  /// does not fit. Every other movable group is blocked the same way, so the rebalance relaxes the budget rather than
+  /// stalling and `host02` ends up 36% over the disk it started with. Positive-but-insufficient headroom is what makes
+  /// this reachable in strict mode and not in the per-segment case.
+  @Test
+  public void testStrictReplicaGroupCanBeForcedOverTheDiskBudget() {
+    Map<String, Map<String, String>> current = new TreeMap<>();
+    Map<String, Map<String, String>> target = new TreeMap<>();
+    Map<String, Long> sizes = new TreeMap<>();
+    current.put("segment000", instanceStateMap("host02", "host07"));
+    current.put("segment001", instanceStateMap("host02", "host07"));
+    current.put("segment002", instanceStateMap("host02", "host07"));
+    current.put("segment003", instanceStateMap("host00", "host01"));
+    current.put("segment004", instanceStateMap("host00", "host01"));
+    current.put("segment005", instanceStateMap("host00", "host01"));
+    current.put("segment006", instanceStateMap("host00", "host01"));
+    current.put("segment007", instanceStateMap("host00", "host01"));
+    current.put("segment008", instanceStateMap("host04"));
+    current.put("segment009", instanceStateMap("host04"));
+    current.put("segment010", instanceStateMap("host04"));
+    current.put("segment011", instanceStateMap("host04"));
+    current.put("segment012", instanceStateMap("host04"));
+    current.put("segment013", instanceStateMap("host04"));
+    current.put("segment014", instanceStateMap("host04", "host05"));
+    current.put("segment015", instanceStateMap("host04", "host05"));
+    current.put("segment016", instanceStateMap("host04", "host05"));
+    current.put("segment017", instanceStateMap("host04", "host05"));
+    current.put("segment018", instanceStateMap("host04", "host05"));
+    current.put("segment019", instanceStateMap("host04", "host05"));
+    target.put("segment000", instanceStateMap("host00", "host01"));
+    target.put("segment001", instanceStateMap("host00", "host01"));
+    target.put("segment002", instanceStateMap("host00", "host01"));
+    target.put("segment003", instanceStateMap("host02", "host04"));
+    target.put("segment004", instanceStateMap("host02", "host04"));
+    target.put("segment005", instanceStateMap("host02", "host04"));
+    target.put("segment006", instanceStateMap("host02", "host04"));
+    target.put("segment007", instanceStateMap("host02", "host04"));
+    target.put("segment008", instanceStateMap("host00", "host06"));
+    target.put("segment009", instanceStateMap("host00", "host06"));
+    target.put("segment010", instanceStateMap("host00", "host06"));
+    target.put("segment011", instanceStateMap("host00", "host06"));
+    target.put("segment012", instanceStateMap("host00", "host06"));
+    target.put("segment013", instanceStateMap("host00", "host06"));
+    target.put("segment014", instanceStateMap("host00", "host02"));
+    target.put("segment015", instanceStateMap("host00", "host02"));
+    target.put("segment016", instanceStateMap("host00", "host02"));
+    target.put("segment017", instanceStateMap("host00", "host02"));
+    target.put("segment018", instanceStateMap("host00", "host02"));
+    target.put("segment019", instanceStateMap("host00", "host02"));
+    sizes.put("segment000", 1152385024L);
+    sizes.put("segment001", 8388608L);
+    sizes.put("segment002", 1190133760L);
+    sizes.put("segment003", 368050176L);
+    sizes.put("segment004", 28311552L);
+    sizes.put("segment005", 24117248L);
+    sizes.put("segment006", 938475520L);
+    sizes.put("segment007", 12582912L);
+    sizes.put("segment008", 8388608L);
+    sizes.put("segment009", 9437184L);
+    sizes.put("segment010", 20971520L);
+    sizes.put("segment011", 14680064L);
+    sizes.put("segment012", 31457280L);
+    sizes.put("segment013", 14680064L);
+    sizes.put("segment014", 24117248L);
+    sizes.put("segment015", 1207959552L);
+    sizes.put("segment016", 27262976L);
+    sizes.put("segment017", 16777216L);
+    sizes.put("segment018", 17825792L);
+    sizes.put("segment019", 18874368L);
+
+    // The config the rebalance would actually run with, so this is a state a real rebalance can be asked to carry out
+    assertEquals(TableRebalancer.getMinAvailableReplicas(current, target,
+        SegmentAssignmentUtils.getSegmentsToMove(current, target), 1, LoggerFactory.getLogger(getClass())), 1);
+
+    SimResult result = simulate(new Scenario("Strict replica group forced over the disk budget", current, target, 1,
+        true, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, sizes));
+    System.out.println(result.report());
+    assertTrue(result.hasSteadyStateViolation(), "expected the budget to be relaxed and a server to go over");
+    assertEquals(result._groupSplits, Set.of(), "groups must still be moved together");
+
+    // The pre-check has to report it, before anything is moved
+    Map<String, Long> reported = TableRebalancer.getServersForcedOverDiskBudget(current, target, 1, true,
+        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, toTableSizeDetails(sizes),
+        LoggerFactory.getLogger(getClass()));
+    System.out.println("Pre-check reports servers forced over their disk budget: " + reported);
+    assertTrue(reported.containsKey("host02"), "expected host02 to be reported, got " + reported);
+  }
+
+  /// The argument that the disk budget can never be the only thing blocking a step does not carry over to strict
+  /// replica group routing: there a whole group of segments has to move at once, so a group can be blocked while the
+  /// server it would move to still has room, which cannot happen when segments are charged one at a time. The sweeps
+  /// above only build groups by round robin, which makes them regular and equally sized, so they say little about it.
+  ///
+  /// Searches randomized group structures - random current and target instance sets, groups of differing sizes,
+  /// segments sitting at differing replica counts, skewed segment sizes - for a strict replica group rebalance the
+  /// budget cannot carry out.
+  @Test
+  public void testStrictReplicaGroupRandomGroupStructureSearch() {
+    Random random = new Random(101);
+    List<SimResult> relaxed = new ArrayList<>();
+    List<SimResult> violations = new ArrayList<>();
+    List<String> splits = new ArrayList<>();
+    List<SimResult> all = new ArrayList<>();
+    int numSkippedAsIllegal = 0;
+    for (int trial = 0; trial < 3000; trial++) {
+      int numServers = 3 + random.nextInt(6);
+      int replication = 2 + random.nextInt(2);
+      int numGroups = 2 + random.nextInt(5);
+      List<String> allServers = servers(0, numServers);
+      Map<String, Map<String, String>> current = new TreeMap<>();
+      Map<String, Map<String, String>> target = new TreeMap<>();
+      int segmentId = 0;
+      for (int group = 0; group < numGroups; group++) {
+        // Segments of a group share one current instance set and one target instance set. Let the current set be
+        // smaller than the replication so that groups part way through a move are covered too.
+        List<String> currentInstances = pickServers(allServers, 1 + random.nextInt(replication), random);
+        List<String> targetInstances = pickServers(allServers, replication, random);
+        int numSegmentsInGroup = 1 + random.nextInt(6);
+        for (int i = 0; i < numSegmentsInGroup; i++) {
+          String segment = String.format("segment%03d", segmentId++);
+          current.put(segment, SegmentAssignmentUtils.getInstanceStateMap(currentInstances, ONLINE));
+          target.put(segment, SegmentAssignmentUtils.getInstanceStateMap(targetInstances, ONLINE));
+        }
+      }
+      // Only run what the rebalance itself would accept
+      if (TableRebalancer.getMinAvailableReplicas(current, target,
+          SegmentAssignmentUtils.getSegmentsToMove(current, target), 1, LoggerFactory.getLogger(getClass()))
+          != 1) {
+        numSkippedAsIllegal++;
+        continue;
+      }
+      String name = String.format("trial %d: servers=%d replication=%d groups=%d segments=%d", trial, numServers,
+          replication, numGroups, current.size());
+      SimResult result = simulate(new Scenario(name, current, target, 1, true,
+          RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, skewedSizes(current.keySet(), random)));
+      all.add(result);
+      if (!result.relaxedSteps().isEmpty()) {
+        relaxed.add(result);
+      }
+      if (result.hasSteadyStateViolation()) {
+        violations.add(result);
+      }
+      result._groupSplits.forEach(split -> splits.add(name + " | " + split));
+    }
+    violations.sort((a, b) -> Double.compare(b.worstAmplification(), a.worstAmplification()));
+    System.out.println();
+    System.out.println(summarize("Strict replica group random group structures", all, violations));
+    System.out.printf("  skipped as illegal minAvailableReplicas: %d%n", numSkippedAsIllegal);
+    if (!relaxed.isEmpty()) {
+      System.out.printf("%nFOUND %d scenarios where the budget had to be relaxed. Worst:%n", relaxed.size());
+      SimResult worst = violations.isEmpty() ? relaxed.get(0) : violations.get(0);
+      System.out.println(worst.report());
+      dumpScenario(worst._scenario);
+    }
+    assertEquals(splits, List.of(), "strict replica group requires every group of segments to be moved together");
+  }
+
+  /// Prints a scenario as Java source, so a case found by the random search can be pinned as a fixed test.
+  private static void dumpScenario(Scenario scenario) {
+    System.out.println("---- scenario as source ----");
+    scenario._currentAssignment.forEach((segment, instanceStateMap) -> System.out.printf(
+        "    current.put(\"%s\", instanceStateMap(%s));%n", segment,
+        instanceStateMap.keySet().stream().map(i -> '"' + i + '"').collect(Collectors.joining(", "))));
+    scenario._targetAssignment.forEach((segment, instanceStateMap) -> System.out.printf(
+        "    target.put(\"%s\", instanceStateMap(%s));%n", segment,
+        instanceStateMap.keySet().stream().map(i -> '"' + i + '"').collect(Collectors.joining(", "))));
+    scenario._segmentSizeBytes.forEach(
+        (segment, sizeBytes) -> System.out.printf("    sizes.put(\"%s\", %dL);%n", segment, sizeBytes));
+    System.out.println("---- end ----");
+  }
+
+  /// Picks `count` distinct servers at random, in a stable order so the assignment is deterministic per seed.
+  private static List<String> pickServers(List<String> allServers, int count, Random random) {
+    List<String> shuffled = new ArrayList<>(allServers);
+    for (int i = shuffled.size() - 1; i > 0; i--) {
+      int j = random.nextInt(i + 1);
+      shuffled.set(i, shuffled.set(j, shuffled.get(i)));
+    }
+    List<String> picked = new ArrayList<>(shuffled.subList(0, Math.min(count, shuffled.size())));
+    picked.sort(null);
+    return picked;
+  }
+
+  /// Sweeps the grid with `batchSizePerServer` set, which is the combination the sweeps above do not cover: batching
+  /// can defer a partition for reasons of its own, and the disk budget can defer the rest, so between them a step can
+  /// end up making no progress at all.
+  @Test
+  public void testSweepWithBatchSizePerServer() {
+    Random random = new Random(31);
+    List<SimResult> violations = new ArrayList<>();
+    List<SimResult> all = new ArrayList<>();
+    for (int numOldServers = 3; numOldServers <= 7; numOldServers++) {
+      for (int shift = 1; shift < numOldServers; shift++) {
+        for (int replication = 2; replication <= 3; replication++) {
+          for (int batchSizePerServer : List.of(1, 2, 5)) {
+            for (boolean enableStrictReplicaGroup : List.of(false, true)) {
+              int numSegments = 12 * replication;
+              List<String> oldServers = servers(0, numOldServers);
+              List<String> newServers = servers(shift, numOldServers);
+              Map<String, Map<String, String>> current = roundRobin(numSegments, replication, oldServers, 0);
+              String name = String.format("old=%d shift=%d replication=%d batchSizePerServer=%d strict=%s",
+                  numOldServers, shift, replication, batchSizePerServer, enableStrictReplicaGroup);
+              all.add(simulate(new Scenario(name, current, roundRobin(numSegments, replication, newServers, 0), 1,
+                  enableStrictReplicaGroup, batchSizePerServer, skewedSizes(current.keySet(), random))));
+            }
+          }
+        }
+      }
+    }
+    List<String> splits = new ArrayList<>();
+    for (SimResult result : all) {
+      if (result.hasSteadyStateViolation()) {
+        violations.add(result);
+      }
+      result._groupSplits.forEach(split -> splits.add(result._scenario._name + " | " + split));
+    }
+    violations.sort((a, b) -> Double.compare(b.worstAmplification(), a.worstAmplification()));
+    System.out.println();
+    System.out.println(summarize("Sweep with batchSizePerServer and skewed sizes", all, violations));
+    for (SimResult result : violations.subList(0, Math.min(5, violations.size()))) {
+      System.out.println(result.report());
+    }
+    assertEquals(splits, List.of(), "strict replica group requires every group of segments to be moved together");
+  }
+
+  /// The pre-check replay must agree with what the rebalance actually does: for every scenario, the servers it
+  /// reports as forced over their disk have to be exactly the ones the simulation observes going over.
+  @Test
+  public void testDiskBudgetReplayMatchesTheRebalance() {
+    Random random = new Random(23);
+    int numChecked = 0;
+    for (int numOldServers = 3; numOldServers <= 7; numOldServers++) {
+      for (int shift = 1; shift < numOldServers; shift++) {
+        for (int replication = 2; replication <= 3; replication++) {
+          for (boolean enableStrictReplicaGroup : List.of(false, true)) {
+            int numSegments = 12 * replication;
+            List<String> oldServers = servers(0, numOldServers);
+            List<String> newServers = servers(shift, numOldServers);
+            Map<String, Map<String, String>> current = roundRobin(numSegments, replication, oldServers, 0);
+            Map<String, Map<String, String>> target = roundRobin(numSegments, replication, newServers, 0);
+            Map<String, Long> segmentSizeBytes = skewedSizes(current.keySet(), random);
+            String name = String.format("old=%d new=%d replication=%d strict=%s", numOldServers, numOldServers,
+                replication, enableStrictReplicaGroup);
+            SimResult result = simulate(new Scenario(name, current, target, 1, enableStrictReplicaGroup,
+                RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, segmentSizeBytes));
+
+            Map<String, Long> reported = TableRebalancer.getServersForcedOverDiskBudget(current, target, 1,
+                enableStrictReplicaGroup, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER,
+                toTableSizeDetails(segmentSizeBytes), LoggerFactory.getLogger(getClass()));
+            Set<String> observed = new TreeSet<>();
+            result.relaxedSteps().forEach(step -> observed.addAll(step._deferralRelaxedFor));
+            assertEquals(reported.keySet(), observed, name + ": pre-check replay disagrees with the rebalance");
+            numChecked++;
+          }
+        }
+      }
+    }
+    System.out.printf("%nDisk budget replay agreed with the rebalance on all %d scenarios%n%n", numChecked);
   }
 
   /// Sweeps a grid of overlapping old/new server sets and reports the worst amplification found, so the blast

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/LowDiskModeRebalanceSimulatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/LowDiskModeRebalanceSimulatorTest.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.restlet.resources.RebalanceConfig;
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentUtils;
 import org.apache.pinot.controller.util.TableSizeReader;
@@ -250,6 +251,309 @@ public class LowDiskModeRebalanceSimulatorTest {
 
   private static Map<String, String> instanceStateMap(String... instances) {
     return SegmentAssignmentUtils.getInstanceStateMap(List.of(instances), ONLINE);
+  }
+
+  /// The disk budget holds a total per pair of current and target instances, used to pick which instance to add. It
+  /// is tempting to charge a strict replica group move by looking that total up, but the two are different totals when
+  /// batching is enabled: `updateNextAssignmentForPartitionIdStrictReplicaGroup` is then called once per partition,
+  /// while the step-wide total spans every partition sharing the pair. Looking it up would charge the whole pair for
+  /// each partition, over-charging by the number of partitions that share it.
+  ///
+  /// Several partitions sharing one pair of instances is the normal shape for a replica group table, where partitions
+  /// per replica group is exactly that multiple.
+  @Test
+  public void testStrictReplicaGroupChargesPerPartitionNotPerInstancePair() {
+    long mib = 1024L * 1024;
+    Map<String, Map<String, String>> current = new TreeMap<>();
+    Map<String, Map<String, String>> target = new TreeMap<>();
+    Map<String, Long> sizes = new TreeMap<>();
+    for (int partition = 0; partition < 2; partition++) {
+      for (int sequence = 0; sequence < 2; sequence++) {
+        String segment = "myTable__" + partition + "__" + sequence + "__20240101T0000Z";
+        current.put(segment, instanceStateMap("hostA", "hostB"));
+        target.put(segment, instanceStateMap("hostC", "hostD"));
+        sizes.put(segment, 100 * mib);
+      }
+    }
+    TableRebalancer.StepDiskBudget stepBudget =
+        TableRebalancer.DiskUsageBudget.create(current, toTableSizeDetails(sizes)).forStep(current, target);
+
+    // All four segments share one pair of instances, so the step-wide map holds a single total covering both partitions
+    Map<Pair<Set<String>, Set<String>>, Long> stepWide = stepBudget.getInstancePairToBytes(current, target);
+    assertEquals(stepWide.size(), 1);
+    long stepWideBytes = stepWide.values().iterator().next();
+
+    // What one call is handed once batching has grouped by pair and then by partition
+    Map<String, Map<String, String>> onePartition = new TreeMap<>();
+    current.forEach((segment, instanceStateMap) -> {
+      if (segment.startsWith("myTable__0__")) {
+        onePartition.put(segment, instanceStateMap);
+      }
+    });
+    long onePartitionBytes = stepBudget.getInstancePairToBytes(onePartition, target).values().iterator().next();
+
+    System.out.printf("%n  step-wide total for the pair: %s, what one call is handed: %s%n",
+        formatMib(stepWideBytes), formatMib(onePartitionBytes));
+    assertEquals(onePartitionBytes, 200 * mib);
+    assertEquals(stepWideBytes, 2 * onePartitionBytes,
+        "the step-wide total spans both partitions, so charging it per partition would double count");
+  }
+
+  /// Where a segment added mid-rebalance costs headroom, and where it does not.
+  ///
+  /// The new segment is credited to the anchor of the servers hosting it, so `ceiling` becomes
+  /// `max(initial + upload, target)`. That covers the upload whenever the anchor side of the max wins - which it
+  /// always does on a server whose net change is a loss. On a server that is growing, the target side wins and the
+  /// credit is swallowed by the max, so the upload eats headroom.
+  ///
+  /// It only costs anything at all when the target assignment does not place the segment where it landed. When it
+  /// does, the target rises by the same amount and the cost cancels out wherever it fell. That is the case strict
+  /// replica group assignment cannot give us: `BaseStrictRealtimeSegmentAssignment` overrides a new segment onto its
+  /// partition's existing placement to keep the partition collocated, which mid-rebalance is the placement the
+  /// rebalance is moving away from.
+  @Test
+  public void testWhereMidRebalanceUploadsCostHeadroom() {
+    long mib = 1024L * 1024;
+    System.out.printf("%n  %-34s %12s %12s %10s%n", "case", "control", "with upload", "cost");
+    for (boolean netLoss : List.of(true, false)) {
+      for (boolean targetAgrees : List.of(true, false)) {
+        long control = remainingOnFocus(netLoss, null, 0, mib);
+        long withUpload = remainingOnFocus(netLoss, targetAgrees ? "focus" : "elsewhere", 300 * mib, mib);
+        System.out.printf("  %-34s %12s %12s %10s%n",
+            (netLoss ? "net loss, " : "net gain,  ") + (targetAgrees ? "target agrees" : "target elsewhere"),
+            formatMib(control), formatMib(withUpload), formatMib(control - withUpload));
+        if (netLoss || targetAgrees) {
+          assertEquals(withUpload, control, "this placement must not cost the rebalance any headroom");
+        } else {
+          // The one combination that costs anything: on a growing server the target side of the max wins, so the
+          // credit for the new segment is swallowed, and the target does not carry it either. The cost is exactly the
+          // segment that appeared, which bounds it - pinned so that a change widening it fails here
+          assertEquals(control - withUpload, 300 * mib,
+              "the cost must stay bounded by the size of the segment that appeared");
+        }
+      }
+    }
+  }
+
+  /// Headroom on `focus` in a mid-rebalance state, optionally with a segment that appeared after the anchor was taken.
+  /// `netLoss` picks whether `focus` is shedding bytes overall or taking them on.
+  private static long remainingOnFocus(boolean netLoss, String uploadedOn, long uploadSizeBytes, long mib) {
+    Map<String, Map<String, String>> initialAssignment = new TreeMap<>();
+    Map<String, Map<String, String>> current = new TreeMap<>();
+    Map<String, Map<String, String>> target = new TreeMap<>();
+    Map<String, Long> sizes = new TreeMap<>();
+
+    if (netLoss) {
+      // focus starts on 1000M and the target places 600M, so the anchor side of the max wins
+      addSegment(initialAssignment, current, target, sizes, "kept", List.of("focus"), List.of("focus"),
+          List.of("focus"), 500 * mib);
+      addSegment(initialAssignment, current, target, sizes, "dropped", List.of("focus"), List.of("other"),
+          List.of("other"), 500 * mib);
+      addSegment(initialAssignment, current, target, sizes, "arriving", List.of("other"), List.of("other"),
+          List.of("focus"), 100 * mib);
+    } else {
+      // focus starts on 100M and the target places 1000M, so the target side of the max wins
+      addSegment(initialAssignment, current, target, sizes, "kept", List.of("focus"), List.of("focus"),
+          List.of("focus"), 100 * mib);
+      addSegment(initialAssignment, current, target, sizes, "arriving", List.of("other"), List.of("other"),
+          List.of("focus"), 900 * mib);
+    }
+    if (uploadedOn != null) {
+      // Appeared after the anchor was taken, so it is absent from initialAssignment
+      current.put("uploaded", instanceStateMap("focus"));
+      target.put("uploaded", instanceStateMap(uploadedOn));
+      sizes.put("uploaded", uploadSizeBytes);
+    }
+    return TableRebalancer.DiskUsageBudget.create(initialAssignment, toTableSizeDetails(sizes))
+        .forStep(current, target).getRemainingBytes().getOrDefault("focus", 0L);
+  }
+
+  private static void addSegment(Map<String, Map<String, String>> initialAssignment,
+      Map<String, Map<String, String>> current, Map<String, Map<String, String>> target, Map<String, Long> sizes,
+      String segment, List<String> initialInstances, List<String> currentInstances, List<String> targetInstances,
+      long sizeBytes) {
+    initialAssignment.put(segment, SegmentAssignmentUtils.getInstanceStateMap(initialInstances, ONLINE));
+    current.put(segment, SegmentAssignmentUtils.getInstanceStateMap(currentInstances, ONLINE));
+    target.put(segment, SegmentAssignmentUtils.getInstanceStateMap(targetInstances, ONLINE));
+    sizes.put(segment, sizeBytes);
+  }
+
+  /// A segment uploaded onto a server that the target assignment also places it on is not automatically harmless.
+  ///
+  /// The ceiling is `max(frozen initial bytes, target bytes)`. Where a server's net change is a gain, the upload
+  /// raises the target side of that max by as much as it raises what the server hosts, so the headroom is untouched.
+  /// Where the net change is a loss the ceiling is pinned to the frozen initial bytes, which the upload cannot raise,
+  /// so an upload accounted for there would consume headroom outright. The budget therefore accounts only for the
+  /// segments the rebalance started with, which keeps the headroom of a net-loss server intact.
+  ///
+  /// `host0` below hosts 1000M and the target places 600M on it, a net loss of 400M. It has to drop a 500M segment and
+  /// take on a 100M one, so once the drop lands it has 500M of headroom for a 100M arrival.
+  @Test
+  public void testUploadOntoNetLossServerEatsHeadroom() {
+    long mib = 1024L * 1024;
+    System.out.printf("%n  %-10s %10s %10s %10s %10s %10s   %s%n", "upload", "ceiling", "hosted", "remaining",
+        "needs", "margin", "verdict");
+    long marginWithoutUpload = -1;
+    for (long uploadMib : List.of(0L, 100L, 200L, 400L, 700L)) {
+      // The state after host0 has dropped its outgoing segment, which is where its headroom opens up
+      Map<String, Map<String, String>> current = new TreeMap<>();
+      Map<String, Map<String, String>> target = new TreeMap<>();
+      Map<String, Long> sizes = new TreeMap<>();
+      Map<String, Map<String, String>> initialAssignment = new TreeMap<>();
+
+      // kept by host0
+      initialAssignment.put("kept", instanceStateMap("host0", "host1"));
+      current.put("kept", instanceStateMap("host0", "host1"));
+      target.put("kept", instanceStateMap("host0", "host1"));
+      sizes.put("kept", 500 * mib);
+      // dropped by host0 — present when the rebalance started, already gone in this state
+      initialAssignment.put("dropped", instanceStateMap("host0", "host1"));
+      current.put("dropped", instanceStateMap("host1"));
+      target.put("dropped", instanceStateMap("host1", "host2"));
+      sizes.put("dropped", 500 * mib);
+      // still to arrive on host0
+      initialAssignment.put("arriving", instanceStateMap("host1", "host2"));
+      current.put("arriving", instanceStateMap("host1"));
+      target.put("arriving", instanceStateMap("host0", "host1"));
+      sizes.put("arriving", 100 * mib);
+
+      if (uploadMib > 0) {
+        // Uploaded after the rebalance started, so absent from the anchor, and placed on host0 by both assignments
+        current.put("uploaded", instanceStateMap("host0"));
+        target.put("uploaded", instanceStateMap("host0"));
+        sizes.put("uploaded", uploadMib * mib);
+      }
+
+      TableRebalancer.DiskUsageBudget budget =
+          TableRebalancer.DiskUsageBudget.create(initialAssignment, toTableSizeDetails(sizes));
+      long remaining = budget.forStep(current, target).getRemainingBytes().getOrDefault("host0", 0L);
+      long hosted = hostedBytesOf(current, sizes).getOrDefault("host0", 0L);
+      // The ceiling the budget is actually working to, which the credit for the uploaded segment raises
+      long ceiling = hosted + remaining;
+      long needs = 100 * mib;
+      long margin = remaining - needs;
+      if (uploadMib == 0) {
+        marginWithoutUpload = margin;
+      }
+      System.out.printf("  %-10s %10s %10s %10s %10s %10s   %s%n", uploadMib == 0 ? "none" : uploadMib + "M",
+          formatMib(ceiling), formatMib(hosted), formatMib(remaining), formatMib(needs), formatMib(margin),
+          margin < 0 ? "BLOCKED" : margin == 0 ? "exact fit, no slack" : "fits");
+      if (uploadMib > 0) {
+        assertEquals(margin, marginWithoutUpload,
+            uploadMib + "M upload must not consume headroom the rebalance needs");
+      }
+    }
+    System.out.println("\n  The margin that absorbs group granularity is unaffected by the upload, because the"
+        + " budget accounts\n  only for the segments the rebalance started with.");
+  }
+
+  /// Segments can be added to a table while a rebalance is running - an uploaded segment, or a new consuming segment.
+  /// The budget is anchored once, before the first step, so it has never heard of them: they are absent from
+  /// `initialServerBytes` and from the per-segment sizes, while they do count towards what a server hosts now and
+  /// towards the recalculated target. Drives that directly, holding the budget across the injection the way
+  /// `doRebalance` does.
+  @Test
+  public void testSegmentsAddedDuringTheRebalance() {
+    List<String> oldServers = List.of("host1", "host2", "host3");
+    List<String> newServers = List.of("host2", "host3", "host4");
+    Map<String, Map<String, String>> current = roundRobin(12, 2, oldServers, 0);
+    Map<String, Map<String, String>> target = roundRobin(12, 2, newServers, 0);
+    Map<String, Long> sizes = new TreeMap<>();
+    current.keySet().forEach(segment -> sizes.put(segment, 100L * 1024 * 1024));
+
+    // The budget the controller builds once, before the first step
+    TableRebalancer.DiskUsageBudget diskUsageBudget =
+        TableRebalancer.DiskUsageBudget.create(current, toTableSizeDetails(sizes));
+    Map<String, Long> frozenCeiling = new TreeMap<>();
+    Map<String, Long> initialBytes = hostedBytesOf(current, sizes);
+    hostedBytesOf(target, sizes).forEach(
+        (server, bytes) -> frozenCeiling.put(server, Math.max(initialBytes.getOrDefault(server, 0L), bytes)));
+    initialBytes.forEach((server, bytes) -> frozenCeiling.merge(server, bytes, Math::max));
+
+    Map<String, Long> peak = new TreeMap<>(initialBytes);
+    int numRelaxedSteps = 0;
+    boolean converged = false;
+    for (int step = 1; step <= 40; step++) {
+      // Segments uploaded part way through, placed by the instance partitions in force at upload time - the old
+      // servers - while the recalculated target places them on the new servers. The overlap servers therefore host
+      // them without the target assignment accounting for them
+      if (step == 3) {
+        for (int i = 0; i < 4; i++) {
+          String uploaded = "uploaded" + i;
+          current.put(uploaded, SegmentAssignmentUtils.getInstanceStateMap(List.of("host1", "host2"), ONLINE));
+          target.put(uploaded, SegmentAssignmentUtils.getInstanceStateMap(List.of("host3", "host4"), ONLINE));
+          sizes.put(uploaded, 400L * 1024 * 1024);
+        }
+        System.out.println("  step 3: 4 uploaded segments of 400M landed on host1/host2, target says host3/host4");
+      }
+      Map<String, Long> allowed = diskUsageBudget.forStep(current, target).getRemainingBytes();
+      // A new segment is credited to the anchor once, so asking again must give the same answer. If it were credited
+      // per call, the rebalance could raise its own ceiling simply by taking another step
+      assertEquals(diskUsageBudget.forStep(current, target).getRemainingBytes(), allowed,
+          "crediting a new segment to the anchor must be idempotent");
+      Map<String, Map<String, String>> next =
+          TableRebalancer.getNextAssignment(current, target, 1, false, true,
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+              NO_DATA_LOSS_RISK, diskUsageBudget);
+      if (next.equals(current)) {
+        break;
+      }
+      // Measured against what the budget accounts for: segments added while the rebalance runs are outside it, so
+      // the bytes they bring are not the rebalance going over its budget
+      Map<String, Long> added = new TreeMap<>();
+      for (Map.Entry<String, Map<String, String>> entry : next.entrySet()) {
+        Map<String, String> currentInstanceStateMap = current.get(entry.getKey());
+        long budgetedBytes = diskUsageBudget.getSegmentSizeBytes(entry.getKey());
+        for (String instance : entry.getValue().keySet()) {
+          if (currentInstanceStateMap == null || !currentInstanceStateMap.containsKey(instance)) {
+            added.merge(instance, budgetedBytes, Long::sum);
+          }
+        }
+      }
+      for (Map.Entry<String, Long> entry : added.entrySet()) {
+        if (entry.getValue() > allowed.getOrDefault(entry.getKey(), 0L)) {
+          numRelaxedSteps++;
+          System.out.printf("  step %d: budget relaxed - %s took %s but was allowed %s%n", step, entry.getKey(),
+              formatMib(entry.getValue()), formatMib(allowed.getOrDefault(entry.getKey(), 0L)));
+          break;
+        }
+      }
+      current = next;
+      hostedBytesOf(current, sizes).forEach((server, bytes) -> peak.merge(server, bytes, Math::max));
+      if (current.equals(target)) {
+        converged = true;
+        break;
+      }
+    }
+
+    System.out.printf("%nconverged=%s, steps where the rebalance exceeded its budget=%d%n", converged,
+        numRelaxedSteps);
+    System.out.println("  peak below counts every segment on the server, including the uploaded ones the budget does"
+        + " not account for");
+    Map<String, Long> finalBytes = hostedBytesOf(target, sizes);
+    System.out.printf("  %-8s %10s %10s %12s %10s%n", "server", "initial", "final", "frozenCeil", "peak");
+    for (String server : peak.keySet()) {
+      System.out.printf("  %-8s %10s %10s %12s %10s%s%n", server,
+          formatMib(initialBytes.getOrDefault(server, 0L)), formatMib(finalBytes.getOrDefault(server, 0L)),
+          formatMib(frozenCeiling.getOrDefault(server, 0L)), formatMib(peak.get(server)),
+          peak.get(server) > Math.max(frozenCeiling.getOrDefault(server, 0L),
+              finalBytes.getOrDefault(server, 0L)) ? "   above the ceiling, carrying uploaded segments" : "");
+    }
+    assertTrue(converged, "the rebalance must still converge when segments are added while it runs");
+    assertEquals(numRelaxedSteps, 0,
+        "segments added while the rebalance runs must not push it outside the budget it started with");
+  }
+
+  private static Map<String, Long> hostedBytesOf(Map<String, Map<String, String>> assignment,
+      Map<String, Long> sizes) {
+    Map<String, Long> bytes = new TreeMap<>();
+    assignment.forEach((segment, instanceStateMap) -> instanceStateMap.keySet()
+        .forEach(instance -> bytes.merge(instance, sizes.get(segment), Long::sum)));
+    return bytes;
+  }
+
+  private static String formatMib(long bytes) {
+    return (bytes / (1024 * 1024)) + "M";
   }
 
   /// Searches broadly for rebalances the disk budget cannot carry out, i.e. the ones the disk utilization pre-check

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/LowDiskModeRebalanceSimulatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/LowDiskModeRebalanceSimulatorTest.java
@@ -22,745 +22,453 @@ import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.restlet.resources.RebalanceConfig;
+import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentUtils;
 import org.apache.pinot.controller.util.TableSizeReader;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 
-/// Step-by-step simulator for `lowDiskMode` rebalance, used to demonstrate that a server can still see a **net
-/// increase** in the number of hosted segments (i.e. disk usage) while the rebalance is in flight.
+/// Drives the real [TableRebalancer#getNextAssignment] step by step, the way [TableRebalancer] does, and checks the
+/// three things low disk mode promises:
 ///
-/// The simulator drives the real [TableRebalancer#getNextAssignment] in a loop, exactly the way
-/// [TableRebalancer] does, and after each step accounts, per server:
-///  * `before`  - segments hosted before the step
-///  * `+adds`   - segments the step assigns to the server (a download)
-///  * `-drops`  - segments the step removes from the server (a deletion)
-///  * `after`   - segments hosted once the step converges
+/// 1. the rebalance always reaches the target assignment, i.e. deferring segment moves never wedges it;
+/// 2. no server is pushed above `max(bytes it held that this rebalance did not place, bytes the target places on it)`,
+///    except where the disk utilization pre-check says up front that it will be;
+/// 3. under strict replica group routing, segments sharing a current and target instance pair always move together.
 ///
-/// `lowDiskMode` is supposed to guarantee that no server ever needs more disk than it started with (or than the
-/// target asks it to hold), so the invariant checked here is:
+/// Segment sizes are the ones [TableSizeReader] reports. Where a scenario supplies none, every segment weighs one
+/// byte, which turns the budget into a bound on the number of segments hosted.
 ///
-///     usage(server, any point in time) <= max(initialUsage(server), targetUsage(server))
-///
-/// Two peaks are tracked against that bound:
-///  * `maxAfter`     - the steady-state peak, i.e. the assignment the controller actually publishes. Exceeding the
-///                     bound here is a *persistent* over-allocation that lasts for at least one full step.
-///  * `maxInStep`    - the worst-case peak within a step (`before + adds`). `getNextSingleSegmentAssignment` notes
-///                     that "even if segment addition and drop happen in the same step, there is no guarantee that
-///                     server process the segment drop before the segment addition", so this is reachable.
-///
-/// All segments are treated as equal-sized, so "segment count" is a proxy for disk.
+/// [#main] runs randomized sweeps over a far wider space than the tests do, and reports how often the budget had to be
+/// given up and how many steps it took. That is for comparing two versions of the assignment logic by hand, not for
+/// CI, so it is deliberately not a test.
 public class LowDiskModeRebalanceSimulatorTest {
   private static final String ONLINE = "ONLINE";
-  private static final int MAX_STEPS = 50;
+  private static final int MAX_STEPS = 200;
+  private static final long MIB = 1024L * 1024;
   private static final TableRebalancer.PartitionIdFetcher DUMMY_PARTITION_FETCHER = segmentName -> 0;
+  /// Reads the partition id back out of a segment name, so that batching groups segments the way it would in a
+  /// cluster rather than treating the whole table as one partition
+  private static final TableRebalancer.PartitionIdFetcher LLC_PARTITION_FETCHER = segmentName -> {
+    LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
+    return llcSegmentName == null ? 0 : llcSegmentName.getPartitionGroupId();
+  };
   private static final TableRebalancer.DataLossRiskAssessor NO_DATA_LOSS_RISK =
       new TableRebalancer.NoOpRiskAssessor();
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // The three guarantees
+  // ---------------------------------------------------------------------------------------------------------------
+
+  /// The budget defers segment moves, so the thing to rule out is that it defers them forever.
+  @Test
+  public void testRebalanceAlwaysReachesTheTargetAssignment() {
+    for (Scenario scenario : scenarios()) {
+      SimResult result = simulate(scenario);
+      assertTrue(result.reachedTarget(), scenario._name + ": " + result._outcome + result.report());
+    }
+  }
+
+  /// The bound, and the pre-check that reports where it cannot be held.
+  ///
+  /// When no progress at all is possible within the budget, the rebalance gives it up for a step rather than stalling,
+  /// so the bound is not absolute. What is absolute is that the pre-check replay names exactly the servers that go
+  /// over, before any segment moves: an operator told nothing is entitled to a rebalance that stays within the disk
+  /// every server started with.
+  @Test
+  public void testSequenceStaysWithinBudgetUnlessThePreCheckSaysOtherwise() {
+    for (Scenario scenario : scenarios()) {
+      SimResult result = simulate(scenario);
+      if (scenario._injectAtStep > 0) {
+        // The pre-check runs before the rebalance, so it cannot know about segments that appear while it runs. Those
+        // are credited to the anchor when first seen, which has to keep the rebalance inside the budget on its own
+        assertEquals(result._serversOverBudget, Set.of(),
+            scenario._name + ": went outside the budget while segments were being added" + result.report());
+        continue;
+      }
+      Set<String> reported = TableRebalancer.getServersForcedOverDiskBudget(scenario._currentAssignment,
+          scenario._targetAssignment, scenario._minAvailableReplicas, scenario._enableStrictReplicaGroup,
+          scenario._batchSizePerServer, toTableSizeDetails(scenario._segmentSizeBytes),
+          LoggerFactory.getLogger(getClass())).keySet();
+      // Asserting what the pre-check reports, and not only that it agrees with the rebalance, is what makes this fail
+      // when a change starts giving the budget up on a shape that used to hold: the equality on its own passes a
+      // rebalance that goes over and says so.
+      if (scenario._withinBudget) {
+        assertEquals(reported, Set.of(),
+            scenario._name + ": the pre-check says the budget cannot be held for a shape that it should"
+                + result.report());
+      } else {
+        assertTrue(!reported.isEmpty(), scenario._name + ": expected the pre-check to report a server, so that the "
+            + "case where it does is covered. If a change made this shape hold, clear its withinBudget flag"
+            + result.report());
+      }
+      assertEquals(result._serversOverBudget, reported,
+          scenario._name + ": the servers that went over the budget are not the ones the pre-check named"
+              + result.report());
+    }
+  }
+
+  /// Strict replica group routing needs every segment of a partition on the same instances at all times, so the budget
+  /// has to charge a whole group of segments at once. Charging one segment at a time fits the first few segments of a
+  /// partition and not the rest, which splits the partition across replica groups.
+  @Test
+  public void testStrictReplicaGroupMovesGroupsTogether() {
+    for (Scenario scenario : scenarios()) {
+      if (scenario._enableStrictReplicaGroup) {
+        SimResult result = simulate(scenario);
+        assertEquals(result._groupSplits, Set.of(),
+            scenario._name + ": split a group of segments across instances" + result.report());
+      }
+    }
+  }
 
   // ---------------------------------------------------------------------------------------------------------------
   // Scenarios
   // ---------------------------------------------------------------------------------------------------------------
 
-  /// The minimal toy example: 3 servers -> 3 servers with 2 servers in the overlap, replication 2,
-  /// `minAvailableReplicas = 1`. Every overlap server both offloads and onloads segments.
-  ///
-  /// `hostC` starts with 4 segments and ends with 4 segments, but transiently holds 6.
-  @Test
-  public void testOverlappingServerSetsRotation() {
-    List<String> oldServers = List.of("hostA", "hostB", "hostC");
-    List<String> newServers = List.of("hostB", "hostC", "hostD");
-    Scenario scenario =
-        new Scenario("3 servers -> 3 servers, 2 in overlap (replication 2, minAvailableReplicas 1)",
-            roundRobin(6, 2, oldServers, 0), roundRobin(6, 2, newServers, 0), 1, false,
-            RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER);
-    SimResult result = simulate(scenario);
-    System.out.println(result.report());
-    assertFalse(result.hasSteadyStateViolation(),
-        "lowDiskMode must not let any server hold more than max(initial, target) segments");
-    assertFalse(result.hasInStepViolation(),
-        "lowDiskMode must not let any server download while it still has segments to drop");
-  }
-
-  /// Same shape, with strict replica-group enabled, to show the problem is not specific to the non-strict path.
-  @Test
-  public void testOverlappingServerSetsRotationStrictReplicaGroup() {
-    List<String> oldServers = List.of("hostA", "hostB", "hostC");
-    List<String> newServers = List.of("hostB", "hostC", "hostD");
-    Scenario scenario = new Scenario("Same, strictReplicaGroup = true", roundRobin(6, 2, oldServers, 0),
-        roundRobin(6, 2, newServers, 0), 1, true, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER);
-    SimResult result = simulate(scenario);
-    System.out.println(result.report());
-    assertFalse(result.hasSteadyStateViolation(),
-        "lowDiskMode must not let any server hold more than max(initial, target) segments");
-    assertFalse(result.hasInStepViolation(),
-        "lowDiskMode must not let any server download while it still has segments to drop");
-    assertEquals(result._groupSplits, Set.of());
-  }
-
-  /// The disk budget is charged as segments are assigned, so charging it per segment could fit the first segments of a
-  /// partition and not the rest, splitting the partition across replica groups. Sweeps the grid with strict replica
-  /// group routing and skewed segment sizes - which is what makes a group only partially fit - and checks that every
-  /// group of segments sharing the same current and target instances is always moved as a whole.
-  @Test
-  public void testStrictReplicaGroupMovesGroupsTogether() {
+  /// The shapes worth holding down: the overlapping server sets that per-segment sequencing could not bound, a pure
+  /// scale-out as a control, both routing modes, batching, uneven segment sizes, segments arriving mid-rebalance, and
+  /// the assignment a randomized search found hardest.
+  private static List<Scenario> scenarios() {
     Random random = new Random(11);
-    List<SimResult> violations = new ArrayList<>();
-    List<SimResult> all = new ArrayList<>();
-    List<String> splits = new ArrayList<>();
+    List<Scenario> scenarios = new ArrayList<>();
+    List<String> threeOld = List.of("host1", "host2", "host3");
+    List<String> threeNew = List.of("host2", "host3", "host4");
+    List<String> sixOld = servers(0, 6);
+    List<String> sixNew = servers(3, 6);
+
+    for (boolean strict : List.of(false, true)) {
+      String suffix = strict ? " [strict]" : "";
+      // The original shape: every server in the overlap both sheds and takes on segments
+      scenarios.add(new Scenario("3 -> 3 servers, 2 in overlap" + suffix, roundRobin(6, 2, threeOld, 0),
+          roundRobin(6, 2, threeNew, 0), 1, strict, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, Map.of(), 0));
+      // Same, with uneven segment sizes, which is what a budget counting segments cannot see
+      Map<String, Map<String, String>> skewed = roundRobin(24, 2, sixOld, 0);
+      scenarios.add(new Scenario("6 -> 6 servers, 3 in overlap, uneven sizes" + suffix, skewed,
+          roundRobin(24, 2, sixNew, 0), 1, strict, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER,
+          skewedSizes(skewed.keySet(), random), 0));
+      // Replication 3 against a minimum of 1, so a segment has to gain two instances at once
+      Map<String, Map<String, String>> deep = roundRobin(18, 3, sixOld, 0);
+      scenarios.add(new Scenario("6 -> 6 servers, replication 3, uneven sizes" + suffix, deep,
+          roundRobin(18, 3, sixNew, 0), 1, strict, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER,
+          skewedSizes(deep.keySet(), random), 0));
+      // Batching, which defers whole partitions for reasons of its own
+      Map<String, Map<String, String>> batched = roundRobin(24, 2, sixOld, 0);
+      scenarios.add(new Scenario("6 -> 6 servers, batchSizePerServer 2" + suffix, batched,
+          roundRobin(24, 2, sixNew, 0), 1, strict, 2, skewedSizes(batched.keySet(), random), 0));
+      // A control: no server in the old set gains anything, so the budget is never binding
+      scenarios.add(new Scenario("4 -> 8 servers, pure scale-out" + suffix, roundRobin(24, 2, servers(0, 4), 0),
+          roundRobin(24, 2, servers(0, 8), 0), 1, strict, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, Map.of(), 0));
+    }
+
+    scenarios.addAll(replicaGroupScenarios(random));
+    scenarios.add(hardestKnownStrictScenario());
+    scenarios.add(knownToNeedTheBudgetGivenUpScenario());
+    scenarios.addAll(midRebalanceUploadScenarios());
+    return scenarios;
+  }
+
+  /// The one assignment known to need the budget given up, found by [#sweepRandomGroupStructures]. Included so that
+  /// the pre-check is checked against a rebalance that does go over, and not only against ones that do not.
+  ///
+  /// `host05` starts on 2041 MiB and the target places 1523 MiB on it, so its ceiling is what it started with. It is
+  /// pinned with eight segments it cannot drop without going below three available replicas, and a step arrives where
+  /// it is the only place left to put a segment and has nothing spare. The rebalance gives the budget up for that step
+  /// and `host05` ends up 31 MiB over, 2% above its ceiling.
+  private static Scenario knownToNeedTheBudgetGivenUpScenario() {
+    // Groups of segments sharing one current and one target instance set, then the size of every segment in MiB
+    String[][] groups = {
+        {"host00,host01,host02,host03", "host02,host04,host05,host06", "0,1,2,3,4,5,6,7,8,9"},
+        {"host00,host02,host06", "host00,host03,host05,host06", "10,11,12"},
+        {"host00,host01,host03,host06", "host01,host02,host03,host05", "13,14,15"},
+        {"host02,host04,host05,host06", "host00,host01,host03,host04", "16,17,18,19,20,21,22,23"},
+        {"host01,host02,host03,host04", "host00,host02,host05,host06", "24,25,26,27,28,29,30,31,32"}
+    };
+    long[] sizesInMib = {
+        31, 12, 17, 9, 16, 14, 431, 664, 23, 23, 23, 20, 12, 12, 28, 9, 29, 1162, 768, 14, 15, 31, 8, 14, 21, 9, 14,
+        25, 15, 25, 18, 24, 28
+    };
+    Map<String, Map<String, String>> current = new TreeMap<>();
+    Map<String, Map<String, String>> target = new TreeMap<>();
+    Map<String, Long> sizes = new TreeMap<>();
+    for (String[] group : groups) {
+      for (String index : group[2].split(",")) {
+        String segment = String.format("segment%03d", Integer.parseInt(index));
+        current.put(segment, instanceStateMap(group[0].split(",")));
+        target.put(segment, instanceStateMap(group[1].split(",")));
+        sizes.put(segment, sizesInMib[Integer.parseInt(index)] * MIB);
+      }
+    }
+    Scenario scenario = new Scenario("assignment known to need the budget given up", current, target, 3, false, 1,
+        sizes, 0);
+    scenario._withinBudget = false;
+    return scenario;
+  }
+
+  /// Replica group assignment, where the placement is structured rather than balanced: every segment of a partition
+  /// sits on one server per replica group, so a partition's segments always share a current and target instance pair.
+  /// That is the shape strict replica group routing is built for, and it moves partitions between the servers of a
+  /// replica group rather than spreading them over all servers the way a balanced assignment does.
+  private static List<Scenario> replicaGroupScenarios(Random random) {
+    List<List<String>> twoBySmall = List.of(List.of("host00", "host01"), List.of("host02", "host03"));
+    List<List<String>> twoByGrown =
+        List.of(List.of("host00", "host01", "host04"), List.of("host02", "host03", "host05"));
+    List<List<String>> twoByRotated = List.of(List.of("host01", "host04"), List.of("host03", "host05"));
+    List<List<String>> threeBySmall =
+        List.of(List.of("host00", "host01"), List.of("host02", "host03"), List.of("host04", "host05"));
+    List<List<String>> threeByGrown = List.of(List.of("host00", "host01", "host06"),
+        List.of("host02", "host03", "host07"), List.of("host04", "host05", "host08"));
+
+    List<Scenario> scenarios = new ArrayList<>();
+    for (boolean strict : List.of(false, true)) {
+      String suffix = strict ? " [strict]" : "";
+      scenarios.add(replicaGroupScenario("replica groups grow 2 -> 3 servers each" + suffix, twoBySmall, twoByGrown,
+          strict, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, random));
+      scenarios.add(replicaGroupScenario("replica groups, one server replaced in each" + suffix, twoBySmall,
+          twoByRotated, strict, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, random));
+    }
+    scenarios.add(replicaGroupScenario("replica groups shrink 3 -> 2 servers each [strict]", twoByGrown, twoBySmall,
+        true, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, random));
+    scenarios.add(replicaGroupScenario("three replica groups grow 2 -> 3 servers each [strict]", threeBySmall,
+        threeByGrown, true, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, random));
+    // Batching groups segments by partition, which only means anything once partition ids are real
+    scenarios.add(replicaGroupScenario("replica groups grow, batchSizePerServer 2 [strict]", twoBySmall, twoByGrown,
+        true, 2, random));
+    return scenarios;
+  }
+
+  private static Scenario replicaGroupScenario(String name, List<List<String>> currentReplicaGroups,
+      List<List<String>> targetReplicaGroups, boolean strict, int batchSizePerServer, Random random) {
+    Map<String, Map<String, String>> current = replicaGroupAssignment(9, 3, currentReplicaGroups);
+    Map<String, Map<String, String>> target = replicaGroupAssignment(9, 3, targetReplicaGroups);
+    Scenario scenario = new Scenario(name, current, target, 1, strict, batchSizePerServer,
+        skewedSizes(current.keySet(), random), 0);
+    scenario._partitionIdFetcher = LLC_PARTITION_FETCHER;
+    return scenario;
+  }
+
+  /// Assigns `numPartitions` partitions of `segmentsPerPartition` segments over `replicaGroups`, one server per
+  /// replica group per partition, the shape `ReplicaGroupSegmentAssignmentStrategy` produces. Segments are named so
+  /// that their partition id can be read back, which is what batching groups them by.
+  private static Map<String, Map<String, String>> replicaGroupAssignment(int numPartitions, int segmentsPerPartition,
+      List<List<String>> replicaGroups) {
+    Map<String, Map<String, String>> assignment = new TreeMap<>();
+    for (int partition = 0; partition < numPartitions; partition++) {
+      List<String> instances = new ArrayList<>(replicaGroups.size());
+      for (List<String> replicaGroup : replicaGroups) {
+        instances.add(replicaGroup.get(partition % replicaGroup.size()));
+      }
+      for (int sequence = 0; sequence < segmentsPerPartition; sequence++) {
+        assignment.put(String.format("myTable__%d__%d__20240101T000000Z", partition, sequence),
+            SegmentAssignmentUtils.getInstanceStateMap(instances, ONLINE));
+      }
+    }
+    return assignment;
+  }
+
+  /// The assignment a randomized search over group structures found hardest: `host02` has 318 MiB free under its own
+  /// ceiling while the group it has to take on is six segments totalling roughly 1.2 GiB, and strict replica group
+  /// routing needs all of them to move at once. Choosing the instances to add without regard for the budget left every
+  /// group blocked here, which gave the budget up and pushed `host02` 36% over.
+  private static Scenario hardestKnownStrictScenario() {
+    // Groups of segments sharing one current and one target instance set, and the size of each segment in MiB
+    String[][] groups = {
+        {"host02,host07", "host00,host01", "0,1,2"},
+        {"host00,host01", "host02,host04", "3,4,5,6,7"},
+        {"host04", "host00,host06", "8,9,10,11,12,13"},
+        {"host04,host05", "host00,host02", "14,15,16,17,18,19"}
+    };
+    long[] sizesInMib = {1099, 8, 1135, 351, 27, 23, 895, 12, 8, 9, 20, 14, 30, 14, 23, 1152, 26, 16, 17, 18};
+
+    Map<String, Map<String, String>> current = new TreeMap<>();
+    Map<String, Map<String, String>> target = new TreeMap<>();
+    Map<String, Long> sizes = new TreeMap<>();
+    for (String[] group : groups) {
+      for (String index : group[2].split(",")) {
+        String segment = String.format("segment%03d", Integer.parseInt(index));
+        current.put(segment, instanceStateMap(group[0].split(",")));
+        target.put(segment, instanceStateMap(group[1].split(",")));
+        sizes.put(segment, sizesInMib[Integer.parseInt(index)] * MIB);
+      }
+    }
+    return new Scenario("hardest known strict replica group assignment", current, target, 1, true,
+        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, sizes, 0);
+  }
+
+  /// Segments can be uploaded, or start consuming, while a rebalance runs. They are absent from the anchor the budget
+  /// was built on, so they are credited to it when first seen: the ceiling of a server whose net change is a loss is
+  /// pinned to what it started with, and would otherwise have the headroom the rebalance needs eaten by them.
+  ///
+  /// Both placements are covered. Strict replica group assignment overrides a new segment onto its partition's
+  /// existing placement to keep the partition collocated, which mid-rebalance is the placement being moved away from,
+  /// so the target assignment naming somewhere else is the normal case there rather than the exception.
+  private static List<Scenario> midRebalanceUploadScenarios() {
+    List<Scenario> scenarios = new ArrayList<>();
+    for (boolean targetAgrees : List.of(true, false)) {
+      Map<String, Map<String, String>> current = roundRobin(12, 2, List.of("host1", "host2", "host3"), 0);
+      Map<String, Map<String, String>> target = roundRobin(12, 2, List.of("host2", "host3", "host4"), 0);
+      Map<String, Long> sizes = new TreeMap<>();
+      current.keySet().forEach(segment -> sizes.put(segment, 100 * MIB));
+
+      Scenario scenario = new Scenario(
+          "3 -> 3 servers, segments uploaded mid-rebalance, target " + (targetAgrees ? "agrees" : "names elsewhere"),
+          current, target, 1, false, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, sizes, 3);
+      for (int i = 0; i < 4; i++) {
+        String segment = "uploaded" + i;
+        scenario._injectedCurrent.put(segment, instanceStateMap("host1", "host2"));
+        scenario._injectedTarget.put(segment,
+            targetAgrees ? instanceStateMap("host1", "host2") : instanceStateMap("host3", "host4"));
+        sizes.put(segment, 400 * MIB);
+      }
+      scenarios.add(scenario);
+    }
+    return scenarios;
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Simulator
+  // ---------------------------------------------------------------------------------------------------------------
+
+  /// Runs `scenario` to the target assignment, or until it stops making progress, tracking for every server the most
+  /// it ever hosts and whether the budget had to be given up to get there.
+  private static SimResult simulate(Scenario scenario) {
+    Map<String, Map<String, String>> current = deepCopy(scenario._currentAssignment);
+    Map<String, Map<String, String>> target = deepCopy(scenario._targetAssignment);
+    Map<String, Long> sizes = new TreeMap<>(scenario._segmentSizeBytes);
+    TableRebalancer.DiskUsageBudget budget =
+        TableRebalancer.DiskUsageBudget.create(current, toTableSizeDetails(scenario._segmentSizeBytes));
+    Object2IntOpenHashMap<String> segmentPartitionIdMap = new Object2IntOpenHashMap<>();
+
+    SimResult result = new SimResult(scenario);
+    result._anchor = hostedBytes(current, sizes);
+    result._peak = new TreeMap<>(result._anchor);
+
+    for (int step = 1; step <= MAX_STEPS; step++) {
+      if (scenario._injectAtStep == step) {
+        current.putAll(scenario._injectedCurrent);
+        target.putAll(scenario._injectedTarget);
+        // A segment this rebalance did not place raises the anchor of whoever is holding it, so that it neither eats
+        // the headroom the rebalance needs nor lets the rebalance raise its own ceiling
+        scenario._injectedCurrent.forEach((segment, instanceStateMap) -> instanceStateMap.keySet()
+            .forEach(instance -> result._anchor.merge(instance, sizes.get(segment), Long::sum)));
+      }
+
+      Map<String, Long> allowed = budget.forStep(current, target).getRemainingBytes();
+      Map<String, Map<String, String>> next;
+      try {
+        next = TableRebalancer.getNextAssignment(current, target, scenario._minAvailableReplicas,
+            scenario._enableStrictReplicaGroup, true, scenario._batchSizePerServer, segmentPartitionIdMap,
+            scenario._partitionIdFetcher, NO_DATA_LOSS_RISK, budget);
+      } catch (Exception e) {
+        result._outcome = "threw " + e;
+        break;
+      }
+      if (next.equals(current)) {
+        result._outcome = "could not make progress";
+        break;
+      }
+
+      // A server assigned more bytes than it was allowed means the budget was given up for this step
+      bytesAdded(current, next, sizes).forEach((server, addedBytes) -> {
+        if (addedBytes > allowed.getOrDefault(server, 0L)) {
+          result._serversOverBudget.add(server);
+        }
+      });
+      recordGroupSplits(scenario, current, target, next, step, result);
+
+      current = next;
+      hostedBytes(current, sizes).forEach((server, bytes) -> result._peak.merge(server, bytes, Math::max));
+      result._steps = step;
+      if (current.equals(target)) {
+        result._outcome = "reached the target assignment";
+        break;
+      }
+      if (step == MAX_STEPS) {
+        result._outcome = "hit the step limit";
+      }
+    }
+    result._target = hostedBytes(target, sizes);
+    return result;
+  }
+
+  private static Map<String, Long> bytesAdded(Map<String, Map<String, String>> current,
+      Map<String, Map<String, String>> next, Map<String, Long> sizes) {
+    Map<String, Long> added = new TreeMap<>();
+    for (Map.Entry<String, Map<String, String>> entry : next.entrySet()) {
+      Map<String, String> currentInstanceStateMap = current.get(entry.getKey());
+      for (String instance : entry.getValue().keySet()) {
+        if (currentInstanceStateMap == null || !currentInstanceStateMap.containsKey(instance)) {
+          added.merge(instance, sizes.getOrDefault(entry.getKey(), 1L), Long::sum);
+        }
+      }
+    }
+    return added;
+  }
+
+  /// Under strict replica group routing every segment sharing a current and target instance pair has to be assigned
+  /// the same instances, or a partition ends up split across replica groups.
+  private static void recordGroupSplits(Scenario scenario, Map<String, Map<String, String>> current,
+      Map<String, Map<String, String>> target, Map<String, Map<String, String>> next, int step, SimResult result) {
+    if (!scenario._enableStrictReplicaGroup) {
+      return;
+    }
+    // Keyed the way the rebalance groups segments: by their current and target instances and by partition. Batching
+    // moves one partition at a time, so two partitions sharing a pair of instance sets are free to move in different
+    // steps - what must never happen is segments of the same partition being assigned different instances.
+    Map<List<Object>, Set<String>> groupToNextInstances = new HashMap<>();
+    for (String segment : current.keySet()) {
+      List<Object> group = List.of(current.get(segment).keySet(), target.get(segment).keySet(),
+          scenario._partitionIdFetcher.fetch(segment));
+      Set<String> nextInstances = next.get(segment).keySet();
+      Set<String> alreadyAssigned = groupToNextInstances.putIfAbsent(group, nextInstances);
+      if (alreadyAssigned != null && !alreadyAssigned.equals(nextInstances)) {
+        result._groupSplits.add(String.format("step %d: partition %s of %s -> %s was split between %s and %s", step,
+            group.get(2), group.get(0), group.get(1), alreadyAssigned, nextInstances));
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Randomized sweeps, for comparing two versions of the assignment logic by hand. Not tests.
+  // ---------------------------------------------------------------------------------------------------------------
+
+  public static void main(String[] args) {
+    sweepServerSetShapes();
+    sweepRandomGroupStructures(new Random(2027), 30_000);
+  }
+
+  /// Every combination of old and new server set sizes, overlap, replication and minimum available replicas, with and
+  /// without strict replica group routing and batching, over unevenly sized segments.
+  private static void sweepServerSetShapes() {
+    Random random = new Random(7);
+    List<SimResult> results = new ArrayList<>();
     for (int numOldServers = 3; numOldServers <= 8; numOldServers++) {
       for (int numNewServers = 3; numNewServers <= 8; numNewServers++) {
         for (int shift = 1; shift < numOldServers; shift++) {
-          for (int replication = 2; replication <= Math.min(3, Math.min(numOldServers, numNewServers));
-              replication++) {
-            int numSegments = 12 * replication;
-            List<String> oldServers = servers(0, numOldServers);
-            List<String> newServers = servers(shift, numNewServers);
-            Map<String, Map<String, String>> current = roundRobin(numSegments, replication, oldServers, 0);
-            String name = String.format("strict old=%d new=%d overlap=%d replication=%d segments=%d", numOldServers,
-                numNewServers, overlap(oldServers, newServers), replication, numSegments);
-            SimResult result = simulate(new Scenario(name, current,
-                roundRobin(numSegments, replication, newServers, 0), 1, true,
-                RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, skewedSizes(current.keySet(), random)));
-            all.add(result);
-            if (result.hasSteadyStateViolation()) {
-              violations.add(result);
-            }
-            result._groupSplits.forEach(split -> splits.add(name + " | " + split));
-          }
-        }
-      }
-    }
-    violations.sort((a, b) -> Double.compare(b.worstAmplification(), a.worstAmplification()));
-    System.out.println();
-    System.out.println(summarize("Strict replica group sweep with skewed segment sizes", all, violations));
-    if (!splits.isEmpty()) {
-      System.out.printf("%d strict replica group splits, first 5:%n", splits.size());
-      splits.subList(0, Math.min(5, splits.size())).forEach(split -> System.out.println("  " + split));
-    }
-    assertEquals(splits, List.of(), "strict replica group requires every group of segments to be moved together");
-  }
-
-  /// A larger, more realistic rotation: 6 servers -> 6 servers with 3 in the overlap, replication 2, 24 segments.
-  /// Shows the over-allocation scales with the table rather than being a rounding artifact - the worst server ends
-  /// up holding double what it started with.
-  ///
-  /// Note that not every overlapping rotation trips this; whether it does depends on how the round-robin lands.
-  /// [#testSweepOverlappingServerSets] enumerates the space.
-  @Test
-  public void testLargerRotationOverlap() {
-    List<String> oldServers = List.of("host1", "host2", "host3", "host4", "host5", "host6");
-    List<String> newServers = List.of("host4", "host5", "host6", "host7", "host8", "host9");
-    Scenario scenario =
-        new Scenario("6 servers -> 6 servers, 3 in overlap (replication 2, minAvailableReplicas 1)",
-            roundRobin(24, 2, oldServers, 0), roundRobin(24, 2, newServers, 0), 1, false,
-            RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER);
-    SimResult result = simulate(scenario);
-    System.out.println(result.report());
-    assertFalse(result.hasSteadyStateViolation(),
-        "lowDiskMode must not let any server hold more than max(initial, target) segments");
-    assertFalse(result.hasInStepViolation(),
-        "lowDiskMode must not let any server download while it still has segments to drop");
-  }
-
-  /// Control case: a pure scale-out where no server in the old set gains anything. `lowDiskMode` holds here, which
-  /// is why the existing coverage in [TableRebalancerTest] does not catch the problem above.
-  @Test
-  public void testPureScaleOutIsClean() {
-    List<String> oldServers = List.of("host1", "host2", "host3", "host4");
-    List<String> newServers = List.of("host1", "host2", "host3", "host4", "host5", "host6", "host7", "host8");
-    Scenario scenario = new Scenario("4 servers -> 8 servers, pure scale-out (control case)",
-        roundRobin(24, 2, oldServers, 0), roundRobin(24, 2, newServers, 0), 1, false,
-        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER);
-    SimResult result = simulate(scenario);
-    System.out.println(result.report());
-    assertFalse(result.hasSteadyStateViolation(), "pure scale-out should not over-allocate any old server");
-  }
-
-  /// The shape that over-allocated the most under a segment count based budget: two servers each ended up holding
-  /// 23 segments against a bound of 18, because the budget was relaxed to break a stall that was not real - both
-  /// servers had free space at the time. Under the byte budget it stays within the bound and is never relaxed.
-  @Test
-  public void testPreviouslyWorstCaseStaysWithinBound() {
-    Scenario scenario =
-        new Scenario("8 servers -> 6 servers, 6 in overlap (replication 3, minAvailableReplicas 2), 36 segments",
-            roundRobin(36, 3, servers(0, 8), 0), roundRobin(36, 3, servers(2, 6), 0), 2, false,
-            RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER);
-    SimResult result = simulate(scenario);
-    System.out.println(result.report());
-    assertFalse(result.hasSteadyStateViolation(), "no server may hold more than max(initial, target)");
-    assertFalse(result.hasInStepViolation(), "no server may exceed max(initial, target) mid-step either");
-    assertTrue(result.relaxedSteps().isEmpty(), "the budget should not have to be relaxed for this shape");
-  }
-
-  /// Exercises the escape hatch: when nothing can move within the budget, the rebalance relaxes it for a step rather
-  /// than stalling, and the replay the pre-check uses reports exactly the servers that go over.
-  ///
-  /// hostA and hostB both start at their ceiling and each has to take on a segment from the other, while the segments
-  /// that would free up their space cannot move at all - single replica, single target instance, so no addition is
-  /// ever attempted for them and `minAvailableReplicas = 1` forbids dropping the only replica.
-  ///
-  /// NOTE: this is not a state a real rebalance reaches. `TableRebalancer#getMinAvailableReplicas` rejects
-  /// `minAvailableReplicas = 1` when a segment being moved has a single target replica, so a rebalance would fail on
-  /// the config before getting here. It is kept because it is the only known way to drive the relaxation, and it
-  /// pins down what the replay reports when it happens.
-  @Test
-  public void testRelaxingTheBudgetIsReportedByTheReplay() {
-    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
-    // Each needs a second replica on the other host, which is already at its ceiling
-    currentAssignment.put("needsReplicaOnB", instanceStateMap("hostA"));
-    currentAssignment.put("needsReplicaOnA", instanceStateMap("hostB"));
-    // These would free up the space, but cannot be moved while keeping 1 replica available
-    currentAssignment.put("stuckOnA", instanceStateMap("hostA"));
-    currentAssignment.put("stuckOnB", instanceStateMap("hostB"));
-
-    Map<String, Map<String, String>> targetAssignment = new TreeMap<>();
-    targetAssignment.put("needsReplicaOnB", instanceStateMap("hostA", "hostB"));
-    targetAssignment.put("needsReplicaOnA", instanceStateMap("hostB", "hostA"));
-    targetAssignment.put("stuckOnA", instanceStateMap("hostC"));
-    targetAssignment.put("stuckOnB", instanceStateMap("hostC"));
-
-    SimResult result = simulate(new Scenario("Cannot stay within the disk each server starts with", currentAssignment,
-        targetAssignment, 1, false, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER));
-    System.out.println(result.report());
-    // hostA and hostB each start with 2 segments and the target places 2 on them, so neither may ever hold 3
-    assertTrue(result.hasSteadyStateViolation(), "expected the rebalance to be forced over the bound");
-    assertEquals(result._maxAfter.get("hostA"), (Long) 3L);
-    assertEquals(result._maxAfter.get("hostB"), (Long) 3L);
-
-    // The pre-check must report exactly those two servers, before anything is moved
-    Map<String, Long> reported = TableRebalancer.getServersForcedOverDiskBudget(currentAssignment, targetAssignment, 1,
-        false, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, null, LoggerFactory.getLogger(getClass()));
-    System.out.println("Pre-check reports servers forced over their disk budget: " + reported);
-    assertEquals(reported, Map.of("hostA", 1L, "hostB", 1L));
-  }
-
-  private static Map<String, String> instanceStateMap(String... instances) {
-    return SegmentAssignmentUtils.getInstanceStateMap(List.of(instances), ONLINE);
-  }
-
-  /// A segment group needing two instances at once, where only one of them has room, is added to the one that does
-  /// rather than being held back entirely.
-  ///
-  /// A group whose current replicas number the minimum available has to gain `replication - minAvailableReplicas`
-  /// instances, which is two or more whenever replication exceeds the minimum by that much. Adding an instance that
-  /// cannot take the group on would have the whole assignment rejected when it is charged, so the instance that could
-  /// have taken it waits too - and if every group in the step is held back that way, the budget is relaxed and the
-  /// guarantee is given up for a step. Adding the one that fits makes progress within the budget instead.
-  @Test
-  public void testGroupIsAddedToTheInstancesThatFitRatherThanHeldBack() {
-    long mib = 1024L * 1024;
-    Map<String, Map<String, String>> initialAssignment = new TreeMap<>();
-    Map<String, Map<String, String>> current = new TreeMap<>();
-    Map<String, Map<String, String>> target = new TreeMap<>();
-    Map<String, Long> sizes = new TreeMap<>();
-
-    // The group to move: one replica left, and the target wants it on two more instances
-    addSegment(initialAssignment, current, target, sizes, "moving", List.of("hostKeep"), List.of("hostKeep"),
-        List.of("hostKeep", "hostRoomy", "hostFull"), 200 * mib);
-    // hostFull starts full and the target keeps it that way, so it has no room for anything else
-    addSegment(initialAssignment, current, target, sizes, "fillsHostFull", List.of("hostFull"), List.of("hostFull"),
-        List.of("hostFull"), 900 * mib);
-    // hostFull also owes a segment it cannot drop, since that is its only replica, which uses up what little the
-    // target assignment leaves it
-    addSegment(initialAssignment, current, target, sizes, "stuckOnHostFull", List.of("hostFull"), List.of("hostFull"),
-        List.of("other"), 150 * mib);
-    // hostRoomy is growing into space it does not use yet
-    addSegment(initialAssignment, current, target, sizes, "fillsHostRoomy", List.of("other"), List.of("other"),
-        List.of("hostRoomy"), 900 * mib);
-
-    TableRebalancer.DiskUsageBudget budget =
-        TableRebalancer.DiskUsageBudget.create(initialAssignment, toTableSizeDetails(sizes));
-    Map<String, Long> remaining = budget.forStep(current, target).getRemainingBytes();
-    System.out.printf("%n  remaining: hostRoomy=%s hostFull=%s, group needs %s%n",
-        formatMib(remaining.getOrDefault("hostRoomy", 0L)), formatMib(remaining.getOrDefault("hostFull", 0L)),
-        formatMib(200 * mib));
-    assertTrue(remaining.getOrDefault("hostRoomy", 0L) >= 200 * mib, "hostRoomy must have room for the group");
-    assertTrue(remaining.getOrDefault("hostFull", 0L) < 200 * mib, "hostFull must not have room for the group");
-
-    Map<String, Map<String, String>> next =
-        TableRebalancer.getNextAssignment(current, target, 1, true, true,
-            RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-            NO_DATA_LOSS_RISK, budget);
-    Set<String> movingNext = next.get("moving").keySet();
-    System.out.println("  next assignment for the group: " + movingNext);
-
-    assertTrue(movingNext.contains("hostRoomy"),
-        "the group should be added to the instance that has room, got " + movingNext);
-    assertFalse(movingNext.contains("hostFull"),
-        "the group must not be added to the instance that has no room, got " + movingNext);
-  }
-
-  /// The disk budget holds a total per pair of current and target instances, used to pick which instance to add. It
-  /// is tempting to charge a strict replica group move by looking that total up, but the two are different totals when
-  /// batching is enabled: `updateNextAssignmentForPartitionIdStrictReplicaGroup` is then called once per partition,
-  /// while the step-wide total spans every partition sharing the pair. Looking it up would charge the whole pair for
-  /// each partition, over-charging by the number of partitions that share it.
-  ///
-  /// Several partitions sharing one pair of instances is the normal shape for a replica group table, where partitions
-  /// per replica group is exactly that multiple.
-  @Test
-  public void testStrictReplicaGroupChargesPerPartitionNotPerInstancePair() {
-    long mib = 1024L * 1024;
-    Map<String, Map<String, String>> current = new TreeMap<>();
-    Map<String, Map<String, String>> target = new TreeMap<>();
-    Map<String, Long> sizes = new TreeMap<>();
-    for (int partition = 0; partition < 2; partition++) {
-      for (int sequence = 0; sequence < 2; sequence++) {
-        String segment = "myTable__" + partition + "__" + sequence + "__20240101T0000Z";
-        current.put(segment, instanceStateMap("hostA", "hostB"));
-        target.put(segment, instanceStateMap("hostC", "hostD"));
-        sizes.put(segment, 100 * mib);
-      }
-    }
-    TableRebalancer.StepDiskBudget stepBudget =
-        TableRebalancer.DiskUsageBudget.create(current, toTableSizeDetails(sizes)).forStep(current, target);
-
-    // All four segments share one pair of instances, so the step-wide map holds a single total covering both partitions
-    Map<Pair<Set<String>, Set<String>>, Long> stepWide = stepBudget.getInstancePairToBytes(current, target);
-    assertEquals(stepWide.size(), 1);
-    long stepWideBytes = stepWide.values().iterator().next();
-
-    // What one call is handed once batching has grouped by pair and then by partition
-    Map<String, Map<String, String>> onePartition = new TreeMap<>();
-    current.forEach((segment, instanceStateMap) -> {
-      if (segment.startsWith("myTable__0__")) {
-        onePartition.put(segment, instanceStateMap);
-      }
-    });
-    long onePartitionBytes = stepBudget.getInstancePairToBytes(onePartition, target).values().iterator().next();
-
-    System.out.printf("%n  step-wide total for the pair: %s, what one call is handed: %s%n",
-        formatMib(stepWideBytes), formatMib(onePartitionBytes));
-    assertEquals(onePartitionBytes, 200 * mib);
-    assertEquals(stepWideBytes, 2 * onePartitionBytes,
-        "the step-wide total spans both partitions, so charging it per partition would double count");
-  }
-
-  /// Where a segment added mid-rebalance costs headroom, and where it does not.
-  ///
-  /// The new segment is credited to the anchor of the servers hosting it, so `ceiling` becomes
-  /// `max(initial + upload, target)`. That covers the upload whenever the anchor side of the max wins - which it
-  /// always does on a server whose net change is a loss. On a server that is growing, the target side wins and the
-  /// credit is swallowed by the max, so the upload eats headroom.
-  ///
-  /// It only costs anything at all when the target assignment does not place the segment where it landed. When it
-  /// does, the target rises by the same amount and the cost cancels out wherever it fell. That is the case strict
-  /// replica group assignment cannot give us: `BaseStrictRealtimeSegmentAssignment` overrides a new segment onto its
-  /// partition's existing placement to keep the partition collocated, which mid-rebalance is the placement the
-  /// rebalance is moving away from.
-  @Test
-  public void testWhereMidRebalanceUploadsCostHeadroom() {
-    long mib = 1024L * 1024;
-    System.out.printf("%n  %-34s %12s %12s %10s%n", "case", "control", "with upload", "cost");
-    for (boolean netLoss : List.of(true, false)) {
-      for (boolean targetAgrees : List.of(true, false)) {
-        long control = remainingOnFocus(netLoss, null, 0, mib);
-        long withUpload = remainingOnFocus(netLoss, targetAgrees ? "focus" : "elsewhere", 300 * mib, mib);
-        System.out.printf("  %-34s %12s %12s %10s%n",
-            (netLoss ? "net loss, " : "net gain,  ") + (targetAgrees ? "target agrees" : "target elsewhere"),
-            formatMib(control), formatMib(withUpload), formatMib(control - withUpload));
-        if (netLoss || targetAgrees) {
-          assertEquals(withUpload, control, "this placement must not cost the rebalance any headroom");
-        } else {
-          // The one combination that costs anything: on a growing server the target side of the max wins, so the
-          // credit for the new segment is swallowed, and the target does not carry it either. The cost is exactly the
-          // segment that appeared, which bounds it - pinned so that a change widening it fails here
-          assertEquals(control - withUpload, 300 * mib,
-              "the cost must stay bounded by the size of the segment that appeared");
-        }
-      }
-    }
-  }
-
-  /// Headroom on `focus` in a mid-rebalance state, optionally with a segment that appeared after the anchor was taken.
-  /// `netLoss` picks whether `focus` is shedding bytes overall or taking them on.
-  private static long remainingOnFocus(boolean netLoss, String uploadedOn, long uploadSizeBytes, long mib) {
-    Map<String, Map<String, String>> initialAssignment = new TreeMap<>();
-    Map<String, Map<String, String>> current = new TreeMap<>();
-    Map<String, Map<String, String>> target = new TreeMap<>();
-    Map<String, Long> sizes = new TreeMap<>();
-
-    if (netLoss) {
-      // focus starts on 1000M and the target places 600M, so the anchor side of the max wins
-      addSegment(initialAssignment, current, target, sizes, "kept", List.of("focus"), List.of("focus"),
-          List.of("focus"), 500 * mib);
-      addSegment(initialAssignment, current, target, sizes, "dropped", List.of("focus"), List.of("other"),
-          List.of("other"), 500 * mib);
-      addSegment(initialAssignment, current, target, sizes, "arriving", List.of("other"), List.of("other"),
-          List.of("focus"), 100 * mib);
-    } else {
-      // focus starts on 100M and the target places 1000M, so the target side of the max wins
-      addSegment(initialAssignment, current, target, sizes, "kept", List.of("focus"), List.of("focus"),
-          List.of("focus"), 100 * mib);
-      addSegment(initialAssignment, current, target, sizes, "arriving", List.of("other"), List.of("other"),
-          List.of("focus"), 900 * mib);
-    }
-    if (uploadedOn != null) {
-      // Appeared after the anchor was taken, so it is absent from initialAssignment
-      current.put("uploaded", instanceStateMap("focus"));
-      target.put("uploaded", instanceStateMap(uploadedOn));
-      sizes.put("uploaded", uploadSizeBytes);
-    }
-    return TableRebalancer.DiskUsageBudget.create(initialAssignment, toTableSizeDetails(sizes))
-        .forStep(current, target).getRemainingBytes().getOrDefault("focus", 0L);
-  }
-
-  private static void addSegment(Map<String, Map<String, String>> initialAssignment,
-      Map<String, Map<String, String>> current, Map<String, Map<String, String>> target, Map<String, Long> sizes,
-      String segment, List<String> initialInstances, List<String> currentInstances, List<String> targetInstances,
-      long sizeBytes) {
-    initialAssignment.put(segment, SegmentAssignmentUtils.getInstanceStateMap(initialInstances, ONLINE));
-    current.put(segment, SegmentAssignmentUtils.getInstanceStateMap(currentInstances, ONLINE));
-    target.put(segment, SegmentAssignmentUtils.getInstanceStateMap(targetInstances, ONLINE));
-    sizes.put(segment, sizeBytes);
-  }
-
-  /// A segment uploaded onto a server that the target assignment also places it on is not automatically harmless.
-  ///
-  /// The ceiling is `max(frozen initial bytes, target bytes)`. Where a server's net change is a gain, the upload
-  /// raises the target side of that max by as much as it raises what the server hosts, so the headroom is untouched.
-  /// Where the net change is a loss the ceiling is pinned to the frozen initial bytes, which the upload cannot raise,
-  /// so an upload accounted for there would consume headroom outright. The budget therefore accounts only for the
-  /// segments the rebalance started with, which keeps the headroom of a net-loss server intact.
-  ///
-  /// `host0` below hosts 1000M and the target places 600M on it, a net loss of 400M. It has to drop a 500M segment and
-  /// take on a 100M one, so once the drop lands it has 500M of headroom for a 100M arrival.
-  @Test
-  public void testUploadOntoNetLossServerEatsHeadroom() {
-    long mib = 1024L * 1024;
-    System.out.printf("%n  %-10s %10s %10s %10s %10s %10s   %s%n", "upload", "ceiling", "hosted", "remaining",
-        "needs", "margin", "verdict");
-    long marginWithoutUpload = -1;
-    for (long uploadMib : List.of(0L, 100L, 200L, 400L, 700L)) {
-      // The state after host0 has dropped its outgoing segment, which is where its headroom opens up
-      Map<String, Map<String, String>> current = new TreeMap<>();
-      Map<String, Map<String, String>> target = new TreeMap<>();
-      Map<String, Long> sizes = new TreeMap<>();
-      Map<String, Map<String, String>> initialAssignment = new TreeMap<>();
-
-      // kept by host0
-      initialAssignment.put("kept", instanceStateMap("host0", "host1"));
-      current.put("kept", instanceStateMap("host0", "host1"));
-      target.put("kept", instanceStateMap("host0", "host1"));
-      sizes.put("kept", 500 * mib);
-      // dropped by host0 — present when the rebalance started, already gone in this state
-      initialAssignment.put("dropped", instanceStateMap("host0", "host1"));
-      current.put("dropped", instanceStateMap("host1"));
-      target.put("dropped", instanceStateMap("host1", "host2"));
-      sizes.put("dropped", 500 * mib);
-      // still to arrive on host0
-      initialAssignment.put("arriving", instanceStateMap("host1", "host2"));
-      current.put("arriving", instanceStateMap("host1"));
-      target.put("arriving", instanceStateMap("host0", "host1"));
-      sizes.put("arriving", 100 * mib);
-
-      if (uploadMib > 0) {
-        // Uploaded after the rebalance started, so absent from the anchor, and placed on host0 by both assignments
-        current.put("uploaded", instanceStateMap("host0"));
-        target.put("uploaded", instanceStateMap("host0"));
-        sizes.put("uploaded", uploadMib * mib);
-      }
-
-      TableRebalancer.DiskUsageBudget budget =
-          TableRebalancer.DiskUsageBudget.create(initialAssignment, toTableSizeDetails(sizes));
-      long remaining = budget.forStep(current, target).getRemainingBytes().getOrDefault("host0", 0L);
-      long hosted = hostedBytesOf(current, sizes).getOrDefault("host0", 0L);
-      // The ceiling the budget is actually working to, which the credit for the uploaded segment raises
-      long ceiling = hosted + remaining;
-      long needs = 100 * mib;
-      long margin = remaining - needs;
-      if (uploadMib == 0) {
-        marginWithoutUpload = margin;
-      }
-      System.out.printf("  %-10s %10s %10s %10s %10s %10s   %s%n", uploadMib == 0 ? "none" : uploadMib + "M",
-          formatMib(ceiling), formatMib(hosted), formatMib(remaining), formatMib(needs), formatMib(margin),
-          margin < 0 ? "BLOCKED" : margin == 0 ? "exact fit, no slack" : "fits");
-      if (uploadMib > 0) {
-        assertEquals(margin, marginWithoutUpload,
-            uploadMib + "M upload must not consume headroom the rebalance needs");
-      }
-    }
-    System.out.println("\n  The margin that absorbs group granularity is unaffected by the upload, because the"
-        + " budget accounts\n  only for the segments the rebalance started with.");
-  }
-
-  /// Segments can be added to a table while a rebalance is running - an uploaded segment, or a new consuming segment.
-  /// The budget is anchored once, before the first step, so it has never heard of them: they are absent from
-  /// `initialServerBytes` and from the per-segment sizes, while they do count towards what a server hosts now and
-  /// towards the recalculated target. Drives that directly, holding the budget across the injection the way
-  /// `doRebalance` does.
-  @Test
-  public void testSegmentsAddedDuringTheRebalance() {
-    List<String> oldServers = List.of("host1", "host2", "host3");
-    List<String> newServers = List.of("host2", "host3", "host4");
-    Map<String, Map<String, String>> current = roundRobin(12, 2, oldServers, 0);
-    Map<String, Map<String, String>> target = roundRobin(12, 2, newServers, 0);
-    Map<String, Long> sizes = new TreeMap<>();
-    current.keySet().forEach(segment -> sizes.put(segment, 100L * 1024 * 1024));
-
-    // The budget the controller builds once, before the first step
-    TableRebalancer.DiskUsageBudget diskUsageBudget =
-        TableRebalancer.DiskUsageBudget.create(current, toTableSizeDetails(sizes));
-    Map<String, Long> frozenCeiling = new TreeMap<>();
-    Map<String, Long> initialBytes = hostedBytesOf(current, sizes);
-    hostedBytesOf(target, sizes).forEach(
-        (server, bytes) -> frozenCeiling.put(server, Math.max(initialBytes.getOrDefault(server, 0L), bytes)));
-    initialBytes.forEach((server, bytes) -> frozenCeiling.merge(server, bytes, Math::max));
-
-    Map<String, Long> peak = new TreeMap<>(initialBytes);
-    int numRelaxedSteps = 0;
-    boolean converged = false;
-    for (int step = 1; step <= 40; step++) {
-      // Segments uploaded part way through, placed by the instance partitions in force at upload time - the old
-      // servers - while the recalculated target places them on the new servers. The overlap servers therefore host
-      // them without the target assignment accounting for them
-      if (step == 3) {
-        for (int i = 0; i < 4; i++) {
-          String uploaded = "uploaded" + i;
-          current.put(uploaded, SegmentAssignmentUtils.getInstanceStateMap(List.of("host1", "host2"), ONLINE));
-          target.put(uploaded, SegmentAssignmentUtils.getInstanceStateMap(List.of("host3", "host4"), ONLINE));
-          sizes.put(uploaded, 400L * 1024 * 1024);
-        }
-        System.out.println("  step 3: 4 uploaded segments of 400M landed on host1/host2, target says host3/host4");
-      }
-      Map<String, Long> allowed = diskUsageBudget.forStep(current, target).getRemainingBytes();
-      // A new segment is credited to the anchor once, so asking again must give the same answer. If it were credited
-      // per call, the rebalance could raise its own ceiling simply by taking another step
-      assertEquals(diskUsageBudget.forStep(current, target).getRemainingBytes(), allowed,
-          "crediting a new segment to the anchor must be idempotent");
-      Map<String, Map<String, String>> next =
-          TableRebalancer.getNextAssignment(current, target, 1, false, true,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-              NO_DATA_LOSS_RISK, diskUsageBudget);
-      if (next.equals(current)) {
-        break;
-      }
-      // Measured against what the budget accounts for: segments added while the rebalance runs are outside it, so
-      // the bytes they bring are not the rebalance going over its budget
-      Map<String, Long> added = new TreeMap<>();
-      for (Map.Entry<String, Map<String, String>> entry : next.entrySet()) {
-        Map<String, String> currentInstanceStateMap = current.get(entry.getKey());
-        long budgetedBytes = diskUsageBudget.getSegmentSizeBytes(entry.getKey());
-        for (String instance : entry.getValue().keySet()) {
-          if (currentInstanceStateMap == null || !currentInstanceStateMap.containsKey(instance)) {
-            added.merge(instance, budgetedBytes, Long::sum);
-          }
-        }
-      }
-      for (Map.Entry<String, Long> entry : added.entrySet()) {
-        if (entry.getValue() > allowed.getOrDefault(entry.getKey(), 0L)) {
-          numRelaxedSteps++;
-          System.out.printf("  step %d: budget relaxed - %s took %s but was allowed %s%n", step, entry.getKey(),
-              formatMib(entry.getValue()), formatMib(allowed.getOrDefault(entry.getKey(), 0L)));
-          break;
-        }
-      }
-      current = next;
-      hostedBytesOf(current, sizes).forEach((server, bytes) -> peak.merge(server, bytes, Math::max));
-      if (current.equals(target)) {
-        converged = true;
-        break;
-      }
-    }
-
-    System.out.printf("%nconverged=%s, steps where the rebalance exceeded its budget=%d%n", converged,
-        numRelaxedSteps);
-    System.out.println("  peak below counts every segment on the server, including the uploaded ones the budget does"
-        + " not account for");
-    Map<String, Long> finalBytes = hostedBytesOf(target, sizes);
-    System.out.printf("  %-8s %10s %10s %12s %10s%n", "server", "initial", "final", "frozenCeil", "peak");
-    for (String server : peak.keySet()) {
-      System.out.printf("  %-8s %10s %10s %12s %10s%s%n", server,
-          formatMib(initialBytes.getOrDefault(server, 0L)), formatMib(finalBytes.getOrDefault(server, 0L)),
-          formatMib(frozenCeiling.getOrDefault(server, 0L)), formatMib(peak.get(server)),
-          peak.get(server) > Math.max(frozenCeiling.getOrDefault(server, 0L),
-              finalBytes.getOrDefault(server, 0L)) ? "   above the ceiling, carrying uploaded segments" : "");
-    }
-    assertTrue(converged, "the rebalance must still converge when segments are added while it runs");
-    assertEquals(numRelaxedSteps, 0,
-        "segments added while the rebalance runs must not push it outside the budget it started with");
-  }
-
-  private static Map<String, Long> hostedBytesOf(Map<String, Map<String, String>> assignment,
-      Map<String, Long> sizes) {
-    Map<String, Long> bytes = new TreeMap<>();
-    assignment.forEach((segment, instanceStateMap) -> instanceStateMap.keySet()
-        .forEach(instance -> bytes.merge(instance, sizes.get(segment), Long::sum)));
-    return bytes;
-  }
-
-  private static String formatMib(long bytes) {
-    return (bytes / (1024 * 1024)) + "M";
-  }
-
-  /// Searches broadly for rebalances the disk budget cannot carry out, i.e. the ones the disk utilization pre-check
-  /// has to report. Randomizes everything that feeds the budget: strict and non strict routing, batching on and off,
-  /// the minimum available replicas, how many replicas a group currently sits at, group sizes, and four different
-  /// segment size distributions including one where a single segment dominates its whole group.
-  ///
-  /// The property asserted is not that a rebalance can always stay within the budget - it cannot, and relaxing the
-  /// budget rather than stalling is the deliberate behaviour - but that the pre-check replay reports exactly the
-  /// servers that end up over. A relaxation the pre-check does not predict would be a silent over-allocation.
-  @Test
-  public void testSearchForRebalancesTheBudgetCannotCarryOut() {
-    Random random = new Random(2027);
-    List<SimResult> relaxed = new ArrayList<>();
-    List<String> mismatches = new ArrayList<>();
-    int numTrials = 30000;
-    int numRun = 0;
-    for (int trial = 0; trial < numTrials; trial++) {
-      int numServers = 3 + random.nextInt(8);
-      int replication = 2 + random.nextInt(3);
-      int minAvailableReplicas = 1 + random.nextInt(replication - 1);
-      int numGroups = 2 + random.nextInt(7);
-      boolean enableStrictReplicaGroup = random.nextBoolean();
-      int batchSizePerServer = List.of(RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, 1, 2, 5, 20)
-          .get(random.nextInt(5));
-      int sizeRegime = random.nextInt(4);
-      List<String> allServers = servers(0, numServers);
-
-      Map<String, Map<String, String>> current = new TreeMap<>();
-      Map<String, Map<String, String>> target = new TreeMap<>();
-      Map<String, Long> sizes = new TreeMap<>();
-      int segmentId = 0;
-      for (int group = 0; group < numGroups; group++) {
-        // A group that already sits at the minimum available replicas cannot drop anything, which is what forces it
-        // to depend on an addition landing somewhere
-        int numCurrentInstances = minAvailableReplicas + random.nextInt(replication - minAvailableReplicas + 1);
-        List<String> currentInstances = pickServers(allServers, numCurrentInstances, random);
-        List<String> targetInstances = pickServers(allServers, replication, random);
-        int numSegmentsInGroup = 1 + random.nextInt(10);
-        List<String> groupSegments = new ArrayList<>();
-        for (int i = 0; i < numSegmentsInGroup; i++) {
-          String segment = String.format("segment%04d", segmentId++);
-          groupSegments.add(segment);
-          current.put(segment, SegmentAssignmentUtils.getInstanceStateMap(currentInstances, ONLINE));
-          target.put(segment, SegmentAssignmentUtils.getInstanceStateMap(targetInstances, ONLINE));
-        }
-        sizes.putAll(sizesForRegime(groupSegments, sizeRegime, random));
-      }
-      List<String> segmentsToMove = SegmentAssignmentUtils.getSegmentsToMove(current, target);
-      if (segmentsToMove.isEmpty() || TableRebalancer.getMinAvailableReplicas(current, target, segmentsToMove,
-          minAvailableReplicas, LoggerFactory.getLogger(getClass())) != minAvailableReplicas) {
-        continue;
-      }
-      numRun++;
-
-      String name = String.format(
-          "trial %d: servers=%d replication=%d minAvail=%d groups=%d strict=%s batch=%d sizes=%d", trial, numServers,
-          replication, minAvailableReplicas, numGroups, enableStrictReplicaGroup, batchSizePerServer, sizeRegime);
-      SimResult result = simulate(new Scenario(name, current, target, minAvailableReplicas, enableStrictReplicaGroup,
-          batchSizePerServer, sizes));
-      Set<String> observed = new TreeSet<>();
-      result.relaxedSteps().forEach(step -> observed.addAll(step._deferralRelaxedFor));
-      if (observed.isEmpty()) {
-        continue;
-      }
-      relaxed.add(result);
-      // The pre-check has to predict it, from the same starting point, before anything moves
-      Map<String, Long> reported = TableRebalancer.getServersForcedOverDiskBudget(current, target,
-          minAvailableReplicas, enableStrictReplicaGroup, batchSizePerServer, toTableSizeDetails(sizes),
-          LoggerFactory.getLogger(getClass()));
-      if (!reported.keySet().equals(observed)) {
-        mismatches.add(name + ": rebalance went over on " + observed + " but the pre-check reported " + reported);
-      }
-    }
-
-    System.out.printf("%nSearched %d of %d generated scenarios (the rest were configs the rebalance would reject)%n",
-        numRun, numTrials);
-    System.out.printf("  rebalances the budget could not carry out: %d%n", relaxed.size());
-    if (!relaxed.isEmpty()) {
-      relaxed.sort((a, b) -> Double.compare(b.worstAmplification(), a.worstAmplification()));
-      System.out.printf("  worst amplification among them: %.2fx%n", relaxed.get(0).worstAmplification());
-      for (SimResult result : relaxed.subList(0, Math.min(8, relaxed.size()))) {
-        System.out.printf("    %-92s worst %s: bound %s, peak %s%n", result._scenario._name, result.worstServer(),
-            formatUnits(result.bound(result.worstServer()), result._scenario),
-            formatUnits(result._maxAfter.get(result.worstServer()), result._scenario));
-      }
-      System.out.println(relaxed.get(0).report());
-      dumpScenario(relaxed.get(0)._scenario);
-    }
-    assertEquals(mismatches, List.of(), "the pre-check must report every rebalance that goes over the disk budget");
-  }
-
-  /// Enumerates every small rebalance exhaustively, rather than sampling. A rebalance the budget cannot carry out is
-  /// a rare structure, so random generation is the wrong instrument for it: if a minimal one exists it should show up
-  /// among 4 servers, 3 groups sitting at the minimum available replicas, and a handful of group sizes.
-  @Test
-  public void testExhaustiveSmallSearchForRebalancesTheBudgetCannotCarryOut() {
-    List<String> allServers = servers(0, 4);
-    List<Long> groupSizes = List.of(1L, 3L, 10L, 40L);
-    List<SimResult> relaxed = new ArrayList<>();
-    List<String> mismatches = new ArrayList<>();
-    int numRun = 0;
-    for (int replication : List.of(2, 3)) {
-      // Every (single current instance, target instance set) a group can have
-      List<List<List<String>>> groupShapes = new ArrayList<>();
-      for (String currentInstance : allServers) {
-        for (List<String> targetInstances : combinations(allServers, replication)) {
-          groupShapes.add(List.of(List.of(currentInstance), targetInstances));
-        }
-      }
-      int numShapes = groupShapes.size();
-      for (int a = 0; a < numShapes; a++) {
-        for (int b = a; b < numShapes; b++) {
-          for (int c = b; c < numShapes; c++) {
-            for (long sizeA : groupSizes) {
-              for (long sizeB : groupSizes) {
-                for (long sizeC : groupSizes) {
-                  List<List<List<String>>> shapes = List.of(groupShapes.get(a), groupShapes.get(b),
-                      groupShapes.get(c));
-                  List<Long> sizesPerGroup = List.of(sizeA, sizeB, sizeC);
-                  Map<String, Map<String, String>> current = new TreeMap<>();
-                  Map<String, Map<String, String>> target = new TreeMap<>();
-                  Map<String, Long> sizes = new TreeMap<>();
-                  for (int group = 0; group < 3; group++) {
-                    String segment = "segment" + group;
-                    current.put(segment,
-                        SegmentAssignmentUtils.getInstanceStateMap(shapes.get(group).get(0), ONLINE));
-                    target.put(segment,
-                        SegmentAssignmentUtils.getInstanceStateMap(shapes.get(group).get(1), ONLINE));
-                    sizes.put(segment, sizesPerGroup.get(group));
-                  }
-                  List<String> segmentsToMove = SegmentAssignmentUtils.getSegmentsToMove(current, target);
-                  if (segmentsToMove.isEmpty() || TableRebalancer.getMinAvailableReplicas(current, target,
-                      segmentsToMove, 1, LoggerFactory.getLogger(getClass())) != 1) {
-                    continue;
-                  }
-                  for (boolean enableStrictReplicaGroup : List.of(false, true)) {
-                    numRun++;
-                    String name = String.format("replication=%d shapes=%s sizes=%s strict=%s", replication, shapes,
-                        sizesPerGroup, enableStrictReplicaGroup);
-                    SimResult result = simulate(new Scenario(name, current, target, 1, enableStrictReplicaGroup,
-                        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, sizes));
-                    Set<String> observed = new TreeSet<>();
-                    result.relaxedSteps().forEach(step -> observed.addAll(step._deferralRelaxedFor));
-                    if (observed.isEmpty()) {
-                      continue;
-                    }
-                    relaxed.add(result);
-                    Map<String, Long> reported = TableRebalancer.getServersForcedOverDiskBudget(current, target, 1,
-                        enableStrictReplicaGroup, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER,
-                        toTableSizeDetails(sizes), LoggerFactory.getLogger(getClass()));
-                    if (!reported.keySet().equals(observed)) {
-                      mismatches.add(name + ": went over on " + observed + " but pre-check reported " + reported);
-                    }
-                  }
+          for (int replication = 2; replication <= Math.min(3, Math.min(numOldServers, numNewServers)); replication++) {
+            for (int minAvailableReplicas = 1; minAvailableReplicas < replication; minAvailableReplicas++) {
+              for (boolean strict : List.of(false, true)) {
+                for (int batchSizePerServer : List.of(RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, 2)) {
+                  int numSegments = 12 * replication;
+                  Map<String, Map<String, String>> current =
+                      roundRobin(numSegments, replication, servers(0, numOldServers), 0);
+                  results.add(simulate(new Scenario(
+                      String.format("old=%d new=%d shift=%d replication=%d minAvail=%d strict=%s batch=%d",
+                          numOldServers, numNewServers, shift, replication, minAvailableReplicas, strict,
+                          batchSizePerServer), current,
+                      roundRobin(numSegments, replication, servers(shift, numNewServers), 0), minAvailableReplicas,
+                      strict, batchSizePerServer, skewedSizes(current.keySet(), random), 0)));
                 }
               }
             }
@@ -768,609 +476,170 @@ public class LowDiskModeRebalanceSimulatorTest {
         }
       }
     }
-    System.out.printf("%nExhaustively ran %d small rebalances%n", numRun);
-    System.out.printf("  rebalances the budget could not carry out: %d%n", relaxed.size());
-    if (!relaxed.isEmpty()) {
-      relaxed.sort((a, b) -> Double.compare(b.worstAmplification(), a.worstAmplification()));
-      System.out.println(relaxed.get(0).report());
-      dumpScenario(relaxed.get(0)._scenario);
-    }
-    assertEquals(mismatches, List.of(), "the pre-check must report every rebalance that goes over the disk budget");
+    report("Server set shapes", results);
   }
 
-  /// All the subsets of `items` of exactly `size`, in a stable order.
-  private static List<List<String>> combinations(List<String> items, int size) {
-    List<List<String>> combinations = new ArrayList<>();
-    if (size == 0) {
-      combinations.add(List.of());
-      return combinations;
-    }
-    for (int i = 0; i <= items.size() - size; i++) {
-      for (List<String> rest : combinations(items.subList(i + 1, items.size()), size - 1)) {
-        List<String> combination = new ArrayList<>();
-        combination.add(items.get(i));
-        combination.addAll(rest);
-        combinations.add(combination);
-      }
-    }
-    return combinations;
-  }
-
-  /// Segment sizes under one of several distributions, so that the search is not limited to one shape of skew.
-  private static Map<String, Long> sizesForRegime(List<String> segments, int sizeRegime, Random random) {
-    Map<String, Long> sizes = new TreeMap<>();
-    long mib = 1024L * 1024;
-    switch (sizeRegime) {
-      case 0 -> segments.forEach(segment -> sizes.put(segment, 64 * mib));
-      case 1 -> segments.forEach(segment -> sizes.put(segment,
-          random.nextInt(10) < 8 ? (8 + random.nextInt(24)) * mib : (320 + random.nextInt(960)) * mib));
-      case 2 -> {
-        // One segment dominates the group, so the group only fits where there is a lot of room
-        segments.forEach(segment -> sizes.put(segment, (4 + random.nextInt(12)) * mib));
-        sizes.put(segments.get(random.nextInt(segments.size())), (1024 + random.nextInt(3072)) * mib);
-      }
-      default -> segments.forEach(
-          segment -> sizes.put(segment, (long) Math.pow(2, 3 + random.nextInt(9)) * mib));
-    }
-    return sizes;
-  }
-
-  /// Regression test for a strict replica group rebalance that used to be pushed over the disk budget, found by
-  /// [#testStrictReplicaGroupRandomGroupStructureSearch].
-  ///
-  /// Before the instances to add were picked with the budget in mind, this stalled at a step where three of the four
-  /// groups still had an instance in their target assignment with room for them - `host01` had exactly the 2242 MiB
-  /// that one group needed, `host04` had room for another and `host00` for the third - but the instances were picked
-  /// purely on the number of segments to offload, which landed on `host00` (2186 MiB free, 56 MiB short), `host02`
-  /// (318 MiB free) and `host02` again. All three were rejected by the budget, none of the instances that fit was
-  /// tried, and with nothing able to move the budget was relaxed and `host02` went 36% over the disk it started with.
-  ///
-  /// A correct sequence existed the whole time; only the choice of instance was blind to the budget.
-  @Test
-  public void testStrictReplicaGroupStaysWithinTheDiskBudget() {
-    Map<String, Map<String, String>> current = new TreeMap<>();
-    Map<String, Map<String, String>> target = new TreeMap<>();
-    Map<String, Long> sizes = new TreeMap<>();
-    current.put("segment000", instanceStateMap("host02", "host07"));
-    current.put("segment001", instanceStateMap("host02", "host07"));
-    current.put("segment002", instanceStateMap("host02", "host07"));
-    current.put("segment003", instanceStateMap("host00", "host01"));
-    current.put("segment004", instanceStateMap("host00", "host01"));
-    current.put("segment005", instanceStateMap("host00", "host01"));
-    current.put("segment006", instanceStateMap("host00", "host01"));
-    current.put("segment007", instanceStateMap("host00", "host01"));
-    current.put("segment008", instanceStateMap("host04"));
-    current.put("segment009", instanceStateMap("host04"));
-    current.put("segment010", instanceStateMap("host04"));
-    current.put("segment011", instanceStateMap("host04"));
-    current.put("segment012", instanceStateMap("host04"));
-    current.put("segment013", instanceStateMap("host04"));
-    current.put("segment014", instanceStateMap("host04", "host05"));
-    current.put("segment015", instanceStateMap("host04", "host05"));
-    current.put("segment016", instanceStateMap("host04", "host05"));
-    current.put("segment017", instanceStateMap("host04", "host05"));
-    current.put("segment018", instanceStateMap("host04", "host05"));
-    current.put("segment019", instanceStateMap("host04", "host05"));
-    target.put("segment000", instanceStateMap("host00", "host01"));
-    target.put("segment001", instanceStateMap("host00", "host01"));
-    target.put("segment002", instanceStateMap("host00", "host01"));
-    target.put("segment003", instanceStateMap("host02", "host04"));
-    target.put("segment004", instanceStateMap("host02", "host04"));
-    target.put("segment005", instanceStateMap("host02", "host04"));
-    target.put("segment006", instanceStateMap("host02", "host04"));
-    target.put("segment007", instanceStateMap("host02", "host04"));
-    target.put("segment008", instanceStateMap("host00", "host06"));
-    target.put("segment009", instanceStateMap("host00", "host06"));
-    target.put("segment010", instanceStateMap("host00", "host06"));
-    target.put("segment011", instanceStateMap("host00", "host06"));
-    target.put("segment012", instanceStateMap("host00", "host06"));
-    target.put("segment013", instanceStateMap("host00", "host06"));
-    target.put("segment014", instanceStateMap("host00", "host02"));
-    target.put("segment015", instanceStateMap("host00", "host02"));
-    target.put("segment016", instanceStateMap("host00", "host02"));
-    target.put("segment017", instanceStateMap("host00", "host02"));
-    target.put("segment018", instanceStateMap("host00", "host02"));
-    target.put("segment019", instanceStateMap("host00", "host02"));
-    sizes.put("segment000", 1152385024L);
-    sizes.put("segment001", 8388608L);
-    sizes.put("segment002", 1190133760L);
-    sizes.put("segment003", 368050176L);
-    sizes.put("segment004", 28311552L);
-    sizes.put("segment005", 24117248L);
-    sizes.put("segment006", 938475520L);
-    sizes.put("segment007", 12582912L);
-    sizes.put("segment008", 8388608L);
-    sizes.put("segment009", 9437184L);
-    sizes.put("segment010", 20971520L);
-    sizes.put("segment011", 14680064L);
-    sizes.put("segment012", 31457280L);
-    sizes.put("segment013", 14680064L);
-    sizes.put("segment014", 24117248L);
-    sizes.put("segment015", 1207959552L);
-    sizes.put("segment016", 27262976L);
-    sizes.put("segment017", 16777216L);
-    sizes.put("segment018", 17825792L);
-    sizes.put("segment019", 18874368L);
-
-    // The config the rebalance would actually run with, so this is a state a real rebalance can be asked to carry out
-    assertEquals(TableRebalancer.getMinAvailableReplicas(current, target,
-        SegmentAssignmentUtils.getSegmentsToMove(current, target), 1, LoggerFactory.getLogger(getClass())), 1);
-
-    SimResult result = simulate(new Scenario("Strict replica group within the disk budget", current, target, 1, true,
-        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, sizes));
-    System.out.println(result.report());
-    assertFalse(result.hasSteadyStateViolation(), "no server may hold more than max(initial, target)");
-    assertFalse(result.hasInStepViolation(), "no server may exceed max(initial, target) mid-step either");
-    assertTrue(result.relaxedSteps().isEmpty(), "the budget should not have to be relaxed for this assignment");
-    assertEquals(result._groupSplits, Set.of(), "groups must still be moved together");
-
-    // And the pre-check must agree that it is safe
-    assertEquals(TableRebalancer.getServersForcedOverDiskBudget(current, target, 1, true,
-        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, toTableSizeDetails(sizes),
-        LoggerFactory.getLogger(getClass())), Map.of());
-  }
-
-  /// The argument that the disk budget can never be the only thing blocking a step does not carry over to strict
-  /// replica group routing: there a whole group of segments has to move at once, so a group can be blocked while the
-  /// server it would move to still has room, which cannot happen when segments are charged one at a time. The sweeps
-  /// above only build groups by round robin, which makes them regular and equally sized, so they say little about it.
-  ///
-  /// Searches randomized group structures - random current and target instance sets, groups of differing sizes,
-  /// segments sitting at differing replica counts, skewed segment sizes - for a strict replica group rebalance the
-  /// budget cannot carry out.
-  @Test
-  public void testStrictReplicaGroupRandomGroupStructureSearch() {
-    Random random = new Random(101);
-    List<SimResult> relaxed = new ArrayList<>();
-    List<SimResult> violations = new ArrayList<>();
-    List<String> splits = new ArrayList<>();
-    List<SimResult> all = new ArrayList<>();
-    int numSkippedAsIllegal = 0;
-    for (int trial = 0; trial < 20000; trial++) {
-      int numServers = 3 + random.nextInt(6);
-      int replication = 2 + random.nextInt(2);
-      int numGroups = 2 + random.nextInt(5);
+  /// Random current and target instance sets, group sizes, replica counts and size distributions. A rebalance the
+  /// budget cannot carry out is a rare structure, so this reaches shapes the fixed scenarios do not.
+  private static void sweepRandomGroupStructures(Random random, int numTrials) {
+    List<SimResult> results = new ArrayList<>();
+    for (int trial = 0; trial < numTrials; trial++) {
+      int numServers = 3 + random.nextInt(8);
+      int replication = 2 + random.nextInt(3);
+      int minAvailableReplicas = 1 + random.nextInt(replication - 1);
       List<String> allServers = servers(0, numServers);
       Map<String, Map<String, String>> current = new TreeMap<>();
       Map<String, Map<String, String>> target = new TreeMap<>();
       int segmentId = 0;
+      int numGroups = 2 + random.nextInt(7);
       for (int group = 0; group < numGroups; group++) {
-        // Segments of a group share one current instance set and one target instance set. Let the current set be
-        // smaller than the replication so that groups part way through a move are covered too.
-        List<String> currentInstances = pickServers(allServers, 1 + random.nextInt(replication), random);
+        List<String> currentInstances = pickServers(allServers,
+            minAvailableReplicas + random.nextInt(replication - minAvailableReplicas + 1), random);
         List<String> targetInstances = pickServers(allServers, replication, random);
-        int numSegmentsInGroup = 1 + random.nextInt(6);
+        int numSegmentsInGroup = 1 + random.nextInt(10);
         for (int i = 0; i < numSegmentsInGroup; i++) {
-          String segment = String.format("segment%03d", segmentId++);
+          String segment = String.format("segment%04d", segmentId++);
           current.put(segment, SegmentAssignmentUtils.getInstanceStateMap(currentInstances, ONLINE));
           target.put(segment, SegmentAssignmentUtils.getInstanceStateMap(targetInstances, ONLINE));
         }
       }
       // Only run what the rebalance itself would accept
       if (TableRebalancer.getMinAvailableReplicas(current, target,
-          SegmentAssignmentUtils.getSegmentsToMove(current, target), 1, LoggerFactory.getLogger(getClass()))
-          != 1) {
-        numSkippedAsIllegal++;
+          SegmentAssignmentUtils.getSegmentsToMove(current, target), minAvailableReplicas,
+          LoggerFactory.getLogger(LowDiskModeRebalanceSimulatorTest.class)) != minAvailableReplicas) {
         continue;
       }
-      String name = String.format("trial %d: servers=%d replication=%d groups=%d segments=%d", trial, numServers,
-          replication, numGroups, current.size());
-      SimResult result = simulate(new Scenario(name, current, target, 1, true,
-          RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, skewedSizes(current.keySet(), random)));
-      all.add(result);
-      if (!result.relaxedSteps().isEmpty()) {
-        relaxed.add(result);
-      }
-      if (result.hasSteadyStateViolation()) {
-        violations.add(result);
-      }
-      result._groupSplits.forEach(split -> splits.add(name + " | " + split));
+      results.add(simulate(new Scenario("trial " + trial, current, target, minAvailableReplicas, random.nextBoolean(),
+          List.of(RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, 1, 2, 20).get(random.nextInt(4)),
+          skewedSizes(current.keySet(), random), 0)));
     }
-    violations.sort((a, b) -> Double.compare(b.worstAmplification(), a.worstAmplification()));
-    System.out.println();
-    System.out.println(summarize("Strict replica group random group structures", all, violations));
-    assertEquals(relaxed.size(), 0, "the budget should not have to be relaxed for any of these assignments");
-    System.out.printf("  skipped as illegal minAvailableReplicas: %d%n", numSkippedAsIllegal);
-    if (!relaxed.isEmpty()) {
-      System.out.printf("%nFOUND %d scenarios where the budget had to be relaxed. Worst:%n", relaxed.size());
-      SimResult worst = violations.isEmpty() ? relaxed.get(0) : violations.get(0);
-      System.out.println(worst.report());
-      dumpScenario(worst._scenario);
-    }
-    assertEquals(splits, List.of(), "strict replica group requires every group of segments to be moved together");
+    report("Random group structures", results);
   }
 
-  /// Prints a scenario as Java source, so a case found by the random search can be pinned as a fixed test.
-  private static void dumpScenario(Scenario scenario) {
-    System.out.println("---- scenario as source ----");
-    scenario._currentAssignment.forEach((segment, instanceStateMap) -> System.out.printf(
-        "    current.put(\"%s\", instanceStateMap(%s));%n", segment,
-        instanceStateMap.keySet().stream().map(i -> '"' + i + '"').collect(Collectors.joining(", "))));
-    scenario._targetAssignment.forEach((segment, instanceStateMap) -> System.out.printf(
-        "    target.put(\"%s\", instanceStateMap(%s));%n", segment,
-        instanceStateMap.keySet().stream().map(i -> '"' + i + '"').collect(Collectors.joining(", "))));
-    scenario._segmentSizeBytes.forEach(
-        (segment, sizeBytes) -> System.out.printf("    sizes.put(\"%s\", %dL);%n", segment, sizeBytes));
-    System.out.println("---- end ----");
-  }
-
-  /// Picks `count` distinct servers at random, in a stable order so the assignment is deterministic per seed.
-  private static List<String> pickServers(List<String> allServers, int count, Random random) {
-    List<String> shuffled = new ArrayList<>(allServers);
-    for (int i = shuffled.size() - 1; i > 0; i--) {
-      int j = random.nextInt(i + 1);
-      shuffled.set(i, shuffled.set(j, shuffled.get(i)));
-    }
-    List<String> picked = new ArrayList<>(shuffled.subList(0, Math.min(count, shuffled.size())));
-    picked.sort(null);
-    return picked;
-  }
-
-  /// Sweeps the grid with `batchSizePerServer` set, which is the combination the sweeps above do not cover: batching
-  /// can defer a partition for reasons of its own, and the disk budget can defer the rest, so between them a step can
-  /// end up making no progress at all.
-  @Test
-  public void testSweepWithBatchSizePerServer() {
-    Random random = new Random(31);
-    List<SimResult> violations = new ArrayList<>();
-    List<SimResult> all = new ArrayList<>();
-    for (int numOldServers = 3; numOldServers <= 7; numOldServers++) {
-      for (int shift = 1; shift < numOldServers; shift++) {
-        for (int replication = 2; replication <= 3; replication++) {
-          for (int batchSizePerServer : List.of(1, 2, 5)) {
-            for (boolean enableStrictReplicaGroup : List.of(false, true)) {
-              int numSegments = 12 * replication;
-              List<String> oldServers = servers(0, numOldServers);
-              List<String> newServers = servers(shift, numOldServers);
-              Map<String, Map<String, String>> current = roundRobin(numSegments, replication, oldServers, 0);
-              String name = String.format("old=%d shift=%d replication=%d batchSizePerServer=%d strict=%s",
-                  numOldServers, shift, replication, batchSizePerServer, enableStrictReplicaGroup);
-              all.add(simulate(new Scenario(name, current, roundRobin(numSegments, replication, newServers, 0), 1,
-                  enableStrictReplicaGroup, batchSizePerServer, skewedSizes(current.keySet(), random))));
-            }
-          }
-        }
-      }
-    }
-    List<String> splits = new ArrayList<>();
-    for (SimResult result : all) {
-      if (result.hasSteadyStateViolation()) {
-        violations.add(result);
-      }
-      result._groupSplits.forEach(split -> splits.add(result._scenario._name + " | " + split));
-    }
-    violations.sort((a, b) -> Double.compare(b.worstAmplification(), a.worstAmplification()));
-    System.out.println();
-    System.out.println(summarize("Sweep with batchSizePerServer and skewed sizes", all, violations));
-    for (SimResult result : violations.subList(0, Math.min(5, violations.size()))) {
-      System.out.println(result.report());
-    }
-    assertEquals(splits, List.of(), "strict replica group requires every group of segments to be moved together");
-  }
-
-  /// The pre-check replay must agree with what the rebalance actually does: for every scenario, the servers it
-  /// reports as forced over their disk have to be exactly the ones the simulation observes going over.
-  @Test
-  public void testDiskBudgetReplayMatchesTheRebalance() {
-    Random random = new Random(23);
-    int numChecked = 0;
-    for (int numOldServers = 3; numOldServers <= 7; numOldServers++) {
-      for (int shift = 1; shift < numOldServers; shift++) {
-        for (int replication = 2; replication <= 3; replication++) {
-          for (boolean enableStrictReplicaGroup : List.of(false, true)) {
-            int numSegments = 12 * replication;
-            List<String> oldServers = servers(0, numOldServers);
-            List<String> newServers = servers(shift, numOldServers);
-            Map<String, Map<String, String>> current = roundRobin(numSegments, replication, oldServers, 0);
-            Map<String, Map<String, String>> target = roundRobin(numSegments, replication, newServers, 0);
-            Map<String, Long> segmentSizeBytes = skewedSizes(current.keySet(), random);
-            String name = String.format("old=%d new=%d replication=%d strict=%s", numOldServers, numOldServers,
-                replication, enableStrictReplicaGroup);
-            SimResult result = simulate(new Scenario(name, current, target, 1, enableStrictReplicaGroup,
-                RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, segmentSizeBytes));
-
-            Map<String, Long> reported = TableRebalancer.getServersForcedOverDiskBudget(current, target, 1,
-                enableStrictReplicaGroup, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER,
-                toTableSizeDetails(segmentSizeBytes), LoggerFactory.getLogger(getClass()));
-            Set<String> observed = new TreeSet<>();
-            result.relaxedSteps().forEach(step -> observed.addAll(step._deferralRelaxedFor));
-            assertEquals(reported.keySet(), observed, name + ": pre-check replay disagrees with the rebalance");
-            numChecked++;
-          }
-        }
-      }
-    }
-    System.out.printf("%nDisk budget replay agreed with the rebalance on all %d scenarios%n%n", numChecked);
-  }
-
-  /// Sweeps a grid of overlapping old/new server sets and reports the worst amplification found, so the blast
-  /// radius of the edge case can be sized.
-  @Test
-  public void testSweepOverlappingServerSets() {
-    List<SimResult> violations = new ArrayList<>();
-    List<SimResult> all = new ArrayList<>();
-    for (int numOldServers = 3; numOldServers <= 8; numOldServers++) {
-      for (int numNewServers = 3; numNewServers <= 8; numNewServers++) {
-        for (int shift = 1; shift < numOldServers; shift++) {
-          for (int replication = 1; replication <= Math.min(3, Math.min(numOldServers, numNewServers));
-              replication++) {
-            for (int minAvailableReplicas = 1; minAvailableReplicas < replication + 1; minAvailableReplicas++) {
-              if (minAvailableReplicas >= replication && replication > 1) {
-                // A rebalance cannot make progress when minAvailableReplicas == replication
-                continue;
-              }
-              int numSegments = 12 * replication;
-              List<String> oldServers = servers(0, numOldServers);
-              List<String> newServers = servers(shift, numNewServers);
-              String name = String.format(
-                  "old=%d new=%d overlap=%d replication=%d minAvailableReplicas=%d segments=%d", numOldServers,
-                  numNewServers, overlap(oldServers, newServers), replication, minAvailableReplicas, numSegments);
-              Scenario scenario = new Scenario(name, roundRobin(numSegments, replication, oldServers, 0),
-                  roundRobin(numSegments, replication, newServers, 0), minAvailableReplicas, false,
-                  RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER);
-              SimResult result = simulate(scenario);
-              all.add(result);
-              if (result.hasSteadyStateViolation()) {
-                violations.add(result);
-              }
-            }
-          }
-        }
-      }
-    }
-    violations.sort((a, b) -> Double.compare(b.worstAmplification(), a.worstAmplification()));
-    System.out.println();
-    System.out.println(summarize("Sweep", all, violations));
-    System.out.println("Worst 10 by amplification (peak hosted / bound):");
-    for (SimResult result : violations.subList(0, Math.min(10, violations.size()))) {
-      System.out.printf("  %-88s worst server %s: bound %s, peak %s (%.2fx, +%s)%n", result._scenario._name,
-          result.worstServer(), formatUnits(result.bound(result.worstServer()), result._scenario),
-          formatUnits(result._maxAfter.get(result.worstServer()), result._scenario), result.worstAmplification(),
-          formatUnits(result.worstExcess(), result._scenario));
-    }
-    System.out.println();
-  }
-
-  /// Aggregate metrics for a batch of scenarios. Counting violating scenarios alone is misleading - a one-segment
-  /// overshoot is not the same problem as a 2x overshoot - so report the magnitude and the convergence cost too.
-  private static String summarize(String label, List<SimResult> all, List<SimResult> violations) {
-    long totalExcess = 0;
-    long worstExcess = 0;
-    double worstAmplification = 1.0;
-    int totalSteps = 0;
+  /// Prints how often the budget had to be given up, how far over it went and how many steps it took, which is what
+  /// there is to compare between two versions of the assignment logic.
+  private static void report(String label, List<SimResult> results) {
+    int gaveUpBudget = 0;
+    int notReached = 0;
+    int splits = 0;
+    long totalSteps = 0;
     int maxSteps = 0;
-    int numStuck = 0;
-    int numRelaxed = 0;
-    int numViolatingWithoutRelax = 0;
-    for (SimResult result : all) {
-      if (!result.relaxedSteps().isEmpty()) {
-        numRelaxed++;
-      } else if (result.hasSteadyStateViolation()) {
-        numViolatingWithoutRelax++;
-      }
-      totalExcess += result.worstExcess();
-      worstExcess = Math.max(worstExcess, result.worstExcess());
-      worstAmplification = Math.max(worstAmplification, result.worstAmplification());
-      totalSteps += result._steps.size();
-      maxSteps = Math.max(maxSteps, result._steps.size());
-      if (result._terminated.startsWith("STUCK") || result._terminated.startsWith("hit MAX_STEPS")) {
-        numStuck++;
-      }
-    }
-    return String.format("%s over %d scenarios:%n"
-            + "  violating scenarios : %d (%.1f%%)%n"
-            + "  worst amplification : %.2fx%n"
-            + "  worst excess        : %d units over the bound%n"
-            + "  total excess        : %d units summed over all scenarios%n"
-            + "  steps               : %.1f mean, %d max%n"
-            + "  did not converge    : %d%n"
-            + "  budget relaxed in    : %d (no progress was possible within the budget)%n"
-            + "  violating, no relax  : %d  <-- unexplained by the relaxation%n", label, all.size(),
-        violations.size(), 100.0 * violations.size() / all.size(), worstAmplification, worstExcess, totalExcess,
-        (double) totalSteps / all.size(), maxSteps, numStuck, numRelaxed, numViolatingWithoutRelax);
-  }
-
-  /// Same grid as [#testSweepOverlappingServerSets], but with a skewed per-segment size distribution, so the budget
-  /// is bounding bytes rather than segment counts. This is the case a count based budget cannot get right: it lets a
-  /// server take on large segments because it dropped small ones.
-  @Test
-  public void testSweepWithSkewedSegmentSizes() {
-    List<SimResult> violations = new ArrayList<>();
-    List<SimResult> all = new ArrayList<>();
-    Random random = new Random(7);
-    for (int numOldServers = 3; numOldServers <= 8; numOldServers++) {
-      for (int numNewServers = 3; numNewServers <= 8; numNewServers++) {
-        for (int shift = 1; shift < numOldServers; shift++) {
-          for (int replication = 1; replication <= Math.min(3, Math.min(numOldServers, numNewServers));
-              replication++) {
-            for (int minAvailableReplicas = 1; minAvailableReplicas < replication + 1; minAvailableReplicas++) {
-              if (minAvailableReplicas >= replication && replication > 1) {
-                continue;
-              }
-              int numSegments = 12 * replication;
-              List<String> oldServers = servers(0, numOldServers);
-              List<String> newServers = servers(shift, numNewServers);
-              Map<String, Map<String, String>> current = roundRobin(numSegments, replication, oldServers, 0);
-              String name = String.format(
-                  "old=%d new=%d overlap=%d replication=%d minAvailableReplicas=%d segments=%d", numOldServers,
-                  numNewServers, overlap(oldServers, newServers), replication, minAvailableReplicas, numSegments);
-              SimResult result = simulate(new Scenario(name, current,
-                  roundRobin(numSegments, replication, newServers, 0), minAvailableReplicas, false,
-                  RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, skewedSizes(current.keySet(), random)));
-              all.add(result);
-              if (result.hasSteadyStateViolation()) {
-                violations.add(result);
-              }
-            }
-          }
+    double worstAmplification = 1;
+    SimResult worst = null;
+    for (SimResult result : results) {
+      if (!result._serversOverBudget.isEmpty()) {
+        gaveUpBudget++;
+        if (result.amplification() > worstAmplification) {
+          worstAmplification = result.amplification();
+          worst = result;
         }
       }
+      notReached += result.reachedTarget() ? 0 : 1;
+      splits += result._groupSplits.size();
+      totalSteps += result._steps;
+      maxSteps = Math.max(maxSteps, result._steps);
     }
-    violations.sort((a, b) -> Double.compare(b.worstAmplification(), a.worstAmplification()));
-    System.out.println();
-    System.out.println(summarize("Sweep with skewed segment sizes", all, violations));
-    for (SimResult result : violations.subList(0, Math.min(10, violations.size()))) {
-      System.out.printf("  %-88s worst server %s: bound %s, peak %s (%.2fx, +%s)%n", result._scenario._name,
-          result.worstServer(), formatUnits(result.bound(result.worstServer()), result._scenario),
-          formatUnits(result._maxAfter.get(result.worstServer()), result._scenario), result.worstAmplification(),
-          formatUnits(result.worstExcess(), result._scenario));
-    }
-    System.out.println();
-  }
-
-  /// Randomized search over non-uniform current assignments (the state a table is in after an interrupted
-  /// rebalance, a replication change, or realtime segments that were created against the new instance
-  /// partitions) looking for the largest amplification.
-  @Test
-  public void testRandomSearch() {
-    Random random = new Random(42);
-    List<SimResult> violations = new ArrayList<>();
-    List<SimResult> all = new ArrayList<>();
-    for (int trial = 0; trial < 400; trial++) {
-      int numOldServers = 3 + random.nextInt(6);
-      int numNewServers = 3 + random.nextInt(6);
-      int shift = 1 + random.nextInt(numOldServers);
-      int replication = 1 + random.nextInt(3);
-      int minAvailableReplicas = 1 + random.nextInt(Math.max(1, replication - 1));
-      int numSegments = 6 + random.nextInt(30);
-      List<String> oldServers = servers(0, numOldServers);
-      List<String> newServers = servers(shift, numNewServers);
-      Map<String, Map<String, String>> current =
-          roundRobin(numSegments, Math.min(replication, numOldServers), oldServers, random.nextInt(numOldServers));
-      Map<String, Map<String, String>> target =
-          roundRobin(numSegments, Math.min(replication, numNewServers), newServers, random.nextInt(numNewServers));
-      String name = String.format("trial %d: old=%d new=%d overlap=%d replication=%d minAvail=%d segments=%d", trial,
-          numOldServers, numNewServers, overlap(oldServers, newServers), replication, minAvailableReplicas,
-          numSegments);
-      SimResult result = simulate(new Scenario(name, current, target, minAvailableReplicas, false,
-          RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER));
-      all.add(result);
-      if (result.hasSteadyStateViolation()) {
-        violations.add(result);
-      }
-    }
-    violations.sort((a, b) -> Double.compare(b.worstAmplification(), a.worstAmplification()));
-    System.out.println();
-    System.out.println(summarize("Random search", all, violations));
-    if (!violations.isEmpty()) {
-      System.out.println("Worst offender:");
-      System.out.println(violations.get(0).report());
+    System.out.printf("%n%s, over %d scenarios%n", label, results.size());
+    System.out.printf("  gave up the budget in    : %d%n", gaveUpBudget);
+    System.out.printf("  worst amplification      : %.2fx%n", worstAmplification);
+    System.out.printf("  split a group of segments: %d%n", splits);
+    System.out.printf("  did not reach the target : %d%n", notReached);
+    System.out.printf("  steps                    : %.1f mean, %d max%n", (double) totalSteps / results.size(),
+        maxSteps);
+    if (worst != null) {
+      System.out.println(worst.report());
     }
   }
 
   // ---------------------------------------------------------------------------------------------------------------
-  // Simulator
+  // Model and helpers
   // ---------------------------------------------------------------------------------------------------------------
 
-  private static SimResult simulate(Scenario scenario) {
-    SimResult result = new SimResult(scenario);
-    Map<String, Map<String, String>> current = deepCopy(scenario._currentAssignment);
-    Object2IntOpenHashMap<String> segmentPartitionIdMap = new Object2IntOpenHashMap<>();
+  private static class Scenario {
+    final String _name;
+    final Map<String, Map<String, String>> _currentAssignment;
+    final Map<String, Map<String, String>> _targetAssignment;
+    final int _minAvailableReplicas;
+    final boolean _enableStrictReplicaGroup;
+    final int _batchSizePerServer;
+    final Map<String, Long> _segmentSizeBytes;
+    /// Step at which to add segments this rebalance did not place, 0 for none
+    final int _injectAtStep;
+    /// Whether the budget can be held for this shape. False for the one shape known to need it given up, which is
+    /// what exercises the pre-check reporting a server rather than reporting nothing.
+    boolean _withinBudget = true;
+    /// How the rebalance reads partition ids, which batching groups segments by. Replica group scenarios name their
+    /// segments so that the real fetcher resolves them, the rest have no meaningful partition.
+    TableRebalancer.PartitionIdFetcher _partitionIdFetcher = DUMMY_PARTITION_FETCHER;
+    final Map<String, Map<String, String>> _injectedCurrent = new TreeMap<>();
+    final Map<String, Map<String, String>> _injectedTarget = new TreeMap<>();
 
-    // The budget the controller uses, anchored to the assignment the rebalance starts from
-    TableRebalancer.DiskUsageBudget diskUsageBudget = TableRebalancer.DiskUsageBudget.create(current,
-        scenario._segmentSizeBytes.isEmpty() ? null : toTableSizeDetails(scenario._segmentSizeBytes));
-
-    result._initial = hostedBytes(current, scenario);
-    result._target = hostedBytes(scenario._targetAssignment, scenario);
-    result._maxAfter = new TreeMap<>(result._initial);
-    result._maxInStep = new TreeMap<>(result._initial);
-    for (String server : result._target.keySet()) {
-      result._maxAfter.putIfAbsent(server, 0L);
-      result._maxInStep.putIfAbsent(server, 0L);
+    Scenario(String name, Map<String, Map<String, String>> currentAssignment,
+        Map<String, Map<String, String>> targetAssignment, int minAvailableReplicas, boolean enableStrictReplicaGroup,
+        int batchSizePerServer, Map<String, Long> segmentSizeBytes, int injectAtStep) {
+      _name = name;
+      _currentAssignment = currentAssignment;
+      _targetAssignment = targetAssignment;
+      _minAvailableReplicas = minAvailableReplicas;
+      _enableStrictReplicaGroup = enableStrictReplicaGroup;
+      _batchSizePerServer = batchSizePerServer;
+      _segmentSizeBytes = segmentSizeBytes;
+      _injectAtStep = injectAtStep;
     }
-
-    for (int step = 1; step <= MAX_STEPS; step++) {
-      Map<String, Map<String, String>> next;
-      try {
-        next = TableRebalancer.getNextAssignment(current, scenario._targetAssignment, scenario._minAvailableReplicas,
-            scenario._enableStrictReplicaGroup, true /* lowDiskMode */, scenario._batchSizePerServer,
-            segmentPartitionIdMap, DUMMY_PARTITION_FETCHER, NO_DATA_LOSS_RISK, diskUsageBudget);
-      } catch (Exception e) {
-        result._terminated = "step " + step + " threw " + e;
-        break;
-      }
-      if (next.equals(current)) {
-        result._terminated = next.equals(scenario._targetAssignment) ? "converged" : "STUCK (no progress possible)";
-        break;
-      }
-
-      Step stepInfo = new Step(step);
-      Map<String, Long> before = hostedBytes(current, scenario);
-      Map<String, Long> after = hostedBytes(next, scenario);
-      for (String segment : current.keySet()) {
-        Set<String> currentInstances = current.get(segment).keySet();
-        Set<String> nextInstances = next.get(segment).keySet();
-        Set<String> targetInstances = scenario._targetAssignment.get(segment).keySet();
-        long sizeBytes = scenario.sizeOf(segment);
-        for (String instance : nextInstances) {
-          if (!currentInstances.contains(instance)) {
-            stepInfo._adds.merge(instance, sizeBytes, Long::sum);
-            stepInfo._addedSegments.computeIfAbsent(instance, k -> new TreeSet<>()).add(segment);
-          } else if (!targetInstances.contains(instance)) {
-            // The instance is not in the target for this segment, yet the step keeps the segment on it. This only
-            // happens because dropping it would break the minAvailableReplicas requirement, i.e. the replacement
-            // replica has not been created yet. The disk it occupies is not accounted for anywhere.
-            stepInfo._heldForAvailability.computeIfAbsent(instance, k -> new TreeSet<>()).add(segment);
-          }
-        }
-        for (String instance : currentInstances) {
-          if (!nextInstances.contains(instance)) {
-            stepInfo._drops.merge(instance, sizeBytes, Long::sum);
-          }
-        }
-      }
-      // Ask the real budget what each server was allowed to take on at the start of this step. A server that was
-      // assigned more than that means TableRebalancer could not make progress within the budget and relaxed it.
-      Map<String, Long> allowedBytes =
-          diskUsageBudget.forStep(current, scenario._targetAssignment).getRemainingBytes();
-      stepInfo._adds.forEach((server, addedBytes) -> {
-        if (addedBytes > allowedBytes.getOrDefault(server, 0L)) {
-          stepInfo._deferralRelaxedFor.add(server);
-        }
-      });
-      for (String server : union(result._maxAfter.keySet(), after.keySet())) {
-        long beforeBytes = before.getOrDefault(server, 0L);
-        long afterBytes = after.getOrDefault(server, 0L);
-        long inStepPeak = beforeBytes + stepInfo._adds.getOrDefault(server, 0L);
-        stepInfo._before.put(server, beforeBytes);
-        stepInfo._after.put(server, afterBytes);
-        result._maxAfter.merge(server, afterBytes, Math::max);
-        result._maxInStep.merge(server, inStepPeak, Math::max);
-      }
-      // Strict replica group routing requires every segment that shares the same current and target instances to get
-      // the same next assignment, otherwise a partition ends up split across replica groups.
-      if (scenario._enableStrictReplicaGroup) {
-        Map<List<Set<String>>, Set<String>> groupToNextInstances = new HashMap<>();
-        for (String segment : current.keySet()) {
-          List<Set<String>> group =
-              List.of(current.get(segment).keySet(), scenario._targetAssignment.get(segment).keySet());
-          Set<String> nextInstances = next.get(segment).keySet();
-          Set<String> alreadyAssigned = groupToNextInstances.putIfAbsent(group, nextInstances);
-          if (alreadyAssigned != null && !alreadyAssigned.equals(nextInstances)) {
-            result._groupSplits.add(
-                String.format("step %d: segments with current %s and target %s were split between %s and %s",
-                    stepInfo._index, group.get(0), group.get(1), alreadyAssigned, nextInstances));
-          }
-        }
-      }
-      result._steps.add(stepInfo);
-
-      current = next;
-      if (current.equals(scenario._targetAssignment)) {
-        result._terminated = "converged";
-        break;
-      }
-      if (step == MAX_STEPS) {
-        result._terminated = "hit MAX_STEPS";
-      }
-    }
-    return result;
   }
 
-  // ---------------------------------------------------------------------------------------------------------------
-  // Assignment builders
-  // ---------------------------------------------------------------------------------------------------------------
+  private static class SimResult {
+    final Scenario _scenario;
+    final Set<String> _serversOverBudget = new TreeSet<>();
+    final Set<String> _groupSplits = new TreeSet<>();
+    Map<String, Long> _anchor = new TreeMap<>();
+    Map<String, Long> _target = new TreeMap<>();
+    Map<String, Long> _peak = new TreeMap<>();
+    int _steps;
+    String _outcome = "did not finish";
+
+    SimResult(Scenario scenario) {
+      _scenario = scenario;
+    }
+
+    boolean reachedTarget() {
+      return "reached the target assignment".equals(_outcome);
+    }
+
+    private long bound(String server) {
+      return Math.max(_anchor.getOrDefault(server, 0L), _target.getOrDefault(server, 0L));
+    }
+
+    /// The most any server held, as a multiple of what it was allowed to hold.
+    double amplification() {
+      double worst = 1;
+      for (String server : _peak.keySet()) {
+        long bound = bound(server);
+        if (bound > 0) {
+          worst = Math.max(worst, (double) _peak.get(server) / bound);
+        }
+      }
+      return worst;
+    }
+
+    /// Rendered only when an assertion fails, or for the worst scenario of a sweep.
+    String report() {
+      StringBuilder sb = new StringBuilder("\n  ").append(_scenario._name).append(" — ").append(_outcome)
+          .append(" after ").append(_steps).append(" steps\n");
+      sb.append(String.format("  %-8s %10s %10s %10s %10s%n", "server", "anchor", "target", "bound", "peak"));
+      for (String server : union(_anchor.keySet(), _peak.keySet())) {
+        long bound = bound(server);
+        long peak = _peak.getOrDefault(server, 0L);
+        sb.append(String.format("  %-8s %10s %10s %10s %10s%s%n", server, mib(_anchor.getOrDefault(server, 0L)),
+            mib(_target.getOrDefault(server, 0L)), mib(bound), mib(peak), peak > bound ? "   OVER" : ""));
+      }
+      if (!_serversOverBudget.isEmpty()) {
+        sb.append("  budget given up for: ").append(_serversOverBudget).append('\n');
+      }
+      _groupSplits.forEach(split -> sb.append("  ").append(split).append('\n'));
+      return sb.toString();
+    }
+  }
 
   private static List<String> servers(int startIndex, int count) {
     List<String> servers = new ArrayList<>(count);
@@ -1380,28 +649,45 @@ public class LowDiskModeRebalanceSimulatorTest {
     return servers;
   }
 
-  private static int overlap(List<String> oldServers, List<String> newServers) {
-    Set<String> intersection = new TreeSet<>(oldServers);
-    intersection.retainAll(newServers);
-    return intersection.size();
+  private static List<String> pickServers(List<String> allServers, int count, Random random) {
+    List<String> shuffled = new ArrayList<>(allServers);
+    for (int i = shuffled.size() - 1; i > 0; i--) {
+      shuffled.set(i, shuffled.set(random.nextInt(i + 1), shuffled.get(i)));
+    }
+    List<String> picked = new ArrayList<>(shuffled.subList(0, Math.min(count, shuffled.size())));
+    picked.sort(null);
+    return picked;
   }
 
-  /// Round-robins `numSegments` segments with `replication` replicas over `servers`, starting at `offset`. This is
-  /// the same shape `BalanceNumSegmentAssignmentStrategy` produces.
+  /// Round-robins `numSegments` segments with `replication` replicas over `servers`, the shape
+  /// `BalanceNumSegmentAssignmentStrategy` produces.
   private static Map<String, Map<String, String>> roundRobin(int numSegments, int replication, List<String> servers,
       int offset) {
     Map<String, Map<String, String>> assignment = new TreeMap<>();
-    int numServers = servers.size();
     int cursor = offset;
     for (int i = 0; i < numSegments; i++) {
       List<String> instances = new ArrayList<>(replication);
       for (int r = 0; r < replication; r++) {
-        instances.add(servers.get(cursor % numServers));
-        cursor++;
+        instances.add(servers.get(cursor++ % servers.size()));
       }
       assignment.put(String.format("segment%03d", i), SegmentAssignmentUtils.getInstanceStateMap(instances, ONLINE));
     }
     return assignment;
+  }
+
+  /// Most segments small and a few an order of magnitude larger, which is what a table with mixed pushes and varying
+  /// retention looks like, and what a budget counting segments rather than bytes cannot see.
+  private static Map<String, Long> skewedSizes(Collection<String> segments, Random random) {
+    Map<String, Long> segmentSizeBytes = new TreeMap<>();
+    for (String segment : segments) {
+      segmentSizeBytes.put(segment,
+          random.nextInt(10) < 8 ? (8 + random.nextInt(24)) * MIB : (320 + random.nextInt(960)) * MIB);
+    }
+    return segmentSizeBytes;
+  }
+
+  private static Map<String, String> instanceStateMap(String... instances) {
+    return SegmentAssignmentUtils.getInstanceStateMap(List.of(instances), ONLINE);
   }
 
   private static Map<String, Map<String, String>> deepCopy(Map<String, Map<String, String>> assignment) {
@@ -1410,27 +696,19 @@ public class LowDiskModeRebalanceSimulatorTest {
     return copy;
   }
 
-  /// Bytes each server hosts under `assignment`. With no per-segment sizes every segment weighs one, so this is the
-  /// hosted segment count and the accounting is identical to a count based budget.
-  private static Map<String, Long> hostedBytes(Map<String, Map<String, String>> assignment, Scenario scenario) {
+  private static Map<String, Long> hostedBytes(Map<String, Map<String, String>> assignment, Map<String, Long> sizes) {
     Map<String, Long> bytes = new TreeMap<>();
-    for (Map.Entry<String, Map<String, String>> entry : assignment.entrySet()) {
-      long sizeBytes = scenario.sizeOf(entry.getKey());
-      for (String instance : entry.getValue().keySet()) {
-        bytes.merge(instance, sizeBytes, Long::sum);
-      }
-    }
+    assignment.forEach((segment, instanceStateMap) -> instanceStateMap.keySet()
+        .forEach(instance -> bytes.merge(instance, sizes.getOrDefault(segment, 1L), Long::sum)));
     return bytes;
   }
 
-  /// Renders the accounting unit: raw segment counts when no sizes were supplied, MiB otherwise.
-  private static String formatUnits(long units, Scenario scenario) {
-    return scenario._segmentSizeBytes.isEmpty() ? Long.toString(units)
-        : (units / (1024 * 1024)) + "M";
-  }
-
-  /// The per-segment sizes as [TableSizeReader] would report them, so the real extraction path is exercised.
+  /// The sizes as [TableSizeReader] reports them, so the real extraction path is exercised. `null` where the scenario
+  /// supplies none, which makes every segment weigh one byte.
   private static TableSizeReader.TableSubTypeSizeDetails toTableSizeDetails(Map<String, Long> segmentSizeBytes) {
+    if (segmentSizeBytes.isEmpty()) {
+      return null;
+    }
     TableSizeReader.TableSubTypeSizeDetails tableSizeDetails = new TableSizeReader.TableSubTypeSizeDetails();
     segmentSizeBytes.forEach((segment, sizeBytes) -> {
       TableSizeReader.SegmentSizeDetails segmentSizeDetails = new TableSizeReader.SegmentSizeDetails();
@@ -1446,262 +724,7 @@ public class LowDiskModeRebalanceSimulatorTest {
     return union;
   }
 
-  // ---------------------------------------------------------------------------------------------------------------
-  // Model
-  // ---------------------------------------------------------------------------------------------------------------
-
-  private static class Scenario {
-    final String _name;
-    final Map<String, Map<String, String>> _currentAssignment;
-    final Map<String, Map<String, String>> _targetAssignment;
-    final int _minAvailableReplicas;
-    final boolean _enableStrictReplicaGroup;
-    final int _batchSizePerServer;
-    /// Per-segment size in bytes. Empty means every segment counts as one byte, i.e. the budget degenerates to
-    /// bounding segment counts.
-    final Map<String, Long> _segmentSizeBytes;
-
-    Scenario(String name, Map<String, Map<String, String>> currentAssignment,
-        Map<String, Map<String, String>> targetAssignment, int minAvailableReplicas,
-        boolean enableStrictReplicaGroup, int batchSizePerServer) {
-      this(name, currentAssignment, targetAssignment, minAvailableReplicas, enableStrictReplicaGroup,
-          batchSizePerServer, Map.of());
-    }
-
-    Scenario(String name, Map<String, Map<String, String>> currentAssignment,
-        Map<String, Map<String, String>> targetAssignment, int minAvailableReplicas,
-        boolean enableStrictReplicaGroup, int batchSizePerServer, Map<String, Long> segmentSizeBytes) {
-      _name = name;
-      _currentAssignment = currentAssignment;
-      _targetAssignment = targetAssignment;
-      _minAvailableReplicas = minAvailableReplicas;
-      _enableStrictReplicaGroup = enableStrictReplicaGroup;
-      _batchSizePerServer = batchSizePerServer;
-      _segmentSizeBytes = segmentSizeBytes;
-    }
-
-    long sizeOf(String segment) {
-      return _segmentSizeBytes.getOrDefault(segment, 1L);
-    }
-  }
-
-  /// Builds a skewed size distribution over `segments`: most segments are small and a few are an order of magnitude
-  /// larger, which is what a table with mixed offline pushes and varying retention actually looks like. Segment count
-  /// based budgeting cannot see this skew, which is the whole reason for going byte based.
-  private static Map<String, Long> skewedSizes(Collection<String> segments, Random random) {
-    Map<String, Long> segmentSizeBytes = new TreeMap<>();
-    for (String segment : segments) {
-      // 80% small, 20% between 10x and 40x larger
-      long sizeBytes = random.nextInt(10) < 8
-          ? 8L * 1024 * 1024 + random.nextInt(24) * 1024L * 1024
-          : 320L * 1024 * 1024 + random.nextInt(960) * 1024L * 1024;
-      segmentSizeBytes.put(segment, sizeBytes);
-    }
-    return segmentSizeBytes;
-  }
-
-  private static class Step {
-    final int _index;
-    final Map<String, Long> _before = new TreeMap<>();
-    final Map<String, Long> _after = new TreeMap<>();
-    final Map<String, Long> _adds = new HashMap<>();
-    final Map<String, Long> _drops = new HashMap<>();
-    /// Server -> segments this step newly assigns to it.
-    final Map<String, Set<String>> _addedSegments = new HashMap<>();
-    /// Server -> segments this step keeps on it even though the target does not place them there, because dropping
-    /// them would break the minAvailableReplicas requirement.
-    final Map<String, Set<String>> _heldForAvailability = new HashMap<>();
-    /// Servers that had segments to drop at the start of this step and were still assigned new segments, i.e. the
-    /// servers for which TableRebalancer gave up on the deferral in order to make progress.
-    final Set<String> _deferralRelaxedFor = new TreeSet<>();
-
-    Step(int index) {
-      _index = index;
-    }
-  }
-
-  private static class SimResult {
-    final Scenario _scenario;
-    final List<Step> _steps = new ArrayList<>();
-    Map<String, Long> _initial = new TreeMap<>();
-    Map<String, Long> _target = new TreeMap<>();
-    Map<String, Long> _maxAfter = new TreeMap<>();
-    Map<String, Long> _maxInStep = new TreeMap<>();
-    /// Strict replica group violations: groups of segments that were not moved together.
-    final Set<String> _groupSplits = new TreeSet<>();
-    String _terminated = "did not terminate";
-
-    SimResult(Scenario scenario) {
-      _scenario = scenario;
-    }
-
-    long bound(String server) {
-      return Math.max(_initial.getOrDefault(server, 0L), _target.getOrDefault(server, 0L));
-    }
-
-    boolean hasSteadyStateViolation() {
-      return _maxAfter.keySet().stream().anyMatch(server -> _maxAfter.get(server) > bound(server));
-    }
-
-    boolean hasInStepViolation() {
-      return _maxInStep.keySet().stream().anyMatch(server -> _maxInStep.get(server) > bound(server));
-    }
-
-    String worstServer() {
-      return _maxAfter.keySet().stream()
-          .max((a, b) -> Double.compare(amplification(a), amplification(b)))
-          .orElseThrow();
-    }
-
-    double amplification(String server) {
-      long bound = bound(server);
-      return bound == 0 ? _maxAfter.get(server) : (double) _maxAfter.get(server) / bound;
-    }
-
-    double worstAmplification() {
-      return amplification(worstServer());
-    }
-
-    /// Steps in which TableRebalancer gave up on deferring the adds in order to make progress.
-    List<Step> relaxedSteps() {
-      return _steps.stream().filter(step -> !step._deferralRelaxedFor.isEmpty()).toList();
-    }
-
-    /// The most any single server holds above its bound, in accounting units.
-    long worstExcess() {
-      return _maxAfter.keySet().stream().mapToLong(server -> _maxAfter.get(server) - bound(server)).max().orElse(0L);
-    }
-
-    String report() {
-      StringBuilder sb = new StringBuilder();
-      sb.append("\n").append("=".repeat(118)).append('\n');
-      sb.append(_scenario._name).append('\n');
-      sb.append("=".repeat(118)).append('\n');
-      sb.append(String.format("steps: %d, outcome: %s%n%n", _steps.size(), _terminated));
-
-      Set<String> servers = union(_maxAfter.keySet(), _initial.keySet());
-      sb.append("Per-step hosted segment counts (before -> after, +downloads/-deletes):\n");
-      sb.append(String.format("  %-6s", "server"));
-      for (Step step : _steps) {
-        sb.append(String.format("%-18s", "step " + step._index));
-      }
-      sb.append('\n');
-      for (String server : servers) {
-        sb.append(String.format("  %-6s", server));
-        for (Step step : _steps) {
-          long adds = step._adds.getOrDefault(server, 0L);
-          long drops = step._drops.getOrDefault(server, 0L);
-          sb.append(String.format("%-22s", String.format("%s->%s %s%s",
-              formatUnits(step._before.getOrDefault(server, 0L), _scenario),
-              formatUnits(step._after.getOrDefault(server, 0L), _scenario),
-              adds > 0 ? "+" + formatUnits(adds, _scenario) : "",
-              drops > 0 ? "-" + formatUnits(drops, _scenario) : "")));
-        }
-        sb.append('\n');
-      }
-
-      sb.append("\nPer-server summary:\n");
-      sb.append(String.format("  %-8s %9s %9s %9s %10s %10s   %s%n", "server", "initial", "target", "bound",
-          "maxAfter", "maxInStep", "verdict"));
-      for (String server : servers) {
-        long bound = bound(server);
-        long maxAfter = _maxAfter.getOrDefault(server, 0L);
-        long maxInStep = _maxInStep.getOrDefault(server, 0L);
-        String verdict;
-        if (maxAfter > bound) {
-          verdict = String.format("NET INCREASE: holds %s vs bound %s (+%s, %.0f%% over)",
-              formatUnits(maxAfter, _scenario), formatUnits(bound, _scenario),
-              formatUnits(maxAfter - bound, _scenario), 100.0 * (maxAfter - bound) / Math.max(1, bound));
-        } else if (maxInStep > bound) {
-          verdict = String.format("TRANSIENT: may hold %s vs bound %s within a step",
-              formatUnits(maxInStep, _scenario), formatUnits(bound, _scenario));
-        } else {
-          verdict = "ok";
-        }
-        sb.append(String.format("  %-8s %9s %9s %9s %10s %10s   %s%n", server,
-            formatUnits(_initial.getOrDefault(server, 0L), _scenario),
-            formatUnits(_target.getOrDefault(server, 0L), _scenario), formatUnits(bound, _scenario),
-            formatUnits(maxAfter, _scenario), formatUnits(maxInStep, _scenario), verdict));
-      }
-      sb.append(String.format("%nsteady-state violation: %s, within-step violation: %s%n", hasSteadyStateViolation(),
-          hasInStepViolation()));
-      for (Step step : relaxedSteps()) {
-        sb.append(String.format("  step %d: budget relaxed for %s (no progress was possible within it)%n",
-            step._index, step._deferralRelaxedFor));
-        // Was the stall physically necessary, or only an artifact of blocking every server that has a pending drop?
-        // Show how many free slots each server had under its own bound at the start of the stalled step.
-        long totalHeadroom = 0;
-        StringBuilder headroomDetail = new StringBuilder();
-        for (String server : _maxAfter.keySet()) {
-          long headroom = bound(server) - step._before.getOrDefault(server, 0L);
-          if (headroom > 0) {
-            totalHeadroom += headroom;
-            headroomDetail.append(String.format(" %s=%s", server, formatUnits(headroom, _scenario)));
-          }
-        }
-        sb.append(String.format("    free space under each server's own bound at that point:%s (total %s)%n",
-            headroomDetail, formatUnits(totalHeadroom, _scenario)));
-      }
-      for (String groupSplit : _groupSplits) {
-        sb.append("  STRICT REPLICA GROUP SPLIT: ").append(groupSplit).append('\n');
-      }
-      if (hasSteadyStateViolation()) {
-        sb.append(explainWorstServer());
-      }
-      return sb.toString();
-    }
-
-    /// Explains the peak for the worst server: the segments it is simultaneously downloading, and the segments it is
-    /// still holding only to satisfy minAvailableReplicas.
-    String explainWorstServer() {
-      String server = worstServer();
-      Step peakStep = null;
-      for (Step step : _steps) {
-        if (peakStep == null || step._after.getOrDefault(server, 0L) > peakStep._after.getOrDefault(server, 0L)) {
-          peakStep = step;
-        }
-      }
-      if (peakStep == null) {
-        return "";
-      }
-      Set<String> added = peakStep._addedSegments.getOrDefault(server, new TreeSet<>());
-      Set<String> held = peakStep._heldForAvailability.getOrDefault(server, new TreeSet<>());
-      StringBuilder sb = new StringBuilder();
-      sb.append(String.format("%nWhy %s peaks at %s in step %d:%n", server,
-          formatUnits(peakStep._after.get(server), _scenario), peakStep._index));
-      sb.append(String.format("  * %d segment(s) downloaded onto %s, because for each of them every current replica "
-              + "is already in the target (nothing left to drop), so lowDiskMode allows the add: %s%n", added.size(),
-          server, abbreviate(added)));
-      sb.append(String.format("  * %d segment(s) still pinned on %s even though the target does not place them "
-              + "there, because dropping them would break minAvailableReplicas=%d: %s%n", held.size(), server,
-          _scenario._minAvailableReplicas, abbreviate(held)));
-      sb.append("  lowDiskMode only sequences drop-before-add *per segment*. Nothing sequences it per server, so a\n"
-          + "  server in the overlap of the old and new server sets pays for both sets at once.\n");
-      return sb.toString();
-    }
-
-    private static String abbreviate(Set<String> segments) {
-      if (segments.size() <= 6) {
-        return segments.toString();
-      }
-      List<String> head = new ArrayList<>(segments).subList(0, 6);
-      return head + " ... (" + segments.size() + " total)";
-    }
-  }
-
-  /// Runs every scenario and prints the reports, for use outside of the TestNG runner.
-  public static void main(String[] args) {
-    LowDiskModeRebalanceSimulatorTest simulator = new LowDiskModeRebalanceSimulatorTest();
-    Map<String, Runnable> scenarios = new LinkedHashMap<>();
-    scenarios.put("overlapping-rotation", simulator::testOverlappingServerSetsRotation);
-    scenarios.put("overlapping-rotation-strict", simulator::testOverlappingServerSetsRotationStrictReplicaGroup);
-    scenarios.put("larger-rotation", simulator::testLargerRotationOverlap);
-    scenarios.put("pure-scale-out-control", simulator::testPureScaleOutIsClean);
-    scenarios.put("sweep", simulator::testSweepOverlappingServerSets);
-    scenarios.put("random-search", simulator::testRandomSearch);
-    scenarios.forEach((name, runnable) -> {
-      System.out.println("\n\n##### " + name + " #####");
-      runnable.run();
-    });
+  private static String mib(long bytes) {
+    return bytes >= MIB ? (bytes / MIB) + "M" : Long.toString(bytes);
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/LowDiskModeRebalanceSimulatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/LowDiskModeRebalanceSimulatorTest.java
@@ -253,6 +253,58 @@ public class LowDiskModeRebalanceSimulatorTest {
     return SegmentAssignmentUtils.getInstanceStateMap(List.of(instances), ONLINE);
   }
 
+  /// A segment group needing two instances at once, where only one of them has room, is added to the one that does
+  /// rather than being held back entirely.
+  ///
+  /// A group whose current replicas number the minimum available has to gain `replication - minAvailableReplicas`
+  /// instances, which is two or more whenever replication exceeds the minimum by that much. Adding an instance that
+  /// cannot take the group on would have the whole assignment rejected when it is charged, so the instance that could
+  /// have taken it waits too - and if every group in the step is held back that way, the budget is relaxed and the
+  /// guarantee is given up for a step. Adding the one that fits makes progress within the budget instead.
+  @Test
+  public void testGroupIsAddedToTheInstancesThatFitRatherThanHeldBack() {
+    long mib = 1024L * 1024;
+    Map<String, Map<String, String>> initialAssignment = new TreeMap<>();
+    Map<String, Map<String, String>> current = new TreeMap<>();
+    Map<String, Map<String, String>> target = new TreeMap<>();
+    Map<String, Long> sizes = new TreeMap<>();
+
+    // The group to move: one replica left, and the target wants it on two more instances
+    addSegment(initialAssignment, current, target, sizes, "moving", List.of("hostKeep"), List.of("hostKeep"),
+        List.of("hostKeep", "hostRoomy", "hostFull"), 200 * mib);
+    // hostFull starts full and the target keeps it that way, so it has no room for anything else
+    addSegment(initialAssignment, current, target, sizes, "fillsHostFull", List.of("hostFull"), List.of("hostFull"),
+        List.of("hostFull"), 900 * mib);
+    // hostFull also owes a segment it cannot drop, since that is its only replica, which uses up what little the
+    // target assignment leaves it
+    addSegment(initialAssignment, current, target, sizes, "stuckOnHostFull", List.of("hostFull"), List.of("hostFull"),
+        List.of("other"), 150 * mib);
+    // hostRoomy is growing into space it does not use yet
+    addSegment(initialAssignment, current, target, sizes, "fillsHostRoomy", List.of("other"), List.of("other"),
+        List.of("hostRoomy"), 900 * mib);
+
+    TableRebalancer.DiskUsageBudget budget =
+        TableRebalancer.DiskUsageBudget.create(initialAssignment, toTableSizeDetails(sizes));
+    Map<String, Long> remaining = budget.forStep(current, target).getRemainingBytes();
+    System.out.printf("%n  remaining: hostRoomy=%s hostFull=%s, group needs %s%n",
+        formatMib(remaining.getOrDefault("hostRoomy", 0L)), formatMib(remaining.getOrDefault("hostFull", 0L)),
+        formatMib(200 * mib));
+    assertTrue(remaining.getOrDefault("hostRoomy", 0L) >= 200 * mib, "hostRoomy must have room for the group");
+    assertTrue(remaining.getOrDefault("hostFull", 0L) < 200 * mib, "hostFull must not have room for the group");
+
+    Map<String, Map<String, String>> next =
+        TableRebalancer.getNextAssignment(current, target, 1, true, true,
+            RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+            NO_DATA_LOSS_RISK, budget);
+    Set<String> movingNext = next.get("moving").keySet();
+    System.out.println("  next assignment for the group: " + movingNext);
+
+    assertTrue(movingNext.contains("hostRoomy"),
+        "the group should be added to the instance that has room, got " + movingNext);
+    assertFalse(movingNext.contains("hostFull"),
+        "the group must not be added to the instance that has no room, got " + movingNext);
+  }
+
   /// The disk budget holds a total per pair of current and target instances, used to pick which instance to add. It
   /// is tempting to charge a strict replica group move by looking that total up, but the two are different totals when
   /// batching is enabled: `updateNextAssignmentForPartitionIdStrictReplicaGroup` is then called once per partition,

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/LowDiskModeRebalanceSimulatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/LowDiskModeRebalanceSimulatorTest.java
@@ -1,0 +1,828 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.rebalance;
+
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import org.apache.pinot.common.restlet.resources.RebalanceConfig;
+import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentUtils;
+import org.apache.pinot.controller.util.TableSizeReader;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+/// Step-by-step simulator for `lowDiskMode` rebalance, used to demonstrate that a server can still see a **net
+/// increase** in the number of hosted segments (i.e. disk usage) while the rebalance is in flight.
+///
+/// The simulator drives the real [TableRebalancer#getNextAssignment] in a loop, exactly the way
+/// [TableRebalancer] does, and after each step accounts, per server:
+///  * `before`  - segments hosted before the step
+///  * `+adds`   - segments the step assigns to the server (a download)
+///  * `-drops`  - segments the step removes from the server (a deletion)
+///  * `after`   - segments hosted once the step converges
+///
+/// `lowDiskMode` is supposed to guarantee that no server ever needs more disk than it started with (or than the
+/// target asks it to hold), so the invariant checked here is:
+///
+///     usage(server, any point in time) <= max(initialUsage(server), targetUsage(server))
+///
+/// Two peaks are tracked against that bound:
+///  * `maxAfter`     - the steady-state peak, i.e. the assignment the controller actually publishes. Exceeding the
+///                     bound here is a *persistent* over-allocation that lasts for at least one full step.
+///  * `maxInStep`    - the worst-case peak within a step (`before + adds`). `getNextSingleSegmentAssignment` notes
+///                     that "even if segment addition and drop happen in the same step, there is no guarantee that
+///                     server process the segment drop before the segment addition", so this is reachable.
+///
+/// All segments are treated as equal-sized, so "segment count" is a proxy for disk.
+public class LowDiskModeRebalanceSimulatorTest {
+  private static final String ONLINE = "ONLINE";
+  private static final int MAX_STEPS = 50;
+  private static final TableRebalancer.PartitionIdFetcher DUMMY_PARTITION_FETCHER = segmentName -> 0;
+  private static final TableRebalancer.DataLossRiskAssessor NO_DATA_LOSS_RISK =
+      new TableRebalancer.NoOpRiskAssessor();
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Scenarios
+  // ---------------------------------------------------------------------------------------------------------------
+
+  /// The minimal toy example: 3 servers -> 3 servers with 2 servers in the overlap, replication 2,
+  /// `minAvailableReplicas = 1`. Every overlap server both offloads and onloads segments.
+  ///
+  /// `hostC` starts with 4 segments and ends with 4 segments, but transiently holds 6.
+  @Test
+  public void testOverlappingServerSetsRotation() {
+    List<String> oldServers = List.of("hostA", "hostB", "hostC");
+    List<String> newServers = List.of("hostB", "hostC", "hostD");
+    Scenario scenario =
+        new Scenario("3 servers -> 3 servers, 2 in overlap (replication 2, minAvailableReplicas 1)",
+            roundRobin(6, 2, oldServers, 0), roundRobin(6, 2, newServers, 0), 1, false,
+            RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER);
+    SimResult result = simulate(scenario);
+    System.out.println(result.report());
+    assertFalse(result.hasSteadyStateViolation(),
+        "lowDiskMode must not let any server hold more than max(initial, target) segments");
+    assertFalse(result.hasInStepViolation(),
+        "lowDiskMode must not let any server download while it still has segments to drop");
+  }
+
+  /// Same shape, with strict replica-group enabled, to show the problem is not specific to the non-strict path.
+  @Test
+  public void testOverlappingServerSetsRotationStrictReplicaGroup() {
+    List<String> oldServers = List.of("hostA", "hostB", "hostC");
+    List<String> newServers = List.of("hostB", "hostC", "hostD");
+    Scenario scenario = new Scenario("Same, strictReplicaGroup = true", roundRobin(6, 2, oldServers, 0),
+        roundRobin(6, 2, newServers, 0), 1, true, RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER);
+    SimResult result = simulate(scenario);
+    System.out.println(result.report());
+    assertFalse(result.hasSteadyStateViolation(),
+        "lowDiskMode must not let any server hold more than max(initial, target) segments");
+    assertFalse(result.hasInStepViolation(),
+        "lowDiskMode must not let any server download while it still has segments to drop");
+    assertEquals(result._groupSplits, Set.of());
+  }
+
+  /// The disk budget is charged as segments are assigned, so charging it per segment could fit the first segments of a
+  /// partition and not the rest, splitting the partition across replica groups. Sweeps the grid with strict replica
+  /// group routing and skewed segment sizes - which is what makes a group only partially fit - and checks that every
+  /// group of segments sharing the same current and target instances is always moved as a whole.
+  @Test
+  public void testStrictReplicaGroupMovesGroupsTogether() {
+    Random random = new Random(11);
+    List<SimResult> violations = new ArrayList<>();
+    List<SimResult> all = new ArrayList<>();
+    List<String> splits = new ArrayList<>();
+    for (int numOldServers = 3; numOldServers <= 8; numOldServers++) {
+      for (int numNewServers = 3; numNewServers <= 8; numNewServers++) {
+        for (int shift = 1; shift < numOldServers; shift++) {
+          for (int replication = 2; replication <= Math.min(3, Math.min(numOldServers, numNewServers));
+              replication++) {
+            int numSegments = 12 * replication;
+            List<String> oldServers = servers(0, numOldServers);
+            List<String> newServers = servers(shift, numNewServers);
+            Map<String, Map<String, String>> current = roundRobin(numSegments, replication, oldServers, 0);
+            String name = String.format("strict old=%d new=%d overlap=%d replication=%d segments=%d", numOldServers,
+                numNewServers, overlap(oldServers, newServers), replication, numSegments);
+            SimResult result = simulate(new Scenario(name, current,
+                roundRobin(numSegments, replication, newServers, 0), 1, true,
+                RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, skewedSizes(current.keySet(), random)));
+            all.add(result);
+            if (result.hasSteadyStateViolation()) {
+              violations.add(result);
+            }
+            result._groupSplits.forEach(split -> splits.add(name + " | " + split));
+          }
+        }
+      }
+    }
+    violations.sort((a, b) -> Double.compare(b.worstAmplification(), a.worstAmplification()));
+    System.out.println();
+    System.out.println(summarize("Strict replica group sweep with skewed segment sizes", all, violations));
+    if (!splits.isEmpty()) {
+      System.out.printf("%d strict replica group splits, first 5:%n", splits.size());
+      splits.subList(0, Math.min(5, splits.size())).forEach(split -> System.out.println("  " + split));
+    }
+    assertEquals(splits, List.of(), "strict replica group requires every group of segments to be moved together");
+  }
+
+  /// A larger, more realistic rotation: 6 servers -> 6 servers with 3 in the overlap, replication 2, 24 segments.
+  /// Shows the over-allocation scales with the table rather than being a rounding artifact - the worst server ends
+  /// up holding double what it started with.
+  ///
+  /// Note that not every overlapping rotation trips this; whether it does depends on how the round-robin lands.
+  /// [#testSweepOverlappingServerSets] enumerates the space.
+  @Test
+  public void testLargerRotationOverlap() {
+    List<String> oldServers = List.of("host1", "host2", "host3", "host4", "host5", "host6");
+    List<String> newServers = List.of("host4", "host5", "host6", "host7", "host8", "host9");
+    Scenario scenario =
+        new Scenario("6 servers -> 6 servers, 3 in overlap (replication 2, minAvailableReplicas 1)",
+            roundRobin(24, 2, oldServers, 0), roundRobin(24, 2, newServers, 0), 1, false,
+            RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER);
+    SimResult result = simulate(scenario);
+    System.out.println(result.report());
+    assertFalse(result.hasSteadyStateViolation(),
+        "lowDiskMode must not let any server hold more than max(initial, target) segments");
+    assertFalse(result.hasInStepViolation(),
+        "lowDiskMode must not let any server download while it still has segments to drop");
+  }
+
+  /// Control case: a pure scale-out where no server in the old set gains anything. `lowDiskMode` holds here, which
+  /// is why the existing coverage in [TableRebalancerTest] does not catch the problem above.
+  @Test
+  public void testPureScaleOutIsClean() {
+    List<String> oldServers = List.of("host1", "host2", "host3", "host4");
+    List<String> newServers = List.of("host1", "host2", "host3", "host4", "host5", "host6", "host7", "host8");
+    Scenario scenario = new Scenario("4 servers -> 8 servers, pure scale-out (control case)",
+        roundRobin(24, 2, oldServers, 0), roundRobin(24, 2, newServers, 0), 1, false,
+        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER);
+    SimResult result = simulate(scenario);
+    System.out.println(result.report());
+    assertFalse(result.hasSteadyStateViolation(), "pure scale-out should not over-allocate any old server");
+  }
+
+  /// The shape that over-allocated the most under a segment count based budget: two servers each ended up holding
+  /// 23 segments against a bound of 18, because the budget was relaxed to break a stall that was not real - both
+  /// servers had free space at the time. Under the byte budget it stays within the bound and is never relaxed.
+  @Test
+  public void testPreviouslyWorstCaseStaysWithinBound() {
+    Scenario scenario =
+        new Scenario("8 servers -> 6 servers, 6 in overlap (replication 3, minAvailableReplicas 2), 36 segments",
+            roundRobin(36, 3, servers(0, 8), 0), roundRobin(36, 3, servers(2, 6), 0), 2, false,
+            RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER);
+    SimResult result = simulate(scenario);
+    System.out.println(result.report());
+    assertFalse(result.hasSteadyStateViolation(), "no server may hold more than max(initial, target)");
+    assertFalse(result.hasInStepViolation(), "no server may exceed max(initial, target) mid-step either");
+    assertTrue(result.relaxedSteps().isEmpty(), "the budget should not have to be relaxed for this shape");
+  }
+
+  /// Sweeps a grid of overlapping old/new server sets and reports the worst amplification found, so the blast
+  /// radius of the edge case can be sized.
+  @Test
+  public void testSweepOverlappingServerSets() {
+    List<SimResult> violations = new ArrayList<>();
+    List<SimResult> all = new ArrayList<>();
+    for (int numOldServers = 3; numOldServers <= 8; numOldServers++) {
+      for (int numNewServers = 3; numNewServers <= 8; numNewServers++) {
+        for (int shift = 1; shift < numOldServers; shift++) {
+          for (int replication = 1; replication <= Math.min(3, Math.min(numOldServers, numNewServers));
+              replication++) {
+            for (int minAvailableReplicas = 1; minAvailableReplicas < replication + 1; minAvailableReplicas++) {
+              if (minAvailableReplicas >= replication && replication > 1) {
+                // A rebalance cannot make progress when minAvailableReplicas == replication
+                continue;
+              }
+              int numSegments = 12 * replication;
+              List<String> oldServers = servers(0, numOldServers);
+              List<String> newServers = servers(shift, numNewServers);
+              String name = String.format(
+                  "old=%d new=%d overlap=%d replication=%d minAvailableReplicas=%d segments=%d", numOldServers,
+                  numNewServers, overlap(oldServers, newServers), replication, minAvailableReplicas, numSegments);
+              Scenario scenario = new Scenario(name, roundRobin(numSegments, replication, oldServers, 0),
+                  roundRobin(numSegments, replication, newServers, 0), minAvailableReplicas, false,
+                  RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER);
+              SimResult result = simulate(scenario);
+              all.add(result);
+              if (result.hasSteadyStateViolation()) {
+                violations.add(result);
+              }
+            }
+          }
+        }
+      }
+    }
+    violations.sort((a, b) -> Double.compare(b.worstAmplification(), a.worstAmplification()));
+    System.out.println();
+    System.out.println(summarize("Sweep", all, violations));
+    System.out.println("Worst 10 by amplification (peak hosted / bound):");
+    for (SimResult result : violations.subList(0, Math.min(10, violations.size()))) {
+      System.out.printf("  %-88s worst server %s: bound %s, peak %s (%.2fx, +%s)%n", result._scenario._name,
+          result.worstServer(), formatUnits(result.bound(result.worstServer()), result._scenario),
+          formatUnits(result._maxAfter.get(result.worstServer()), result._scenario), result.worstAmplification(),
+          formatUnits(result.worstExcess(), result._scenario));
+    }
+    System.out.println();
+  }
+
+  /// Aggregate metrics for a batch of scenarios. Counting violating scenarios alone is misleading - a one-segment
+  /// overshoot is not the same problem as a 2x overshoot - so report the magnitude and the convergence cost too.
+  private static String summarize(String label, List<SimResult> all, List<SimResult> violations) {
+    long totalExcess = 0;
+    long worstExcess = 0;
+    double worstAmplification = 1.0;
+    int totalSteps = 0;
+    int maxSteps = 0;
+    int numStuck = 0;
+    int numRelaxed = 0;
+    int numViolatingWithoutRelax = 0;
+    for (SimResult result : all) {
+      if (!result.relaxedSteps().isEmpty()) {
+        numRelaxed++;
+      } else if (result.hasSteadyStateViolation()) {
+        numViolatingWithoutRelax++;
+      }
+      totalExcess += result.worstExcess();
+      worstExcess = Math.max(worstExcess, result.worstExcess());
+      worstAmplification = Math.max(worstAmplification, result.worstAmplification());
+      totalSteps += result._steps.size();
+      maxSteps = Math.max(maxSteps, result._steps.size());
+      if (result._terminated.startsWith("STUCK") || result._terminated.startsWith("hit MAX_STEPS")) {
+        numStuck++;
+      }
+    }
+    return String.format("%s over %d scenarios:%n"
+            + "  violating scenarios : %d (%.1f%%)%n"
+            + "  worst amplification : %.2fx%n"
+            + "  worst excess        : %d units over the bound%n"
+            + "  total excess        : %d units summed over all scenarios%n"
+            + "  steps               : %.1f mean, %d max%n"
+            + "  did not converge    : %d%n"
+            + "  budget relaxed in    : %d (no progress was possible within the budget)%n"
+            + "  violating, no relax  : %d  <-- unexplained by the relaxation%n", label, all.size(),
+        violations.size(), 100.0 * violations.size() / all.size(), worstAmplification, worstExcess, totalExcess,
+        (double) totalSteps / all.size(), maxSteps, numStuck, numRelaxed, numViolatingWithoutRelax);
+  }
+
+  /// Same grid as [#testSweepOverlappingServerSets], but with a skewed per-segment size distribution, so the budget
+  /// is bounding bytes rather than segment counts. This is the case a count based budget cannot get right: it lets a
+  /// server take on large segments because it dropped small ones.
+  @Test
+  public void testSweepWithSkewedSegmentSizes() {
+    List<SimResult> violations = new ArrayList<>();
+    List<SimResult> all = new ArrayList<>();
+    Random random = new Random(7);
+    for (int numOldServers = 3; numOldServers <= 8; numOldServers++) {
+      for (int numNewServers = 3; numNewServers <= 8; numNewServers++) {
+        for (int shift = 1; shift < numOldServers; shift++) {
+          for (int replication = 1; replication <= Math.min(3, Math.min(numOldServers, numNewServers));
+              replication++) {
+            for (int minAvailableReplicas = 1; minAvailableReplicas < replication + 1; minAvailableReplicas++) {
+              if (minAvailableReplicas >= replication && replication > 1) {
+                continue;
+              }
+              int numSegments = 12 * replication;
+              List<String> oldServers = servers(0, numOldServers);
+              List<String> newServers = servers(shift, numNewServers);
+              Map<String, Map<String, String>> current = roundRobin(numSegments, replication, oldServers, 0);
+              String name = String.format(
+                  "old=%d new=%d overlap=%d replication=%d minAvailableReplicas=%d segments=%d", numOldServers,
+                  numNewServers, overlap(oldServers, newServers), replication, minAvailableReplicas, numSegments);
+              SimResult result = simulate(new Scenario(name, current,
+                  roundRobin(numSegments, replication, newServers, 0), minAvailableReplicas, false,
+                  RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, skewedSizes(current.keySet(), random)));
+              all.add(result);
+              if (result.hasSteadyStateViolation()) {
+                violations.add(result);
+              }
+            }
+          }
+        }
+      }
+    }
+    violations.sort((a, b) -> Double.compare(b.worstAmplification(), a.worstAmplification()));
+    System.out.println();
+    System.out.println(summarize("Sweep with skewed segment sizes", all, violations));
+    for (SimResult result : violations.subList(0, Math.min(10, violations.size()))) {
+      System.out.printf("  %-88s worst server %s: bound %s, peak %s (%.2fx, +%s)%n", result._scenario._name,
+          result.worstServer(), formatUnits(result.bound(result.worstServer()), result._scenario),
+          formatUnits(result._maxAfter.get(result.worstServer()), result._scenario), result.worstAmplification(),
+          formatUnits(result.worstExcess(), result._scenario));
+    }
+    System.out.println();
+  }
+
+  /// Randomized search over non-uniform current assignments (the state a table is in after an interrupted
+  /// rebalance, a replication change, or realtime segments that were created against the new instance
+  /// partitions) looking for the largest amplification.
+  @Test
+  public void testRandomSearch() {
+    Random random = new Random(42);
+    List<SimResult> violations = new ArrayList<>();
+    List<SimResult> all = new ArrayList<>();
+    for (int trial = 0; trial < 400; trial++) {
+      int numOldServers = 3 + random.nextInt(6);
+      int numNewServers = 3 + random.nextInt(6);
+      int shift = 1 + random.nextInt(numOldServers);
+      int replication = 1 + random.nextInt(3);
+      int minAvailableReplicas = 1 + random.nextInt(Math.max(1, replication - 1));
+      int numSegments = 6 + random.nextInt(30);
+      List<String> oldServers = servers(0, numOldServers);
+      List<String> newServers = servers(shift, numNewServers);
+      Map<String, Map<String, String>> current =
+          roundRobin(numSegments, Math.min(replication, numOldServers), oldServers, random.nextInt(numOldServers));
+      Map<String, Map<String, String>> target =
+          roundRobin(numSegments, Math.min(replication, numNewServers), newServers, random.nextInt(numNewServers));
+      String name = String.format("trial %d: old=%d new=%d overlap=%d replication=%d minAvail=%d segments=%d", trial,
+          numOldServers, numNewServers, overlap(oldServers, newServers), replication, minAvailableReplicas,
+          numSegments);
+      SimResult result = simulate(new Scenario(name, current, target, minAvailableReplicas, false,
+          RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER));
+      all.add(result);
+      if (result.hasSteadyStateViolation()) {
+        violations.add(result);
+      }
+    }
+    violations.sort((a, b) -> Double.compare(b.worstAmplification(), a.worstAmplification()));
+    System.out.println();
+    System.out.println(summarize("Random search", all, violations));
+    if (!violations.isEmpty()) {
+      System.out.println("Worst offender:");
+      System.out.println(violations.get(0).report());
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Simulator
+  // ---------------------------------------------------------------------------------------------------------------
+
+  private static SimResult simulate(Scenario scenario) {
+    SimResult result = new SimResult(scenario);
+    Map<String, Map<String, String>> current = deepCopy(scenario._currentAssignment);
+    Object2IntOpenHashMap<String> segmentPartitionIdMap = new Object2IntOpenHashMap<>();
+
+    // The budget the controller uses, anchored to the assignment the rebalance starts from
+    TableRebalancer.DiskUsageBudget diskUsageBudget = TableRebalancer.DiskUsageBudget.create(current,
+        scenario._segmentSizeBytes.isEmpty() ? null : toTableSizeDetails(scenario._segmentSizeBytes));
+
+    result._initial = hostedBytes(current, scenario);
+    result._target = hostedBytes(scenario._targetAssignment, scenario);
+    result._maxAfter = new TreeMap<>(result._initial);
+    result._maxInStep = new TreeMap<>(result._initial);
+    for (String server : result._target.keySet()) {
+      result._maxAfter.putIfAbsent(server, 0L);
+      result._maxInStep.putIfAbsent(server, 0L);
+    }
+
+    for (int step = 1; step <= MAX_STEPS; step++) {
+      Map<String, Map<String, String>> next;
+      try {
+        next = TableRebalancer.getNextAssignment(current, scenario._targetAssignment, scenario._minAvailableReplicas,
+            scenario._enableStrictReplicaGroup, true /* lowDiskMode */, scenario._batchSizePerServer,
+            segmentPartitionIdMap, DUMMY_PARTITION_FETCHER, NO_DATA_LOSS_RISK, diskUsageBudget);
+      } catch (Exception e) {
+        result._terminated = "step " + step + " threw " + e;
+        break;
+      }
+      if (next.equals(current)) {
+        result._terminated = next.equals(scenario._targetAssignment) ? "converged" : "STUCK (no progress possible)";
+        break;
+      }
+
+      Step stepInfo = new Step(step);
+      Map<String, Long> before = hostedBytes(current, scenario);
+      Map<String, Long> after = hostedBytes(next, scenario);
+      for (String segment : current.keySet()) {
+        Set<String> currentInstances = current.get(segment).keySet();
+        Set<String> nextInstances = next.get(segment).keySet();
+        Set<String> targetInstances = scenario._targetAssignment.get(segment).keySet();
+        long sizeBytes = scenario.sizeOf(segment);
+        for (String instance : nextInstances) {
+          if (!currentInstances.contains(instance)) {
+            stepInfo._adds.merge(instance, sizeBytes, Long::sum);
+            stepInfo._addedSegments.computeIfAbsent(instance, k -> new TreeSet<>()).add(segment);
+          } else if (!targetInstances.contains(instance)) {
+            // The instance is not in the target for this segment, yet the step keeps the segment on it. This only
+            // happens because dropping it would break the minAvailableReplicas requirement, i.e. the replacement
+            // replica has not been created yet. The disk it occupies is not accounted for anywhere.
+            stepInfo._heldForAvailability.computeIfAbsent(instance, k -> new TreeSet<>()).add(segment);
+          }
+        }
+        for (String instance : currentInstances) {
+          if (!nextInstances.contains(instance)) {
+            stepInfo._drops.merge(instance, sizeBytes, Long::sum);
+          }
+        }
+      }
+      // Ask the real budget what each server was allowed to take on at the start of this step. A server that was
+      // assigned more than that means TableRebalancer could not make progress within the budget and relaxed it.
+      Map<String, Long> allowedBytes =
+          diskUsageBudget.forStep(current, scenario._targetAssignment).getRemainingBytes();
+      stepInfo._adds.forEach((server, addedBytes) -> {
+        if (addedBytes > allowedBytes.getOrDefault(server, 0L)) {
+          stepInfo._deferralRelaxedFor.add(server);
+        }
+      });
+      for (String server : union(result._maxAfter.keySet(), after.keySet())) {
+        long beforeBytes = before.getOrDefault(server, 0L);
+        long afterBytes = after.getOrDefault(server, 0L);
+        long inStepPeak = beforeBytes + stepInfo._adds.getOrDefault(server, 0L);
+        stepInfo._before.put(server, beforeBytes);
+        stepInfo._after.put(server, afterBytes);
+        result._maxAfter.merge(server, afterBytes, Math::max);
+        result._maxInStep.merge(server, inStepPeak, Math::max);
+      }
+      // Strict replica group routing requires every segment that shares the same current and target instances to get
+      // the same next assignment, otherwise a partition ends up split across replica groups.
+      if (scenario._enableStrictReplicaGroup) {
+        Map<List<Set<String>>, Set<String>> groupToNextInstances = new HashMap<>();
+        for (String segment : current.keySet()) {
+          List<Set<String>> group =
+              List.of(current.get(segment).keySet(), scenario._targetAssignment.get(segment).keySet());
+          Set<String> nextInstances = next.get(segment).keySet();
+          Set<String> alreadyAssigned = groupToNextInstances.putIfAbsent(group, nextInstances);
+          if (alreadyAssigned != null && !alreadyAssigned.equals(nextInstances)) {
+            result._groupSplits.add(
+                String.format("step %d: segments with current %s and target %s were split between %s and %s",
+                    stepInfo._index, group.get(0), group.get(1), alreadyAssigned, nextInstances));
+          }
+        }
+      }
+      result._steps.add(stepInfo);
+
+      current = next;
+      if (current.equals(scenario._targetAssignment)) {
+        result._terminated = "converged";
+        break;
+      }
+      if (step == MAX_STEPS) {
+        result._terminated = "hit MAX_STEPS";
+      }
+    }
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Assignment builders
+  // ---------------------------------------------------------------------------------------------------------------
+
+  private static List<String> servers(int startIndex, int count) {
+    List<String> servers = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      servers.add(String.format("host%02d", startIndex + i));
+    }
+    return servers;
+  }
+
+  private static int overlap(List<String> oldServers, List<String> newServers) {
+    Set<String> intersection = new TreeSet<>(oldServers);
+    intersection.retainAll(newServers);
+    return intersection.size();
+  }
+
+  /// Round-robins `numSegments` segments with `replication` replicas over `servers`, starting at `offset`. This is
+  /// the same shape `BalanceNumSegmentAssignmentStrategy` produces.
+  private static Map<String, Map<String, String>> roundRobin(int numSegments, int replication, List<String> servers,
+      int offset) {
+    Map<String, Map<String, String>> assignment = new TreeMap<>();
+    int numServers = servers.size();
+    int cursor = offset;
+    for (int i = 0; i < numSegments; i++) {
+      List<String> instances = new ArrayList<>(replication);
+      for (int r = 0; r < replication; r++) {
+        instances.add(servers.get(cursor % numServers));
+        cursor++;
+      }
+      assignment.put(String.format("segment%03d", i), SegmentAssignmentUtils.getInstanceStateMap(instances, ONLINE));
+    }
+    return assignment;
+  }
+
+  private static Map<String, Map<String, String>> deepCopy(Map<String, Map<String, String>> assignment) {
+    Map<String, Map<String, String>> copy = new TreeMap<>();
+    assignment.forEach((segment, instanceStateMap) -> copy.put(segment, new TreeMap<>(instanceStateMap)));
+    return copy;
+  }
+
+  /// Bytes each server hosts under `assignment`. With no per-segment sizes every segment weighs one, so this is the
+  /// hosted segment count and the accounting is identical to a count based budget.
+  private static Map<String, Long> hostedBytes(Map<String, Map<String, String>> assignment, Scenario scenario) {
+    Map<String, Long> bytes = new TreeMap<>();
+    for (Map.Entry<String, Map<String, String>> entry : assignment.entrySet()) {
+      long sizeBytes = scenario.sizeOf(entry.getKey());
+      for (String instance : entry.getValue().keySet()) {
+        bytes.merge(instance, sizeBytes, Long::sum);
+      }
+    }
+    return bytes;
+  }
+
+  /// Renders the accounting unit: raw segment counts when no sizes were supplied, MiB otherwise.
+  private static String formatUnits(long units, Scenario scenario) {
+    return scenario._segmentSizeBytes.isEmpty() ? Long.toString(units)
+        : (units / (1024 * 1024)) + "M";
+  }
+
+  /// The per-segment sizes as [TableSizeReader] would report them, so the real extraction path is exercised.
+  private static TableSizeReader.TableSubTypeSizeDetails toTableSizeDetails(Map<String, Long> segmentSizeBytes) {
+    TableSizeReader.TableSubTypeSizeDetails tableSizeDetails = new TableSizeReader.TableSubTypeSizeDetails();
+    segmentSizeBytes.forEach((segment, sizeBytes) -> {
+      TableSizeReader.SegmentSizeDetails segmentSizeDetails = new TableSizeReader.SegmentSizeDetails();
+      segmentSizeDetails._maxReportedSizePerReplicaInBytes = sizeBytes;
+      tableSizeDetails._segments.put(segment, segmentSizeDetails);
+    });
+    return tableSizeDetails;
+  }
+
+  private static Set<String> union(Set<String> a, Set<String> b) {
+    Set<String> union = new TreeSet<>(a);
+    union.addAll(b);
+    return union;
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Model
+  // ---------------------------------------------------------------------------------------------------------------
+
+  private static class Scenario {
+    final String _name;
+    final Map<String, Map<String, String>> _currentAssignment;
+    final Map<String, Map<String, String>> _targetAssignment;
+    final int _minAvailableReplicas;
+    final boolean _enableStrictReplicaGroup;
+    final int _batchSizePerServer;
+    /// Per-segment size in bytes. Empty means every segment counts as one byte, i.e. the budget degenerates to
+    /// bounding segment counts.
+    final Map<String, Long> _segmentSizeBytes;
+
+    Scenario(String name, Map<String, Map<String, String>> currentAssignment,
+        Map<String, Map<String, String>> targetAssignment, int minAvailableReplicas,
+        boolean enableStrictReplicaGroup, int batchSizePerServer) {
+      this(name, currentAssignment, targetAssignment, minAvailableReplicas, enableStrictReplicaGroup,
+          batchSizePerServer, Map.of());
+    }
+
+    Scenario(String name, Map<String, Map<String, String>> currentAssignment,
+        Map<String, Map<String, String>> targetAssignment, int minAvailableReplicas,
+        boolean enableStrictReplicaGroup, int batchSizePerServer, Map<String, Long> segmentSizeBytes) {
+      _name = name;
+      _currentAssignment = currentAssignment;
+      _targetAssignment = targetAssignment;
+      _minAvailableReplicas = minAvailableReplicas;
+      _enableStrictReplicaGroup = enableStrictReplicaGroup;
+      _batchSizePerServer = batchSizePerServer;
+      _segmentSizeBytes = segmentSizeBytes;
+    }
+
+    long sizeOf(String segment) {
+      return _segmentSizeBytes.getOrDefault(segment, 1L);
+    }
+  }
+
+  /// Builds a skewed size distribution over `segments`: most segments are small and a few are an order of magnitude
+  /// larger, which is what a table with mixed offline pushes and varying retention actually looks like. Segment count
+  /// based budgeting cannot see this skew, which is the whole reason for going byte based.
+  private static Map<String, Long> skewedSizes(Collection<String> segments, Random random) {
+    Map<String, Long> segmentSizeBytes = new TreeMap<>();
+    for (String segment : segments) {
+      // 80% small, 20% between 10x and 40x larger
+      long sizeBytes = random.nextInt(10) < 8
+          ? 8L * 1024 * 1024 + random.nextInt(24) * 1024L * 1024
+          : 320L * 1024 * 1024 + random.nextInt(960) * 1024L * 1024;
+      segmentSizeBytes.put(segment, sizeBytes);
+    }
+    return segmentSizeBytes;
+  }
+
+  private static class Step {
+    final int _index;
+    final Map<String, Long> _before = new TreeMap<>();
+    final Map<String, Long> _after = new TreeMap<>();
+    final Map<String, Long> _adds = new HashMap<>();
+    final Map<String, Long> _drops = new HashMap<>();
+    /// Server -> segments this step newly assigns to it.
+    final Map<String, Set<String>> _addedSegments = new HashMap<>();
+    /// Server -> segments this step keeps on it even though the target does not place them there, because dropping
+    /// them would break the minAvailableReplicas requirement.
+    final Map<String, Set<String>> _heldForAvailability = new HashMap<>();
+    /// Servers that had segments to drop at the start of this step and were still assigned new segments, i.e. the
+    /// servers for which TableRebalancer gave up on the deferral in order to make progress.
+    final Set<String> _deferralRelaxedFor = new TreeSet<>();
+
+    Step(int index) {
+      _index = index;
+    }
+  }
+
+  private static class SimResult {
+    final Scenario _scenario;
+    final List<Step> _steps = new ArrayList<>();
+    Map<String, Long> _initial = new TreeMap<>();
+    Map<String, Long> _target = new TreeMap<>();
+    Map<String, Long> _maxAfter = new TreeMap<>();
+    Map<String, Long> _maxInStep = new TreeMap<>();
+    /// Strict replica group violations: groups of segments that were not moved together.
+    final Set<String> _groupSplits = new TreeSet<>();
+    String _terminated = "did not terminate";
+
+    SimResult(Scenario scenario) {
+      _scenario = scenario;
+    }
+
+    long bound(String server) {
+      return Math.max(_initial.getOrDefault(server, 0L), _target.getOrDefault(server, 0L));
+    }
+
+    boolean hasSteadyStateViolation() {
+      return _maxAfter.keySet().stream().anyMatch(server -> _maxAfter.get(server) > bound(server));
+    }
+
+    boolean hasInStepViolation() {
+      return _maxInStep.keySet().stream().anyMatch(server -> _maxInStep.get(server) > bound(server));
+    }
+
+    String worstServer() {
+      return _maxAfter.keySet().stream()
+          .max((a, b) -> Double.compare(amplification(a), amplification(b)))
+          .orElseThrow();
+    }
+
+    double amplification(String server) {
+      long bound = bound(server);
+      return bound == 0 ? _maxAfter.get(server) : (double) _maxAfter.get(server) / bound;
+    }
+
+    double worstAmplification() {
+      return amplification(worstServer());
+    }
+
+    /// Steps in which TableRebalancer gave up on deferring the adds in order to make progress.
+    List<Step> relaxedSteps() {
+      return _steps.stream().filter(step -> !step._deferralRelaxedFor.isEmpty()).toList();
+    }
+
+    /// The most any single server holds above its bound, in accounting units.
+    long worstExcess() {
+      return _maxAfter.keySet().stream().mapToLong(server -> _maxAfter.get(server) - bound(server)).max().orElse(0L);
+    }
+
+    String report() {
+      StringBuilder sb = new StringBuilder();
+      sb.append("\n").append("=".repeat(118)).append('\n');
+      sb.append(_scenario._name).append('\n');
+      sb.append("=".repeat(118)).append('\n');
+      sb.append(String.format("steps: %d, outcome: %s%n%n", _steps.size(), _terminated));
+
+      Set<String> servers = union(_maxAfter.keySet(), _initial.keySet());
+      sb.append("Per-step hosted segment counts (before -> after, +downloads/-deletes):\n");
+      sb.append(String.format("  %-6s", "server"));
+      for (Step step : _steps) {
+        sb.append(String.format("%-18s", "step " + step._index));
+      }
+      sb.append('\n');
+      for (String server : servers) {
+        sb.append(String.format("  %-6s", server));
+        for (Step step : _steps) {
+          long adds = step._adds.getOrDefault(server, 0L);
+          long drops = step._drops.getOrDefault(server, 0L);
+          sb.append(String.format("%-22s", String.format("%s->%s %s%s",
+              formatUnits(step._before.getOrDefault(server, 0L), _scenario),
+              formatUnits(step._after.getOrDefault(server, 0L), _scenario),
+              adds > 0 ? "+" + formatUnits(adds, _scenario) : "",
+              drops > 0 ? "-" + formatUnits(drops, _scenario) : "")));
+        }
+        sb.append('\n');
+      }
+
+      sb.append("\nPer-server summary:\n");
+      sb.append(String.format("  %-8s %9s %9s %9s %10s %10s   %s%n", "server", "initial", "target", "bound",
+          "maxAfter", "maxInStep", "verdict"));
+      for (String server : servers) {
+        long bound = bound(server);
+        long maxAfter = _maxAfter.getOrDefault(server, 0L);
+        long maxInStep = _maxInStep.getOrDefault(server, 0L);
+        String verdict;
+        if (maxAfter > bound) {
+          verdict = String.format("NET INCREASE: holds %s vs bound %s (+%s, %.0f%% over)",
+              formatUnits(maxAfter, _scenario), formatUnits(bound, _scenario),
+              formatUnits(maxAfter - bound, _scenario), 100.0 * (maxAfter - bound) / Math.max(1, bound));
+        } else if (maxInStep > bound) {
+          verdict = String.format("TRANSIENT: may hold %s vs bound %s within a step",
+              formatUnits(maxInStep, _scenario), formatUnits(bound, _scenario));
+        } else {
+          verdict = "ok";
+        }
+        sb.append(String.format("  %-8s %9s %9s %9s %10s %10s   %s%n", server,
+            formatUnits(_initial.getOrDefault(server, 0L), _scenario),
+            formatUnits(_target.getOrDefault(server, 0L), _scenario), formatUnits(bound, _scenario),
+            formatUnits(maxAfter, _scenario), formatUnits(maxInStep, _scenario), verdict));
+      }
+      sb.append(String.format("%nsteady-state violation: %s, within-step violation: %s%n", hasSteadyStateViolation(),
+          hasInStepViolation()));
+      for (Step step : relaxedSteps()) {
+        sb.append(String.format("  step %d: budget relaxed for %s (no progress was possible within it)%n",
+            step._index, step._deferralRelaxedFor));
+        // Was the stall physically necessary, or only an artifact of blocking every server that has a pending drop?
+        // Show how many free slots each server had under its own bound at the start of the stalled step.
+        long totalHeadroom = 0;
+        StringBuilder headroomDetail = new StringBuilder();
+        for (String server : _maxAfter.keySet()) {
+          long headroom = bound(server) - step._before.getOrDefault(server, 0L);
+          if (headroom > 0) {
+            totalHeadroom += headroom;
+            headroomDetail.append(String.format(" %s=%s", server, formatUnits(headroom, _scenario)));
+          }
+        }
+        sb.append(String.format("    free space under each server's own bound at that point:%s (total %s)%n",
+            headroomDetail, formatUnits(totalHeadroom, _scenario)));
+      }
+      for (String groupSplit : _groupSplits) {
+        sb.append("  STRICT REPLICA GROUP SPLIT: ").append(groupSplit).append('\n');
+      }
+      if (hasSteadyStateViolation()) {
+        sb.append(explainWorstServer());
+      }
+      return sb.toString();
+    }
+
+    /// Explains the peak for the worst server: the segments it is simultaneously downloading, and the segments it is
+    /// still holding only to satisfy minAvailableReplicas.
+    String explainWorstServer() {
+      String server = worstServer();
+      Step peakStep = null;
+      for (Step step : _steps) {
+        if (peakStep == null || step._after.getOrDefault(server, 0L) > peakStep._after.getOrDefault(server, 0L)) {
+          peakStep = step;
+        }
+      }
+      if (peakStep == null) {
+        return "";
+      }
+      Set<String> added = peakStep._addedSegments.getOrDefault(server, new TreeSet<>());
+      Set<String> held = peakStep._heldForAvailability.getOrDefault(server, new TreeSet<>());
+      StringBuilder sb = new StringBuilder();
+      sb.append(String.format("%nWhy %s peaks at %s in step %d:%n", server,
+          formatUnits(peakStep._after.get(server), _scenario), peakStep._index));
+      sb.append(String.format("  * %d segment(s) downloaded onto %s, because for each of them every current replica "
+              + "is already in the target (nothing left to drop), so lowDiskMode allows the add: %s%n", added.size(),
+          server, abbreviate(added)));
+      sb.append(String.format("  * %d segment(s) still pinned on %s even though the target does not place them "
+              + "there, because dropping them would break minAvailableReplicas=%d: %s%n", held.size(), server,
+          _scenario._minAvailableReplicas, abbreviate(held)));
+      sb.append("  lowDiskMode only sequences drop-before-add *per segment*. Nothing sequences it per server, so a\n"
+          + "  server in the overlap of the old and new server sets pays for both sets at once.\n");
+      return sb.toString();
+    }
+
+    private static String abbreviate(Set<String> segments) {
+      if (segments.size() <= 6) {
+        return segments.toString();
+      }
+      List<String> head = new ArrayList<>(segments).subList(0, 6);
+      return head + " ... (" + segments.size() + " total)";
+    }
+  }
+
+  /// Runs every scenario and prints the reports, for use outside of the TestNG runner.
+  public static void main(String[] args) {
+    LowDiskModeRebalanceSimulatorTest simulator = new LowDiskModeRebalanceSimulatorTest();
+    Map<String, Runnable> scenarios = new LinkedHashMap<>();
+    scenarios.put("overlapping-rotation", simulator::testOverlappingServerSetsRotation);
+    scenarios.put("overlapping-rotation-strict", simulator::testOverlappingServerSetsRotationStrictReplicaGroup);
+    scenarios.put("larger-rotation", simulator::testLargerRotationOverlap);
+    scenarios.put("pure-scale-out-control", simulator::testPureScaleOutIsClean);
+    scenarios.put("sweep", simulator::testSweepOverlappingServerSets);
+    scenarios.put("random-search", simulator::testRandomSearch);
+    scenarios.forEach((name, runnable) -> {
+      System.out.println("\n\n##### " + name + " #####");
+      runnable.run();
+    });
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
@@ -573,7 +573,7 @@ public class TableRebalancerTest {
     }
     Map<Pair<Set<String>, Set<String>>, Set<String>> assignmentMap = new HashMap<>();
     return TableRebalancer.getNextSingleSegmentAssignment(currentInstanceStateMap, targetInstanceStateMap,
-        minAvailableReplicas, lowDiskMode, numSegmentsToOffloadMap, assignmentMap);
+        minAvailableReplicas, lowDiskMode, numSegmentsToOffloadMap, assignmentMap, null);
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
@@ -1305,6 +1305,68 @@ public class TableRebalancerTest {
     assertEquals(nextAssignment, targetAssignment);
   }
 
+  /// In low disk mode a server that is in both the current and the target assignment can be in the drop phase for
+  /// some segments while being in the add phase for others, which makes it hold both sets at once. Verify that the
+  /// adds to such a server are deferred until it has dropped everything the target assignment does not place on it.
+  @Test
+  public void testAssignmentWithLowDiskModeDefersAddsToServersWithPendingDrops() {
+    // 6 segments with replication 2 over host1/host2/host3, moving to host2/host3/host4. host2 and host3 are in both
+    // the current and the target assignment, so they both offload and onload segments.
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+    currentAssignment.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(List.of("host1", "host2"), ONLINE));
+    currentAssignment.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(List.of("host3", "host1"), ONLINE));
+    currentAssignment.put("segment3", SegmentAssignmentUtils.getInstanceStateMap(List.of("host2", "host3"), ONLINE));
+    currentAssignment.put("segment4", SegmentAssignmentUtils.getInstanceStateMap(List.of("host1", "host2"), ONLINE));
+    currentAssignment.put("segment5", SegmentAssignmentUtils.getInstanceStateMap(List.of("host3", "host1"), ONLINE));
+    currentAssignment.put("segment6", SegmentAssignmentUtils.getInstanceStateMap(List.of("host2", "host3"), ONLINE));
+
+    Map<String, Map<String, String>> targetAssignment = new TreeMap<>();
+    targetAssignment.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(List.of("host2", "host3"), ONLINE));
+    targetAssignment.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(List.of("host4", "host2"), ONLINE));
+    targetAssignment.put("segment3", SegmentAssignmentUtils.getInstanceStateMap(List.of("host3", "host4"), ONLINE));
+    targetAssignment.put("segment4", SegmentAssignmentUtils.getInstanceStateMap(List.of("host2", "host3"), ONLINE));
+    targetAssignment.put("segment5", SegmentAssignmentUtils.getInstanceStateMap(List.of("host4", "host2"), ONLINE));
+    targetAssignment.put("segment6", SegmentAssignmentUtils.getInstanceStateMap(List.of("host3", "host4"), ONLINE));
+
+    // Every host hosts 4 segments to begin with, and host2 and host3 also host 4 in the target assignment
+    assertEquals(getNumSegmentsHosted(currentAssignment), Map.of("host1", 4, "host2", 4, "host3", 4));
+    assertEquals(getNumSegmentsHosted(targetAssignment), Map.of("host2", 4, "host3", 4, "host4", 4));
+
+    // With no per-segment sizes available every segment counts as one byte. host1, host2 and host3 are all already
+    // at the disk they started the rebalance with, so none of them may take on a segment until they have dropped one,
+    // while host4 is empty and can take on its full target.
+    TableRebalancer.StepDiskBudget stepBudget =
+        TableRebalancer.DiskUsageBudget.create(currentAssignment, null).forStep(currentAssignment, targetAssignment);
+    assertEquals(stepBudget.getRemainingBytes(), Map.of("host1", 0L, "host2", 0L, "host3", 0L, "host4", 4L));
+
+    Map<String, Map<String, String>> nextAssignment = currentAssignment;
+    int maxNumSegmentsHostedByHost3 = 4;
+    for (int step = 1; step <= 10 && !nextAssignment.equals(targetAssignment); step++) {
+      nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 1, false, true,
+          RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+          DEFAULT_DATA_LOSS_RISK_ASSESSOR);
+      Map<String, Integer> numSegmentsHosted = getNumSegmentsHosted(nextAssignment);
+      maxNumSegmentsHostedByHost3 = Math.max(maxNumSegmentsHostedByHost3, numSegmentsHosted.getOrDefault("host3", 0));
+      if (step == 2) {
+        assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(List.of("host2")));
+        assertEquals(nextAssignment.get("segment4").keySet(), new TreeSet<>(List.of("host2")));
+      }
+    }
+    assertEquals(nextAssignment, targetAssignment);
+    // host3 starts and ends with 4 segments, so it must never host more than 4 at any point of the rebalance
+    assertEquals(maxNumSegmentsHostedByHost3, 4);
+  }
+
+  private static Map<String, Integer> getNumSegmentsHosted(Map<String, Map<String, String>> assignment) {
+    Map<String, Integer> numSegmentsHosted = new TreeMap<>();
+    for (Map<String, String> instanceStateMap : assignment.values()) {
+      for (String instance : instanceStateMap.keySet()) {
+        numSegmentsHosted.merge(instance, 1, Integer::sum);
+      }
+    }
+    return numSegmentsHosted;
+  }
+
   @Test
   public void testIsExternalViewConverged() {
     String offlineTableName = "testTable_OFFLINE";


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Low disk mode rebalance now uses disk usage budget to prevent transient overages, validated by pre\-check replay\.

```mermaid
flowchart TD
  N0["PreCheck#95;RebalanceReplay #40;F1#41;"]:::stAdded
  N1["RebalanceStart#95;CreateDiskUsageBudget #40;F2#41;"]:::stAdded
  N2["RebalanceStep#95;ComputeStepBudget #40;F2#41;"]:::stAdded
  N3["RebalanceStep#95;AttemptMoveSegments #40;F2#44; F5#41;"]:::stModified
  N4["RebalanceStep#95;CheckProgress #40;F2#41;"]:::stModified
  N5["RebalanceStep#95;FallbackToNoBudget #40;F2#41;"]:::stAdded
  N6["RebalanceStep#95;UpdateCurrentAssignment #40;F2#41;"]:::stModified
  N0 -->|"precheck pass #91;F1#93; #40;when returns PASS#44; proceed to rebalance#41;"| N1
  N1 -->|"start step#58; compute step budget #91;F2#93;"| N2
  N2 -->|"try move segments within budget #91;F2#93;"| N3
  N3 -->|"check if assignment changed #91;F2#93;"| N4
  N4 -->|"if changed#58; update assignment #91;F2#93;"| N6
  N4 -->|"if not changed#58; fallback to no budget #91;F2#93;"| N5
  N5 -->|"compute fallback assignment #91;F2#93;"| N6
  N6 -->|"next step#58; recompute step budget #91;F2#93;"| N2
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

Partial evidence: 0 file patches omitted; 2 truncated.

<details>
<summary>Diff evidence</summary>

- F1: pinot\-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker\.java — [before](https://github.com/apache/pinot/blob/79931dee059a6457c96ef6d55b0f7ffbb0061daf/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java) · [after](https://github.com/apache/pinot/blob/ee75e04894959ca3f1f821c5cb29006018537b8c/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java)
- F2: pinot\-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer\.java — [before](https://github.com/apache/pinot/blob/79931dee059a6457c96ef6d55b0f7ffbb0061daf/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java) · [after](https://github.com/apache/pinot/blob/ee75e04894959ca3f1f821c5cb29006018537b8c/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java)
- F5: pinot\-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest\.java — [before](https://github.com/apache/pinot/blob/79931dee059a6457c96ef6d55b0f7ffbb0061daf/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java) · [after](https://github.com/apache/pinot/blob/ee75e04894959ca3f1f821c5cb29006018537b8c/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6Ijc5OTMxZGVlMDU5YTY0NTdjOTZlZjZkNTViMGY3ZmZiYjAwNjFkYWYiLCJjb250ZXh0X2hhc2giOiJjNzViZGE5ZjRiYjI5NTRhZDI5ZjVlZTNiYmEwODk3YzM2NDVmZjVkZTRmYTRjNzNkMjFmOGZiNDk2YTc4ZDE1IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTAxMTE1LCJoZWFkX3NoYSI6ImVlNzVlMDQ4OTQ5NTljYTNmMWY4MjFjNWNiMjkwMDYwMTg1MzdiOGMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIxOTE4MDQxNGZkYmM3MDliMTUwYTEyNTE1NmNlNzJjYjEzOTM5MjFmIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 026b5d982846df4c64dbdff9a85707cda6d8397034a92ee0cb74e13958ef4873 -->
<!-- pinot-pr-flow:end -->

## Description

Low disk mode today in table rebalance only guarantees that within a segment, the replica to offload will be done first, then the replica to add.

The scope is limited to a segment, not server. However, when servers have limited disk space, we want to further guarantee that at any step, a server won't load more bytes than they initially did if a server is to net lose some bytes, or a server won't load more bytes than it would eventually load if it's to net gain some bytes.

Current implementation won't give this guarantee (see example), and we need this guarantee to avoid jamming disk spaces. Also when the disk is already jammed such that no segments can be added to it, we need this guarantee to rebalance our way out without segments getting into error state due to no disk space.

## Example of the current implementation
```
  3 servers → 3 servers with 2 in the overlap, replication 2, 6 segments, minAvailableReplicas=1:


  segment   start    step 1   step 2   step 3   step 4 = target
  s0        A,B      B        B,C      B,C      B,C
  s1        A,C      C        C,D      D        B,D
  s2        B,C      C        C,D      C,D      C,D
  s3        A,B      B        B,C      B,C      B,C
  s4        A,C      C        C,D      D        B,D
  s5        B,C      C        C,D      C,D      C,D

  segments hosted
  A         4        0        0        0        0
  B         4        2        2        2        4
  C         4        4      → 6 ←      4        4
  D         0        0        4        4        4
```

## New design and new constraint

Scope: we only change how we derive the next step, i.e. the result returned by `getNextAssignment`. Nothing change in deriving target assignment, only the intermediate steps. Also, for `lowDiskMode=false` the algorithm is the same.

The illustration here are shown the segment count, but this PR generalize it to segment bytes. 

### DiskUsageBudget
We compute the budget of each server on how many bytes of segments they can load at most at the beginning of the rebalance.

The idea is that each server won't load more bytes than they initially did if a server is to net lose some bytes, or won't load more bytes than it would eventually load if it's to net gain some bytes.

### StepDiskBudget
Compute for each step. This tells you how many bytes you can still take based on the current assignment, respect to the DiskUsageBudget we initially fixed on.

### computeNextAssignment
It will only change the segment's assignment if it fits the `StepDiskBudget`. Reject the new assignment if it violates, so the segment stay at its places for this step. In the case of strict replica group, the cost is computed on the entire replica group since they'll be moved together.

For this mechanism, most of the cases should be able to resolve a sequence that fits the `DiskUsageBudget` constraint entirely. The above example would become this:

```
  segment   start    step 1   step 2   step 3   step 4 = target
  s0        A,B      B        B        B        B,C
  s1        A,C      C        C,D      D        B,D
  s2        B,C      C        C,D      C,D      C,D
  s3        A,B      B        B        B        B,C
  s4        A,C      C        C,D      D        B,D
  s5        B,C      C        C,D      C,D      C,D

  segments hosted
  A         4        0        0        0        0
  B         4        2        2        2        4
  C         4        4      → 4 ←      2        4
  D         0        0        4        4        4
```

### Precheck

No guarantee that such sequence is resolvable under the any algorithm, though. If next assignment couldn't be obtained under the constraint, it will fall back to the original low disk mode implementation. 

Therefore we have a pre-check to tell if the rebalance will violate this constraint (since the sequence resolution is deterministic, we can verify that during pre-check).


```  
"preChecksResult": {
    "diskUtilization": {
      "preCheckStatus": "ERROR",
      "message": "UNSAFE. Servers with unsafe disk utilization DURING rebalance (>=50%): Server_1 (52%). lowDiskMode cannot avoid it for this target assignment: the rebalance cannot make
  progress without going over the disk these servers start with, by up to Server_1 (150B). Rebalance to a target assignment that frees up space on them first, or add capacity"
    }
  }
```
  It names the server, how far over it would go, and two concrete remedies.

  The case it replaces

  Before this PR, that same situation returned PASS, because the check assumed lowDiskMode always removed the transient usage:
```
  {
    "preCheckStatus": "PASS",
    "message": "Within threshold (<50%) AFTER rebalance. Servers that would go over it DURING the rebalance: Server_1 (52%). lowDiskMode avoids that transient disk usage by deleting segments
  before adding the new ones"
  }
```
  That message is still returned — but now only when the replay confirms the budget actually holds, rather than being asserted unconditionally.

  The other outcomes on this path, unchanged
```
  PASS   Within threshold (<50%)
```
```
  ERROR  UNSAFE. Servers with unsafe disk utilization AFTER rebalance (>=50%): Server_1 (52%)
```
```
  ERROR  UNSAFE. Servers with unsafe disk utilization DURING rebalance (>=50%): Server_1 (52%).
         Enable lowDiskMode to delete segments before adding the new ones
```
### In case of mid-flight uploaded segments

When a new segment appear in ideal state by external sources (e.g. segment upload, consuming segment committed), there are two cases:
1. They are added to the ideal state as the target assignment. This case the rebalance steps outcome won't change
2. They are added to the ideal state that's different to their target assignments. For example when strict replica routing is in place. This case, it might lead to a different computeNextAssignment result.

Every step we check if there are new segments added into the ideal state that's not seen in the beginning, account for their bytes as if they were in the ideal state when we computed the `DiskUsageBudget`. 

Notice that we don't guarantee the disk would be in the safe shape if the segments are added mid-flight because pre-check won't see that. But we'll still move the segments so that no servers would bare additional bytes.

## Testing

  `LowDiskModeRebalanceSimulatorTest` drives the real TableRebalancer.getNextAssignment in a loop, exactly as doRebalance does, tracking every server's bytes at each step — so it exercises
  production code, not a re-implementation. Three properties are asserted over 21 fixed scenarios:

  1. the rebalance always reaches the target assignment;
  2. no server exceeds max(bytes it held that this rebalance did not place, bytes the target places on it), unless the disk-utilization pre-check names it up front;
  3. under strict replica group routing, segments of a partition are never assigned different instances.

  Scenarios cover balanced and replica-group assignment, both routing modes, batchSizePerServer, skewed segment sizes, segments uploaded mid-rebalance, and the two assignments a randomized
  search found hardest. main() additionally runs ~32k randomized scenarios for comparing effectiveness by hand; those are not tests.

  Constraint violations, before and after
```
  ┌─────────────────────────────────────┬────────────────────────────────────────┬───────┐
  │               corpus                │                 before                 │ after │
  ├─────────────────────────────────────┼────────────────────────────────────────┼───────┤
  │ old/new server sets, 648            │ 120 over-allocate (18.5%), worst 2.00× │ 0     │
  ├─────────────────────────────────────┼────────────────────────────────────────┼───────┤
  │ strict replica group, 324           │ 92 over-allocate (28.4%), worst 1.78×  │ 0     │
  ├─────────────────────────────────────┼────────────────────────────────────────┼───────┤
  │ random non-uniform assignments, 400 │ 47 over-allocate (11.8%), worst 2.00×  │ 0     │
  └─────────────────────────────────────┴────────────────────────────────────────┴───────┘
```
  Post-change the wider sweeps — 1,944 server-set shapes and 30,000 random group structures — also report zero. Mean step count moves 3.4 → 3.5, so the bound costs essentially nothing.
