### PR TITLE
Honor tier overwrites in IndexLoadingConfig.isSkipSegmentPreprocess

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -87,6 +87,7 @@ public class IndexLoadingConfig {
   private List<StarTreeIndexConfig> _starTreeIndexConfigs;
   private boolean _enableDefaultStarTree;
   private Map<String, FieldIndexConfigs> _indexConfigsByColName = new HashMap<>();
+  private boolean _skipSegmentPreprocess;
 
   private boolean _dirty = true;
 
@@ -216,6 +217,7 @@ public class IndexLoadingConfig {
     _starTreeIndexConfigs = indexingConfig.getStarTreeIndexConfigs();
     _enableDefaultStarTree = indexingConfig.isEnableDefaultStarTree();
     _multiColTextIndexConfig = indexingConfig.getMultiColumnTextIndexConfig();
+    _skipSegmentPreprocess = indexingConfig.isSkipSegmentPreprocess();
     _dirty = false;
   }
 
@@ -350,8 +352,10 @@ public class IndexLoadingConfig {
   }
 
   public boolean isSkipSegmentPreprocess() {
-    TableConfig tableConfig = getTableConfigWithTierOverwrites();
-    return tableConfig != null && tableConfig.getIndexingConfig().isSkipSegmentPreprocess();
+    if (_dirty) {
+      refreshIndexConfigs();
+    }
+    return _skipSegmentPreprocess;
   }
 
   @Nullable

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -350,7 +350,8 @@ public class IndexLoadingConfig {
   }
 
   public boolean isSkipSegmentPreprocess() {
-    return _tableConfig != null && _tableConfig.getIndexingConfig().isSkipSegmentPreprocess();
+    TableConfig tableConfig = getTableConfigWithTierOverwrites();
+    return tableConfig != null && tableConfig.getIndexingConfig().isSkipSegmentPreprocess();
   }
 
   @Nullable

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfigTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfigTest.java
@@ -157,6 +157,37 @@ public class IndexLoadingConfigTest {
   }
 
   @Test
+  public void testSkipSegmentPreprocessRespectsTierOverwrites()
+      throws IOException {
+    InstanceDataManagerConfig idmCfg = mock(InstanceDataManagerConfig.class);
+    when(idmCfg.getConfig()).thenReturn(new PinotConfiguration());
+    Schema schema =
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("col1", FieldSpec.DataType.INT)
+            .build();
+    // Table-level skipSegmentPreprocess=true; override to false on "preprocessed" tier.
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setSkipSegmentPreprocess(true)
+        .setTierOverwrites(JsonUtils.stringToJsonNode("{\"preprocessed\": {\"skipSegmentPreprocess\": false}}"))
+        .build();
+
+    IndexLoadingConfig ilc = new IndexLoadingConfig(idmCfg, tableConfig, schema);
+    // Default tier: no override applied, table-level value flows through.
+    assertTrue(ilc.isSkipSegmentPreprocess());
+
+    // Unknown tier: no override for it, still falls back to table-level value.
+    ilc.setSegmentTier("someOtherTier");
+    assertTrue(ilc.isSkipSegmentPreprocess());
+
+    // "preprocessed" tier: override kicks in and flips the flag.
+    ilc.setSegmentTier("preprocessed");
+    assertFalse(ilc.isSkipSegmentPreprocess());
+
+    // Switching back to a tier without an override: table-level value again.
+    ilc.setSegmentTier(null);
+    assertTrue(ilc.isSkipSegmentPreprocess());
+  }
+
+  @Test
   public void testCalculateForwardIndexConfig()
       throws JsonProcessingException {
     // Check default settings


### PR DESCRIPTION
## Summary

`IndexLoadingConfig` already merges tier overrides via `getTableConfigWithTierOverwrites()`, and every other index-related getter routes through that merged view. But `isSkipSegmentPreprocess()` was still reading the raw `_tableConfig` directly, so a tier override like parsed and stored correctly but had no effect on preprocess decisions.


```
"tableIndexConfig": {
  "skipSegmentPreprocess": true,
  "tierOverwrites": {
    "preprocessed": { "skipSegmentPreprocess": false }
  }
}
```

This one-line fix routes the getter through the tier-merged view so the flag can be flipped per tier, matching the surrounding index config getters. Enables patterns like "skip preprocess on the hot tier, run it on the cold tier."

## Changes

- `IndexLoadingConfig.isSkipSegmentPreprocess()` reads via `getTableConfigWithTierOverwrites()` instead of directly from `_tableConfig`.
- Added `testSkipSegmentPreprocessRespectsTierOverwrites` covering default tier, unknown tier, tier with override, and clearing the tier back to default.