### PR TITLE
Fix checkTableSetup table-size flake by polling until the size converges

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -308,11 +308,19 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
   /// Ensure table is at the same state after the test.
   @AfterMethod
-  public void checkTableSetup()
-      throws IOException {
+  public void checkTableSetup() {
     assertEquals(getOfflineTableConfig(), _tableConfig);
     assertEquals(getSchema(getTableName()), _schema);
-    assertEquals(getTableSize(getTableName()), _tableSize);
+    // Table size is reported by the servers and transiently returns -1 while a segment reload from the preceding test
+    // is still in flight, so poll until it converges. A test that actually changed the table never converges and still
+    // fails, and a failure here is a configuration failure that skips all remaining tests in the class.
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        return getTableSize(getTableName()) == _tableSize;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }, 60_000L, "Table size did not converge back to " + _tableSize);
   }
 
   private void reloadAllSegments(String testQuery, boolean forceDownload, long numTotalDocs)


### PR DESCRIPTION
## Summary

`OfflineClusterIntegrationTest.checkTableSetup` is an `@AfterMethod` that asserts the table returned to its pre-test state, and it compares `getTableSize()` against the recorded size instantly. Table size is server-reported and transiently returns `-1` while a segment reload from the preceding test is still in flight (e.g. right after `testForwardIndexTriggering`), so the check occasionally fails with `expected [20318824] but found [-1]` ([example run](https://github.com/apache/pinot/actions/runs/33211824921/job/98986582618)).

The blast radius makes this worse than a normal flake: a failed `@AfterMethod` is a TestNG configuration failure, so a single transient `-1` skipped the remaining 82 tests of the class in that run, and the failure attaches to whichever test happened to run before it.

The size check now polls until the size converges back to the recorded value (60s bound, same idiom as the file's other waits). This is also semantically truer to the assertion's intent: the config and schema asserts stay strict since they are deterministic ZK reads, while a test that genuinely changed the table never converges and still fails, now with an explicit "Table size did not converge back to ..." message.
