### PR TITLE
Use a daemon thread for asynchronous ZooKeeper disconnects

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ZkStarter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ZkStarter.java
@@ -234,7 +234,7 @@ public class ZkStarter {
   }
 
   private static final ExecutorService ZK_DISCONNECTOR =
-      Executors.newFixedThreadPool(1, new NamedThreadFactory("zk-disconnector"));
+      Executors.newFixedThreadPool(1, new NamedThreadFactory("zk-disconnector", true));
 
   /// Stops a local Zk instance, deleting its data directory
   public static void stopLocalZkServer(final ZookeeperInstance instance) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/ZkStarterTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/ZkStarterTest.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.helix.zookeeper.impl.client.ZkClient;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+
+/// Tests lifecycle properties of [ZkStarter]'s asynchronous client cleanup.
+public class ZkStarterTest {
+  @Test
+  public void testAsyncCloserUsesDaemonThread()
+      throws Exception {
+    ZkClient client = mock(ZkClient.class);
+    CountDownLatch closeCalled = new CountDownLatch(1);
+    AtomicBoolean daemonThread = new AtomicBoolean();
+    doAnswer(invocation -> {
+      daemonThread.set(Thread.currentThread().isDaemon());
+      closeCalled.countDown();
+      return null;
+    }).when(client).close();
+
+    ZkStarter.closeAsync(client);
+
+    assertThat(closeCalled.await(10, TimeUnit.SECONDS)).isTrue();
+    assertThat(daemonThread.get()).isTrue();
+  }
+}


### PR DESCRIPTION
## Summary

Make the static asynchronous ZooKeeper disconnector use a daemon worker thread. The executor is process-scoped and intentionally has no shutdown path, so its worker must not keep short-lived Pinot tools, tests, or benchmark forks alive after their useful work finishes.

## How to reproduce

1. Start a JVM that invokes `ZkStarter.closeAsync(...)` or starts/stops a local ZooKeeper instance.
2. Allow the main application work and every other non-daemon thread to finish.
3. Observe that the JVM remains alive because the static `zk-disconnector` fixed-pool worker is non-daemon.

With this change, the queued close still runs, but the idle worker no longer prevents natural JVM shutdown.

## Validation

- `ZkStarterTest.testAsyncCloserUsesDaemonThread` verifies that the asynchronous close executes on a daemon worker
- formatting, Checkstyle, and license checks for `pinot-common`
