### PR TITLE
Leave tenant isolation unset in the generated controller config

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
@@ -23,6 +23,7 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.spi.services.ServiceRole;
@@ -64,8 +65,10 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
       // forbids = {"-controllerHost", "-controllerPort", "-dataDir", "-zkAddress", "-clusterName", "-controllerMode"})
   private String _configFileName;
 
-  // This can be set via the set method, or via config file input.
-  private boolean _tenantIsolation = true;
+  // This can be set via the set method, or via config file input. Left null when neither supplies a value, in which
+  // case the generated config does not pin the key and the controller starter's default applies.
+  @Nullable
+  private Boolean _tenantIsolation;
 
   @CommandLine.Option(names = {"-configOverride"}, required = false, split = ",")
   private Map<String, Object> _configOverrides = new HashMap<>();
@@ -98,7 +101,9 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
     return _configFileName;
   }
 
-  public boolean isTenantIsolation() {
+  /// Returns the configured tenant isolation value, or `null` when it was never set.
+  @Nullable
+  public Boolean getTenantIsolation() {
     return _tenantIsolation;
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
@@ -198,8 +198,9 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
       throws SocketException, UnknownHostException {
     switch (serviceRole) {
       case CONTROLLER:
+        // Tenant isolation is left unset so the controller starter's own default applies.
         return PinotConfigUtils.generateControllerConf(_zkAddress, _clusterName, null, DEFAULT_CONTROLLER_PORT, null,
-            ControllerConf.ControllerMode.DUAL, true);
+            ControllerConf.ControllerMode.DUAL, null);
       case BROKER:
         return PinotConfigUtils
             .generateBrokerConf(_clusterName, _zkAddress, null, CommonConstants.Helix.DEFAULT_BROKER_QUERY_PORT,

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.apache.commons.configuration2.builder.fluent.Configurations;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.lang3.StringUtils;
@@ -50,8 +51,15 @@ public class PinotConfigUtils {
   private static final String CONTROLLER_CONFIG_VALIDATION_ERROR_MESSAGE_FORMAT =
       "Pinot Controller Config Validation Error: %s";
 
+  /// Generates the controller config from the given individual options.
+  ///
+  /// A `null` `tenantIsolation` leaves [ControllerConf#CLUSTER_TENANT_ISOLATION_ENABLE] out of the returned config so
+  /// that the value stays unresolved here. It is then decided by whoever consumes the config -- a controller starter
+  /// applying its own defaults, or the fallback in [ControllerConf#tenantIsolationEnabled]. Pass an explicit value
+  /// only when the caller genuinely wants to pin it.
   public static Map<String, Object> generateControllerConf(String zkAddress, String clusterName, String controllerHost,
-      String controllerPort, String dataDir, ControllerConf.ControllerMode controllerMode, boolean tenantIsolation)
+      String controllerPort, String dataDir, ControllerConf.ControllerMode controllerMode,
+      @Nullable Boolean tenantIsolation)
       throws SocketException, UnknownHostException {
     if (StringUtils.isEmpty(zkAddress)) {
       throw new RuntimeException("zkAddress cannot be empty.");
@@ -70,7 +78,9 @@ public class PinotConfigUtils {
     properties.put(ControllerConf.DATA_DIR, !StringUtils.isEmpty(dataDir) ? dataDir
         : TMP_DIR + String.format("Controller_%s_%s/controller/data", controllerHost, controllerPort));
     properties.put(ControllerConf.CONTROLLER_VIP_HOST, controllerHost);
-    properties.put(ControllerConf.CLUSTER_TENANT_ISOLATION_ENABLE, tenantIsolation);
+    if (tenantIsolation != null) {
+      properties.put(ControllerConf.CLUSTER_TENANT_ISOLATION_ENABLE, tenantIsolation);
+    }
     properties.put(ControllerPeriodicTasksConf.RETENTION_MANAGER_FREQUENCY_PERIOD, "6h");
     properties.put(ControllerPeriodicTasksConf.OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_PERIOD, "1h");
     properties.put(ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_FREQUENCY_PERIOD, "1h");

--- a/pinot-tools/src/test/java/org/apache/pinot/tools/utils/PinotConfigUtilsTest.java
+++ b/pinot-tools/src/test/java/org/apache/pinot/tools/utils/PinotConfigUtilsTest.java
@@ -29,10 +29,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.testng.Assert.*;
 
 
 public class PinotConfigUtilsTest {
@@ -59,6 +56,16 @@ public class PinotConfigUtilsTest {
     assertEquals(config.get(ControllerConf.DATA_DIR), dataDir);
     assertEquals(config.get(ControllerConf.CONTROLLER_VIP_HOST), controllerHost);
     assertEquals(config.get(ControllerConf.CLUSTER_TENANT_ISOLATION_ENABLE), tenantIsolation);
+  }
+
+  @Test
+  public void testGenerateControllerConfWithoutTenantIsolation()
+      throws SocketException, UnknownHostException {
+    Map<String, Object> config = PinotConfigUtils.generateControllerConf(
+        "localhost:2181", "testCluster", "localhost", "9000", "/tmp/pinot", ControllerConf.ControllerMode.DUAL, null);
+
+    assertFalse(config.containsKey(ControllerConf.CLUSTER_TENANT_ISOLATION_ENABLE));
+    assertEquals(config.get(ControllerConf.HELIX_CLUSTER_NAME), "testCluster");
   }
 
   @Test(expectedExceptions = RuntimeException.class)


### PR DESCRIPTION
## Summary

`PinotConfigUtils#generateControllerConf` always wrote `cluster.tenant.isolation.enable` into the config it generates from individual options. The generated config therefore had no way to express "the caller did not choose a value", and any default a `ControllerStarter` implementation supplies from `applyCustomConfigs` was dead on that path — the key was already present, so a set-if-missing default could never win.

The value is now a nullable `Boolean`, and the key is written only when a caller passes one.

### Changes

- `PinotConfigUtils#generateControllerConf` takes `@Nullable Boolean tenantIsolation` and only puts the key when it is non-null.
- `StartControllerCommand#_tenantIsolation` defaults to `null` instead of `true`. Worth noting this field has no `@CommandLine.Option` — it can only be set programmatically — so previously there was no way to run the command *without* pinning the key.
- `StartServiceManagerCommand#getDefaultConfig` hardcoded `true` for `CONTROLLER`, pinning the key for every controller the service manager bootstraps without an explicit config. It now leaves it unset.
- `isTenantIsolation()` is renamed to `getTenantIsolation()` and returns a nullable `Boolean`, so callers see the tri-state instead of auto-unboxing a possibly-null value.

Unchanged: `QuickstartRunner` still calls `setTenantIsolation(...)` explicitly, so quickstarts keep pinning whatever they ask for. `PerfBenchmarkDriver` and `ControllerStarter#startDefault` still pin their values directly. `setTenantIsolation(boolean)` keeps its signature, so existing callers compile as-is.

## Behavior

No change for Pinot. `ControllerConf#tenantIsolationEnabled` already falls back to `true` when the key is absent, which is exactly what the removed literals wrote. The effect is that this fallback becomes the single place the default lives, instead of being shadowed by three call sites that wrote the same value into generated configs.

The motivation is downstream: a `ControllerStarter` subclass that wants a different tenant isolation default can now express it through `applyCustomConfigs`, on every launch path rather than only when a config file is supplied.

## API note

`isTenantIsolation()` → `getTenantIsolation()` is a public signature change on `StartControllerCommand`. It has no callers in the repo. Happy to keep the old name and just widen the return type if reviewers prefer the smaller surface, though `isX()` returning a boxed nullable invites an auto-unboxing NPE at call sites.
