### PR TITLE
Use caller-owned buffers for codec pipelines

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/BaseDeltaCodecDefinition.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/BaseDeltaCodecDefinition.java
@@ -67,13 +67,13 @@ abstract class BaseDeltaCodecDefinition<O extends CodecOptions> implements Chunk
   }
 
   @Override
-  public final int maxEncodedSize(O options, int inputSize) {
+  public final int maxEncodedSize(O options, CodecContext ctx, int inputSize) {
     // Passthrough: output is exactly the same size as the input (no header).
     return inputSize;
   }
 
   @Override
-  public final boolean requiresDirectDstBuffer() {
+  public final boolean requiresDirectDecodeDstBuffer() {
     return false;
   }
 
@@ -82,28 +82,29 @@ abstract class BaseDeltaCodecDefinition<O extends CodecOptions> implements Chunk
   public abstract O parseOptions(List<String> args);
 
   @Override
-  public final ByteBuffer encode(O options, CodecContext ctx, ByteBuffer src) {
+  public final void encode(O options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) {
+    src.order(ByteOrder.BIG_ENDIAN);
+    dst.clear();
     int elementSize = elementSize(ctx, src.remaining());
     int count = src.remaining() / elementSize;
-    return elementSize == Long.BYTES ? encodeLong(src, count) : encodeInt(src, count);
-  }
-
-  @Override
-  public final ByteBuffer decode(O options, CodecContext ctx, ByteBuffer src) {
-    // The persisted transform layout is always big-endian, independent of the byte order on a
-    // caller-provided view. duplicate() also keeps the caller's position/limit untouched.
-    src = src.duplicate().order(ByteOrder.BIG_ENDIAN);
-    int elementSize = elementSize(ctx, src.remaining());
-    int count = src.remaining() / elementSize;
-    if (count == 0) {
-      return ByteBuffer.allocateDirect(0);
+    int encodedSize = count * elementSize;
+    if (encodedSize > dst.capacity()) {
+      throw new IllegalArgumentException(
+          name() + ": encoded size " + encodedSize + " exceeds dst capacity " + dst.capacity());
     }
-    return elementSize == Long.BYTES ? decodeLong(src, count) : decodeInt(src, count);
+    if (count > 0) {
+      if (elementSize == Long.BYTES) {
+        encodeLongInto(src, count, dst);
+      } else {
+        encodeIntInto(src, count, dst);
+      }
+    }
+    dst.flip();
   }
 
   @Override
-  public final void decodeInto(O options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) {
-    src = src.duplicate().order(ByteOrder.BIG_ENDIAN);
+  public final void decode(O options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) {
+    src.order(ByteOrder.BIG_ENDIAN);
     dst.clear();
     int elementSize = elementSize(ctx, src.remaining());
     int count = src.remaining() / elementSize;
@@ -144,13 +145,9 @@ abstract class BaseDeltaCodecDefinition<O extends CodecOptions> implements Chunk
   // All operate on a header-less, same-width array of `count` values.
   // -------------------------------------------------------------------------
 
-  protected abstract ByteBuffer encodeInt(ByteBuffer src, int count);
+  protected abstract void encodeIntInto(ByteBuffer src, int count, ByteBuffer dst);
 
-  protected abstract ByteBuffer encodeLong(ByteBuffer src, int count);
-
-  protected abstract ByteBuffer decodeInt(ByteBuffer src, int count);
-
-  protected abstract ByteBuffer decodeLong(ByteBuffer src, int count);
+  protected abstract void encodeLongInto(ByteBuffer src, int count, ByteBuffer dst);
 
   protected abstract void decodeIntInto(ByteBuffer src, int count, ByteBuffer dst);
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/ChunkCodecHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/ChunkCodecHandler.java
@@ -27,55 +27,54 @@ import java.nio.ByteBuffer;
 ///
 /// All implementations are expected to be stateless and thread-safe.
 ///
-/// Buffer contract for all methods:
+/// Buffer contract for [#encode()] and [#decode()]:
 ///
-/// - [#encode()] and [#decode()]: `src` is ready for read (position=0);
-///       the returned buffer is ready for read and owned by the caller.
-/// - [#decodeInto()]: implementations must treat `dst` as freshly cleared
-///       (calling `dst.clear()` internally is recommended as a defensive first step);
-///       `dst` is flipped (position=0, limit=decoded bytes) on return.
+/// - `src` supplies the readable range from its current position to its limit. Typed codecs
+///       interpret values in persisted `BIG_ENDIAN` order. Implementations may advance its
+///       position or change its byte order; callers that need to reuse it must preserve its state
+///       or pass a duplicate.
+/// - `dst` is writable, uses `BIG_ENDIAN` byte order, and does not overlap `src`. Implementations
+///       clear it before writing and leave it ready for read (position=0, limit=output bytes) on
+///       successful return. Its position and limit are unspecified after failure.
+/// - Both buffers remain caller-owned: implementations must not retain or release them. The
+///       destination capacity bounds the output; callers requiring a tighter bound must pass a
+///       capacity-limited view, because clearing the buffer discards its previous limit.
+/// - Heap input is supported, but JNI codecs may copy it into a temporary direct buffer. Use
+///       direct input on hot paths to avoid that allocation.
 ///
 /// @param <O> typed [CodecOptions] for this codec
 interface ChunkCodecHandler<O extends CodecOptions> extends CodecDefinition<O> {
 
-  /// Encodes `src` and returns the encoded bytes ready for read.
-  ///
-  /// **Position contract:** implementations may consume `src` (advance its position).
-  /// Callers that need to re-read `src` after this call must pass `src.duplicate()`.
-  ///
-  /// @param options parsed options for this codec invocation
-  /// @param ctx     column context (data type, etc.)
-  /// @param src     unencoded data, ready for read
-  /// @return encoded buffer ready for read; caller owns this buffer
-  ByteBuffer encode(O options, CodecContext ctx, ByteBuffer src) throws IOException;
-
-  /// Decodes `src` and returns the decoded bytes ready for read.
-  ///
-  /// **Position contract:** implementations may consume `src` (advance its position).
-  /// Callers that need to re-read `src` after this call must pass `src.duplicate()`.
+  /// Encodes `src` into caller-owned `dst`, without allocating an output buffer.
+  /// Encoding callers must supply a direct destination to support all registered codecs.
   ///
   /// @param options parsed options for this codec invocation
   /// @param ctx     column context
-  /// @param src     encoded data, ready for read
-  /// @return decoded buffer ready for read; caller owns this buffer
-  ByteBuffer decode(O options, CodecContext ctx, ByteBuffer src) throws IOException;
+  /// @param src     unencoded data, ready for read
+  /// @param dst     direct output buffer with at least [#maxEncodedSize(CodecOptions, CodecContext, int)]
+  ///                bytes of capacity
+  void encode(O options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) throws IOException;
 
-  /// Decodes `src` directly into `dst`, avoiding an extra allocation.
-  /// Implementations must treat `dst` as freshly cleared and flip it before returning.
+  /// Decodes `src` into caller-owned `dst`, without allocating an output buffer.
   ///
   /// Callers must ensure `dst` is a direct [ByteBuffer] when
-  /// [#requiresDirectDstBuffer()] returns `true`.
+  /// [#requiresDirectDecodeDstBuffer()] returns `true`.
   ///
   /// @param options parsed options for this codec invocation
   /// @param ctx     column context
   /// @param src     encoded data, ready for read
   /// @param dst     output buffer; must be direct when required; must have sufficient capacity
-  void decodeInto(O options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) throws IOException;
+  void decode(O options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) throws IOException;
 
   /// Returns an upper bound on the encoded byte count for an input of `inputSize` bytes.
-  int maxEncodedSize(O options, int inputSize);
+  ///
+  /// @param options   parsed options for this codec invocation
+  /// @param ctx       column context
+  /// @param inputSize unencoded input size in bytes
+  int maxEncodedSize(O options, CodecContext ctx, int inputSize);
 
-  /// Returns `true` if [#decodeInto()] requires `dst` to be a direct
+  /// Returns `true` if [#decode()] requires `dst` to be a direct
   /// [ByteBuffer] (e.g. codecs that delegate to JNI libraries with direct-buffer-only APIs).
-  boolean requiresDirectDstBuffer();
+  /// This requirement applies only to decoding; encoding callers always supply a direct buffer.
+  boolean requiresDirectDecodeDstBuffer();
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/CodecBufferUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/CodecBufferUtils.java
@@ -74,9 +74,4 @@ final class CodecBufferUtils {
       CleanerUtil.cleanQuietly(converted);
     }
   }
-
-  /// Releases an owned direct buffer after a failed codec operation.
-  static void cleanQuietly(ByteBuffer buffer) {
-    CleanerUtil.cleanQuietly(buffer);
-  }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/CodecPipelineExecutor.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/CodecPipelineExecutor.java
@@ -36,9 +36,8 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 /// Write path: values → transforms (in order) → compression stages → bytes stored on disk.
 /// Read path: bytes from disk → reverse compression/transform stages → values.
 ///
-/// The executor is constructed once per column from the canonical `codecSpec` string
-/// stored in the file header and is thread-safe for concurrent read calls (it holds no mutable
-/// per-call state).
+/// Executors are immutable and thread-safe, so lifecycle owners can retain and share them;
+/// concurrent calls must use separate caller-owned workspaces and output buffers.
 ///
 /// The executor is codec-agnostic: it holds an ordered list of internal bound stages, each pairing
 /// a handler with its parsed options. The registry and handlers are a closed, package-private
@@ -46,13 +45,13 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 ///
 /// ### Buffer contract
 ///
-/// - [#encode]: `src` is ready for read (position=0); returns a new
-///       [ByteBuffer] ready for read containing the encoded bytes.
-/// - [#decode(ByteBuffer)]: `src` is ready for read; returns a new
-///       [ByteBuffer] ready for read containing the decoded bytes.
+/// - [#encode]: reads the source's remaining bytes and returns a scratch-owned readable view,
+///       invalidated by the next encode call with that workspace or by closing the workspace.
+/// - [#decode]: reads the source's remaining bytes into a caller-owned destination and leaves
+///       the destination ready for read. Source and destination must not alias scratch storage
+///       or each other. Source consumption is permitted on decode.
 /// - [#maxEncodedSize]: returns an upper bound on encoded size.
 public final class CodecPipelineExecutor {
-
   /// A codec handler bound to the options parsed from a specific pipeline invocation.
   private static final class BoundStage<O extends CodecOptions> {
     final ChunkCodecHandler<O> _handler;
@@ -65,24 +64,20 @@ public final class CodecPipelineExecutor {
       _ctx = ctx;
     }
 
-    ByteBuffer encode(ByteBuffer src) throws IOException {
-      return _handler.encode(_options, _ctx, src);
+    void encode(ByteBuffer src, ByteBuffer dst) throws IOException {
+      _handler.encode(_options, _ctx, src, dst);
     }
 
-    ByteBuffer decode(ByteBuffer src) throws IOException {
-      return _handler.decode(_options, _ctx, src);
-    }
-
-    void decodeInto(ByteBuffer src, ByteBuffer dst) throws IOException {
-      _handler.decodeInto(_options, _ctx, src, dst);
+    void decode(ByteBuffer src, ByteBuffer dst) throws IOException {
+      _handler.decode(_options, _ctx, src, dst);
     }
 
     int maxEncodedSize(int inputSize) {
-      return _handler.maxEncodedSize(_options, inputSize);
+      return _handler.maxEncodedSize(_options, _ctx, inputSize);
     }
 
-    boolean requiresDirectDstBuffer() {
-      return _handler.requiresDirectDstBuffer();
+    boolean requiresDirectDecodeDstBuffer() {
+      return _handler.requiresDirectDecodeDstBuffer();
     }
 
     boolean isCompression() {
@@ -94,35 +89,69 @@ public final class CodecPipelineExecutor {
     }
   }
 
-  /// Caller-owned, reusable decode workspace.
-  ///
-  /// The workspace retains at most two direct buffers and grows them on demand. Multi-stage
-  /// decoding alternates between those buffers, so repeated chunk reads avoid allocating and
-  /// explicitly cleaning a direct buffer for every intermediate stage. This class is not
-  /// thread-safe; each reader context or calling thread must own a separate instance.
-  public static final class DecodeScratch implements AutoCloseable {
+  /// Shared bounded-buffer machinery for encode and decode scratch spaces. Every stage checkout
+  /// resets byte order and limits capacity to the validated bound, including after backing-buffer
+  /// growth invalidates cached views.
+  private static final class StageViewWorkspace implements AutoCloseable {
+    private final String _ownerName;
     private final ByteBuffer[] _buffers = new ByteBuffer[2];
+    private final ByteBuffer[][] _stageViews = {new ByteBuffer[0], new ByteBuffer[0]};
+    private final int[][] _stageViewCapacities = {new int[0], new int[0]};
     private int[] _stageBounds = new int[0];
     private int _allocationCount;
+    private int _viewCreationCount;
     private boolean _closed;
 
-    private ByteBuffer buffer(int slot, int capacity) {
+    private StageViewWorkspace(String ownerName) {
+      _ownerName = ownerName;
+    }
+
+    private ByteBuffer buffer(int stageIndex, int slot, int capacity) {
       ensureOpen();
       Preconditions.checkArgument(capacity >= 0, "Scratch capacity must be non-negative: %s", capacity);
-      ByteBuffer buffer = _buffers[slot];
-      if (buffer == null || buffer.capacity() < capacity) {
-        CleanerUtil.cleanQuietly(buffer);
-        buffer = ByteBuffer.allocateDirect(capacity);
-        _buffers[slot] = buffer;
-        _allocationCount++;
-      }
+      ensureCapacity(slot, capacity);
+      ensureStageViewCapacity(slot, stageIndex + 1);
       // Limit the returned view's capacity to this stage's validated bound. Reusing a larger
       // backing buffer must not let a corrupt inner frame exploit capacity left from an earlier
       // larger chunk.
-      ByteBuffer view = buffer.duplicate();
-      view.clear();
-      view.limit(capacity);
-      return view.slice();
+      ByteBuffer view = _stageViews[slot][stageIndex];
+      if (view == null || _stageViewCapacities[slot][stageIndex] != capacity) {
+        view = _buffers[slot].duplicate().order(ByteOrder.BIG_ENDIAN);
+        view.clear();
+        view.limit(capacity);
+        view = view.slice().order(ByteOrder.BIG_ENDIAN);
+        _stageViews[slot][stageIndex] = view;
+        _stageViewCapacities[slot][stageIndex] = capacity;
+        _viewCreationCount++;
+      } else {
+        view.clear();
+        view.order(ByteOrder.BIG_ENDIAN);
+      }
+      return view;
+    }
+
+    private void ensureCapacity(int slot, int capacity) {
+      ensureOpen();
+      ByteBuffer buffer = _buffers[slot];
+      if (buffer == null || buffer.capacity() < capacity) {
+        CleanerUtil.cleanQuietly(buffer);
+        _buffers[slot] = ByteBuffer.allocateDirect(capacity);
+        _stageViews[slot] = new ByteBuffer[0];
+        _stageViewCapacities[slot] = new int[0];
+        _allocationCount++;
+      }
+    }
+
+    private void ensureStageViewCapacity(int slot, int requiredSize) {
+      if (_stageViews[slot].length >= requiredSize) {
+        return;
+      }
+      ByteBuffer[] views = new ByteBuffer[requiredSize];
+      System.arraycopy(_stageViews[slot], 0, views, 0, _stageViews[slot].length);
+      _stageViews[slot] = views;
+      int[] capacities = new int[requiredSize];
+      System.arraycopy(_stageViewCapacities[slot], 0, capacities, 0, _stageViewCapacities[slot].length);
+      _stageViewCapacities[slot] = capacities;
     }
 
     private int[] stageBounds(int stageCount) {
@@ -134,11 +163,19 @@ public final class CodecPipelineExecutor {
     }
 
     private void ensureOpen() {
-      Preconditions.checkState(!_closed, "DecodeScratch is closed");
+      Preconditions.checkState(!_closed, "%s is closed", _ownerName);
     }
 
-    int allocationCount() {
+    private boolean isClosed() {
+      return _closed;
+    }
+
+    private int allocationCount() {
       return _allocationCount;
+    }
+
+    private int viewCreationCount() {
+      return _viewCreationCount;
     }
 
     @Override
@@ -150,8 +187,138 @@ public final class CodecPipelineExecutor {
       for (int i = 0; i < _buffers.length; i++) {
         CleanerUtil.cleanQuietly(_buffers[i]);
         _buffers[i] = null;
+        _stageViews[i] = new ByteBuffer[0];
+        _stageViewCapacities[i] = new int[0];
       }
       _stageBounds = new int[0];
+    }
+  }
+
+  /// Caller-owned, reusable encode workspace.
+  ///
+  /// The workspace retains one source view and at most two direct buffers, growing the buffers on
+  /// demand. Pipeline stages alternate between capacity-bounded views of those buffers, so repeated
+  /// chunk writes do not allocate and explicitly clean direct buffers per stage. This class is not
+  /// thread-safe; each writer or calling thread must own a separate instance. Any view returned by
+  /// [#encode(ByteBuffer, int, long, EncodeScratch)] is owned by this workspace and is invalidated
+  /// by the next encode call or by [#close()].
+  public static final class EncodeScratch implements AutoCloseable {
+    private final StageViewWorkspace _workspace = new StageViewWorkspace("EncodeScratch");
+    private ByteBuffer _source;
+    private ByteBuffer _sourceView;
+    private int _sourceViewCreationCount;
+
+    private ByteBuffer buffer(int stageIndex, int slot, int capacity) {
+      return _workspace.buffer(stageIndex, slot, capacity);
+    }
+
+    private ByteBuffer sourceView(ByteBuffer source) {
+      ensureOpen();
+      if (_source != source) {
+        _source = source;
+        _sourceView = source.duplicate();
+        _sourceViewCreationCount++;
+      }
+      _sourceView.limit(source.limit());
+      _sourceView.position(source.position());
+      _sourceView.order(ByteOrder.BIG_ENDIAN);
+      return _sourceView;
+    }
+
+    private void prepare(int[] stageBounds, int stageCount) {
+      ensureOpen();
+      int evenCapacity = 0;
+      int oddCapacity = 0;
+      for (int i = 0; i < stageCount; i++) {
+        if ((i & 1) == 0) {
+          evenCapacity = Math.max(evenCapacity, stageBounds[i]);
+        } else {
+          oddCapacity = Math.max(oddCapacity, stageBounds[i]);
+        }
+      }
+      _workspace.ensureCapacity(0, evenCapacity);
+      if (stageCount > 1) {
+        _workspace.ensureCapacity(1, oddCapacity);
+      }
+    }
+
+    private int[] stageBounds(int stageCount) {
+      return _workspace.stageBounds(stageCount);
+    }
+
+    private void ensureOpen() {
+      _workspace.ensureOpen();
+    }
+
+    int allocationCount() {
+      return _workspace.allocationCount();
+    }
+
+    int viewCreationCount() {
+      return _workspace.viewCreationCount() + _sourceViewCreationCount;
+    }
+
+    @Override
+    public void close() {
+      if (_workspace.isClosed()) {
+        return;
+      }
+      _workspace.close();
+      _source = null;
+      _sourceView = null;
+    }
+  }
+
+  /// Caller-owned, reusable decode workspace.
+  ///
+  /// The workspace retains at most two direct buffers and grows them on demand. Multi-stage
+  /// decoding alternates between those buffers, so repeated chunk reads avoid allocating and
+  /// explicitly cleaning a direct buffer for every intermediate stage. This class is not
+  /// thread-safe; each reader context or calling thread must own a separate instance.
+  public static final class DecodeScratch implements AutoCloseable {
+    private final StageViewWorkspace _workspace = new StageViewWorkspace("DecodeScratch");
+    private ByteBuffer _finalDestination;
+    private ByteBuffer _finalView;
+
+    private ByteBuffer buffer(int stageIndex, int slot, int capacity) {
+      return _workspace.buffer(stageIndex, slot, capacity);
+    }
+
+    private ByteBuffer finalOutput(ByteBuffer destination) {
+      ensureOpen();
+      if (_finalDestination != destination) {
+        _finalDestination = destination;
+        _finalView = destination.duplicate().order(ByteOrder.BIG_ENDIAN);
+      }
+      _finalView.clear();
+      _finalView.order(ByteOrder.BIG_ENDIAN);
+      return _finalView;
+    }
+
+    private int[] stageBounds(int stageCount) {
+      return _workspace.stageBounds(stageCount);
+    }
+
+    private void ensureOpen() {
+      _workspace.ensureOpen();
+    }
+
+    int allocationCount() {
+      return _workspace.allocationCount();
+    }
+
+    int viewCreationCount() {
+      return _workspace.viewCreationCount();
+    }
+
+    @Override
+    public void close() {
+      if (_workspace.isClosed()) {
+        return;
+      }
+      _workspace.close();
+      _finalDestination = null;
+      _finalView = null;
     }
   }
 
@@ -159,7 +326,7 @@ public final class CodecPipelineExecutor {
   private final String _canonicalSpec;
   private final DataType _storedType;
   private final boolean _hasCompression;
-  private final boolean _requiresDirectDstBuffer;
+  private final boolean _requiresDirectDecodeDstBuffer;
 
   /// Creates an executor by parsing and validating the given spec.
   ///
@@ -189,13 +356,13 @@ public final class CodecPipelineExecutor {
       CodecOptions opts = handler.parseOptions(inv.args());
       stages.add(new BoundStage<>(handler, opts, ctx));
     }
-    _stages = stages;
+    _stages = List.copyOf(stages);
     _canonicalSpec = buildCanonical(stages);
     _storedType = ctx.getDataType();
     _hasCompression = stages.stream().anyMatch(BoundStage::isCompression);
-    // decodeInto() writes the final output through stage zero. All other stage outputs use
-    // executor-owned direct scratch buffers, so only stage zero constrains the caller's dst.
-    _requiresDirectDstBuffer = stages.get(0).requiresDirectDstBuffer();
+    // decode() writes the final output through stage zero. All other stage outputs use
+    // caller-owned direct scratch buffers, so only stage zero constrains the caller's dst.
+    _requiresDirectDecodeDstBuffer = stages.get(0).requiresDirectDecodeDstBuffer();
   }
 
   /// Returns the canonical spec string derived from the parsed pipeline.
@@ -225,11 +392,18 @@ public final class CodecPipelineExecutor {
   /// bounds. The cumulative limit bounds CPU and allocation churn for long pipelines even when
   /// each individual stage stays below `maxStageSize`.
   public int maxEncodedSize(int decodedSize, int maxStageSize, long maxCumulativeSize) {
+    return encodedStageBounds(decodedSize, maxStageSize, maxCumulativeSize, null);
+  }
+
+  private int encodedStageBounds(int decodedSize, int maxStageSize, long maxCumulativeSize,
+      int[] stageBounds) {
     Preconditions.checkArgument(decodedSize >= 0, "decodedSize must be non-negative: %s", decodedSize);
     Preconditions.checkArgument(maxStageSize >= decodedSize,
         "maxStageSize %s must be at least decodedSize %s", maxStageSize, decodedSize);
     Preconditions.checkArgument(maxCumulativeSize >= decodedSize,
         "maxCumulativeSize %s must be at least decodedSize %s", maxCumulativeSize, decodedSize);
+    Preconditions.checkArgument(stageBounds == null || stageBounds.length >= _stages.size(),
+        "stageBounds length must be at least %s", _stages.size());
     int size = decodedSize;
     long cumulativeSize = 0;
     for (int i = 0; i < _stages.size(); i++) {
@@ -245,174 +419,109 @@ public final class CodecPipelineExecutor {
             "Codec pipeline cumulative stage-output bound " + cumulativeSize + " exceeds " + maxCumulativeSize
                 + " at stage " + i + " for pipeline " + _canonicalSpec);
       }
+      if (stageBounds != null) {
+        stageBounds[i] = size;
+      }
     }
     return size;
   }
 
-  /// Encodes `src` through the pipeline and returns the encoded bytes ready for read.
+  /// Encodes through capacity-bounded caller-owned scratch buffers.
   ///
-  /// The readable range is interpreted in the persisted big-endian typed-value order, independent
-  /// of the caller view's byte order. The caller's position, limit, and order are not modified.
+  /// Every stage output is written directly into one of two alternating direct buffers. The
+  /// returned readable view is owned by `scratch`: callers must consume or copy it before the next
+  /// call using that workspace, and must not use it after the workspace is closed. The caller's
+  /// source position, limit, and byte order are not modified. Typed input is interpreted in
+  /// persisted big-endian order, independent of the caller view's byte order. The source must
+  /// not alias this workspace's buffers (including a view returned by a previous call).
   ///
-  /// @param src decoded chunk data, ready for read (position=0, limit=dataSize)
-  /// @return encoded buffer ready for read; the caller owns this buffer
-  public ByteBuffer encode(ByteBuffer src) throws IOException {
-    ByteBuffer input = src.duplicate().order(ByteOrder.BIG_ENDIAN);
-    ByteBuffer current = input;
-    try {
-      for (BoundStage<?> stage : _stages) {
-        ByteBuffer previous = current;
-        current = stage.encode(previous);
-        if (previous != input && previous != current) {
-          CleanerUtil.cleanQuietly(previous);
-        }
-      }
-      return current;
-    } catch (IOException | RuntimeException | Error e) {
-      if (current != input) {
-        CleanerUtil.cleanQuietly(current);
-      }
-      throw e;
-    }
-  }
-
-  /// Decodes `src` through the reversed pipeline and returns the original bytes.
-  ///
-  /// @param src encoded chunk data, ready for read
-  /// @return decoded buffer ready for read; the caller owns this buffer
-  ByteBuffer decode(ByteBuffer src) throws IOException {
-    ByteBuffer current = src;
-    try {
-      for (int i = _stages.size() - 1; i >= 0; i--) {
-        ByteBuffer previous = current;
-        current = _stages.get(i).decode(previous);
-        if (previous != src && previous != current) {
-          CleanerUtil.cleanQuietly(previous);
-        }
-      }
-      return current;
-    } catch (IOException | RuntimeException | Error e) {
-      if (current != src) {
-        CleanerUtil.cleanQuietly(current);
-      }
-      throw e;
-    }
-  }
-
-  /// Decodes `src` through the reversed pipeline, writing the result directly into
-  /// `dst`.  On return `dst` is flipped and ready for read (position=0,
-  /// limit=decoded size).
-  ///
-  /// For single-stage pipelines (transform-only or compression-only), the decoded bytes are
-  /// written directly into `dst`, avoiding an intermediate allocation.  For multi-stage
-  /// pipelines an intermediate buffer is allocated for any stage that is not the last in the
-  /// reversed pipeline; the final stage writes directly into `dst`.
-  ///
-  /// @param src encoded chunk data, ready for read
-  /// @param dst caller-supplied output buffer; must be a *direct* [ByteBuffer] when
-  ///            the pipeline requires it (see [ChunkCodecHandler#requiresDirectDstBuffer]);
-  ///            must have sufficient [ByteBuffer#capacity()] for the decoded data; its
-  ///            position and limit are overwritten before returning
-  /// @throws IOException              if decoding fails
-  /// @throws IllegalArgumentException if `dst` is not direct when required, or does not have
-  ///                                  enough capacity
-  void decode(ByteBuffer src, ByteBuffer dst) throws IOException {
-    decode(src, dst, dst.capacity());
-  }
-
-  /// Decodes into `dst` while bounding every intermediate allocation from the expected final
-  /// decoded size. This is the segment-reader entry point: codec frames are untrusted and may
-  /// advertise arbitrary decoded lengths, so an intermediate stage must never allocate directly
-  /// from its frame header.
-  ///
-  /// @param src                 encoded chunk data, ready for read
-  /// @param dst                 caller-owned final output buffer
-  /// @param expectedDecodedSize exact decoded bytes declared and validated by the outer format
-  void decode(ByteBuffer src, ByteBuffer dst, int expectedDecodedSize) throws IOException {
-    decode(src, dst, expectedDecodedSize, Integer.MAX_VALUE, Long.MAX_VALUE);
-  }
-
-  /// Variant of [#decode(ByteBuffer, ByteBuffer, int)] that caps every intermediate scratch
-  /// buffer. Callers reading untrusted persisted data should pass the format's validated limit.
-  void decode(ByteBuffer src, ByteBuffer dst, int expectedDecodedSize, int maxIntermediateSize)
+  /// @param src               decoded chunk data, ready for read
+  /// @param maxStageSize      maximum permitted output bound for any stage
+  /// @param maxCumulativeSize maximum permitted sum of all stage-output bounds
+  /// @param scratch           caller-owned workspace, not shared across concurrent calls
+  /// @return scratch-owned encoded bytes ready for read
+  public ByteBuffer encode(ByteBuffer src, int maxStageSize, long maxCumulativeSize, EncodeScratch scratch)
       throws IOException {
-    decode(src, dst, expectedDecodedSize, maxIntermediateSize, Long.MAX_VALUE);
-  }
-
-  /// Variant that also caps the sum of stage-output bounds, limiting total work and allocation
-  /// churn for an otherwise-valid long pipeline. This convenience overload owns a temporary
-  /// workspace; production chunk readers should use the caller-owned [DecodeScratch] overload.
-  void decode(ByteBuffer src, ByteBuffer dst, int expectedDecodedSize, int maxIntermediateSize,
-      long maxCumulativeSize)
-      throws IOException {
-    try (DecodeScratch scratch = new DecodeScratch()) {
-      decode(src, dst, expectedDecodedSize, maxIntermediateSize, maxCumulativeSize, scratch);
+    scratch.ensureOpen();
+    int[] stageBounds = scratch.stageBounds(_stages.size());
+    encodedStageBounds(src.remaining(), maxStageSize, maxCumulativeSize, stageBounds);
+    scratch.prepare(stageBounds, _stages.size());
+    ByteBuffer current = scratch.sourceView(src);
+    for (int i = 0; i < _stages.size(); i++) {
+      ByteBuffer output = scratch.buffer(i, i & 1, stageBounds[i]);
+      _stages.get(i).encode(current, output);
+      Preconditions.checkState(output.position() == 0,
+          "Codec stage %s did not return an encoded buffer ready for read", i);
+      Preconditions.checkState(output.remaining() <= stageBounds[i],
+          "Codec stage %s encoded size %s exceeds validated bound %s", i, output.remaining(), stageBounds[i]);
+      current = output;
     }
+    return current;
   }
 
   /// Decodes with caller-owned reusable scratch buffers.
   ///
   /// The caller must not share scratch across concurrent decode calls and must close it when the
-  /// owning reader context is closed.
-  public void decode(ByteBuffer src, ByteBuffer dst, int expectedDecodedSize, int maxIntermediateSize,
+  /// owning reader context is closed. Source and destination must not alias each other or scratch
+  /// storage. The source may be consumed; destination position and limit are overwritten, leaving
+  /// it ready for read, and its byte order is preserved.
+  ///
+  /// @param src                 encoded chunk data, ready for read
+  /// @param dst                 caller-owned output; direct when required by the first codec
+  /// @param expectedDecodedSize exact decoded bytes validated by the caller, not an inner codec frame
+  /// @param maxStageSize      maximum permitted stage-output bound
+  /// @param maxCumulativeSize maximum permitted sum of stage-output bounds
+  /// @param scratch           caller-owned workspace, not shared across concurrent calls
+  public void decode(ByteBuffer src, ByteBuffer dst, int expectedDecodedSize, int maxStageSize,
       long maxCumulativeSize, DecodeScratch scratch)
       throws IOException {
     scratch.ensureOpen();
-    Preconditions.checkArgument(!_requiresDirectDstBuffer || dst.isDirect(),
+    Preconditions.checkArgument(!_requiresDirectDecodeDstBuffer || dst.isDirect(),
         "decode(src, dst) requires a direct ByteBuffer for pipeline: %s", _canonicalSpec);
     Preconditions.checkArgument(expectedDecodedSize >= 0 && expectedDecodedSize <= dst.capacity(),
         "expectedDecodedSize %s is out of range [0, %s]", expectedDecodedSize, dst.capacity());
-    Preconditions.checkArgument(maxIntermediateSize >= expectedDecodedSize,
-        "maxIntermediateSize %s must be at least expectedDecodedSize %s", maxIntermediateSize, expectedDecodedSize);
+    Preconditions.checkArgument(maxStageSize >= expectedDecodedSize,
+        "maxStageSize %s must be at least expectedDecodedSize %s", maxStageSize, expectedDecodedSize);
     Preconditions.checkArgument(maxCumulativeSize >= expectedDecodedSize,
         "maxCumulativeSize %s must be at least expectedDecodedSize %s", maxCumulativeSize, expectedDecodedSize);
 
     int stageCount = _stages.size();
     int[] maxOutputAfterStage = scratch.stageBounds(stageCount);
-    int maxSize = expectedDecodedSize;
-    long cumulativeSize = 0;
-    for (int i = 0; i < stageCount; i++) {
-      maxSize = _stages.get(i).maxEncodedSize(maxSize);
-      if (maxSize < 0 || maxSize > maxIntermediateSize) {
-        throw new IllegalArgumentException(
-            "Codec stage " + i + " maximum encoded size " + maxSize + " is outside [0, "
-                + maxIntermediateSize + "] for pipeline " + _canonicalSpec);
-      }
-      cumulativeSize += maxSize;
-      if (cumulativeSize > maxCumulativeSize) {
-        throw new IllegalArgumentException(
-            "Codec pipeline cumulative stage-output bound " + cumulativeSize + " exceeds " + maxCumulativeSize
-                + " at stage " + i + " for pipeline " + _canonicalSpec);
-      }
-      maxOutputAfterStage[i] = maxSize;
-    }
-    Preconditions.checkArgument(src.remaining() <= maxOutputAfterStage[stageCount - 1],
+    int maxEncodedSize = encodedStageBounds(expectedDecodedSize, maxStageSize, maxCumulativeSize,
+        maxOutputAfterStage);
+    Preconditions.checkArgument(src.remaining() <= maxEncodedSize,
         "Encoded input size %s exceeds composed pipeline bound %s for expected decoded size %s",
-        src.remaining(), maxOutputAfterStage[stageCount - 1], expectedDecodedSize);
+        src.remaining(), maxEncodedSize, expectedDecodedSize);
 
-    // Decode every stage through decodeInto(). Intermediate stages alternate between two reusable
+    // Decode every stage into its destination. Intermediate stages alternate between two reusable
     // direct buffers whose views are capacity-limited to the forward maxEncodedSize chain rooted
     // at the validated final decoded size. A corrupt inner frame-controlled length can therefore
     // only trigger a bounded "exceeds dst capacity" failure, never a frame-controlled allocation.
-    ByteBuffer finalOutput = dst.duplicate().order(ByteOrder.BIG_ENDIAN);
-    ByteBuffer current = src;
-    int scratchSlot = 0;
-    for (int i = stageCount - 1; i >= 0; i--) {
-      ByteBuffer output;
-      if (i == 0) {
-        output = finalOutput;
-      } else {
-        output = scratch.buffer(scratchSlot, maxOutputAfterStage[i - 1]);
-        scratchSlot ^= 1;
+    ByteBuffer finalOutput = scratch.finalOutput(dst);
+    ByteOrder sourceOrder = src.order();
+    try {
+      src.order(ByteOrder.BIG_ENDIAN);
+      ByteBuffer current = src;
+      int scratchSlot = 0;
+      for (int i = stageCount - 1; i >= 0; i--) {
+        ByteBuffer output;
+        if (i == 0) {
+          output = finalOutput;
+        } else {
+          output = scratch.buffer(i - 1, scratchSlot, maxOutputAfterStage[i - 1]);
+          scratchSlot ^= 1;
+        }
+        _stages.get(i).decode(current, output);
+        current = output;
       }
-      _stages.get(i).decodeInto(current, output);
-      current = output;
+    } finally {
+      src.order(sourceOrder);
     }
     if (finalOutput.remaining() != expectedDecodedSize) {
       throw new IOException("Codec pipeline decoded " + finalOutput.remaining() + " bytes but expected "
           + expectedDecodedSize + " for pipeline " + _canonicalSpec + ". Segment may be corrupt.");
     }
-    // decodeInto() flips the final view. Mirror that readable range onto the caller's buffer while
+    // decode() flips the final view. Mirror that readable range onto the caller's buffer while
     // preserving its independently configured byte order.
     dst.clear();
     dst.limit(finalOutput.limit());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/DeltaCodecDefinition.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/DeltaCodecDefinition.java
@@ -77,88 +77,62 @@ final class DeltaCodecDefinition extends BaseDeltaCodecDefinition<DeltaCodecDefi
   }
 
   @Override
-  protected ByteBuffer encodeInt(ByteBuffer src, int count) {
-    ByteBuffer out = ByteBuffer.allocateDirect(count * Integer.BYTES);
-    if (count == 0) {
-      out.flip();
-      return out;
-    }
-    int prev = src.getInt();
-    out.putInt(prev);
+  protected void encodeIntInto(ByteBuffer src, int count, ByteBuffer dst) {
+    int srcOffset = src.position();
+    int dstOffset = dst.position();
+    int prev = src.getInt(srcOffset);
+    dst.putInt(dstOffset, prev);
     for (int i = 1; i < count; i++) {
-      int cur = src.getInt();
-      out.putInt(cur - prev);
+      int cur = src.getInt(srcOffset + i * Integer.BYTES);
+      dst.putInt(dstOffset + i * Integer.BYTES, cur - prev);
       prev = cur;
     }
-    out.flip();
-    return out;
+    src.position(srcOffset + count * Integer.BYTES);
+    dst.position(dstOffset + count * Integer.BYTES);
   }
 
   @Override
-  protected ByteBuffer encodeLong(ByteBuffer src, int count) {
-    ByteBuffer out = ByteBuffer.allocateDirect(count * Long.BYTES);
-    if (count == 0) {
-      out.flip();
-      return out;
-    }
-    long prev = src.getLong();
-    out.putLong(prev);
+  protected void encodeLongInto(ByteBuffer src, int count, ByteBuffer dst) {
+    int srcOffset = src.position();
+    int dstOffset = dst.position();
+    long prev = src.getLong(srcOffset);
+    dst.putLong(dstOffset, prev);
     for (int i = 1; i < count; i++) {
-      long cur = src.getLong();
-      out.putLong(cur - prev);
+      long cur = src.getLong(srcOffset + i * Long.BYTES);
+      dst.putLong(dstOffset + i * Long.BYTES, cur - prev);
       prev = cur;
     }
-    out.flip();
-    return out;
-  }
-
-  @Override
-  protected ByteBuffer decodeInt(ByteBuffer src, int count) {
-    ByteBuffer out = ByteBuffer.allocateDirect(count * Integer.BYTES);
-    int prev = src.getInt();
-    out.putInt(prev);
-    for (int i = 1; i < count; i++) {
-      int delta = src.getInt();
-      prev += delta;
-      out.putInt(prev);
-    }
-    out.flip();
-    return out;
-  }
-
-  @Override
-  protected ByteBuffer decodeLong(ByteBuffer src, int count) {
-    ByteBuffer out = ByteBuffer.allocateDirect(count * Long.BYTES);
-    long prev = src.getLong();
-    out.putLong(prev);
-    for (int i = 1; i < count; i++) {
-      long delta = src.getLong();
-      prev += delta;
-      out.putLong(prev);
-    }
-    out.flip();
-    return out;
+    src.position(srcOffset + count * Long.BYTES);
+    dst.position(dstOffset + count * Long.BYTES);
   }
 
   @Override
   protected void decodeIntInto(ByteBuffer src, int count, ByteBuffer dst) {
-    int prev = src.getInt();
-    dst.putInt(prev);
+    int srcOffset = src.position();
+    int dstOffset = dst.position();
+    int prev = src.getInt(srcOffset);
+    dst.putInt(dstOffset, prev);
     for (int i = 1; i < count; i++) {
-      int delta = src.getInt();
+      int delta = src.getInt(srcOffset + i * Integer.BYTES);
       prev += delta;
-      dst.putInt(prev);
+      dst.putInt(dstOffset + i * Integer.BYTES, prev);
     }
+    src.position(srcOffset + count * Integer.BYTES);
+    dst.position(dstOffset + count * Integer.BYTES);
   }
 
   @Override
   protected void decodeLongInto(ByteBuffer src, int count, ByteBuffer dst) {
-    long prev = src.getLong();
-    dst.putLong(prev);
+    int srcOffset = src.position();
+    int dstOffset = dst.position();
+    long prev = src.getLong(srcOffset);
+    dst.putLong(dstOffset, prev);
     for (int i = 1; i < count; i++) {
-      long delta = src.getLong();
+      long delta = src.getLong(srcOffset + i * Long.BYTES);
       prev += delta;
-      dst.putLong(prev);
+      dst.putLong(dstOffset + i * Long.BYTES, prev);
     }
+    src.position(srcOffset + count * Long.BYTES);
+    dst.position(dstOffset + count * Long.BYTES);
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/DeltaDeltaCodecDefinition.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/DeltaDeltaCodecDefinition.java
@@ -80,130 +80,88 @@ final class DeltaDeltaCodecDefinition
   }
 
   @Override
-  protected ByteBuffer encodeInt(ByteBuffer src, int count) {
-    ByteBuffer out = ByteBuffer.allocateDirect(count * Integer.BYTES);
-    if (count == 0) {
-      out.flip();
-      return out;
-    }
-    int prev = src.getInt();
-    out.putInt(prev);
-    if (count == 1) {
-      out.flip();
-      return out;
-    }
-    int prevDelta = src.getInt() - prev;
-    out.putInt(prevDelta);
-    prev += prevDelta;
-    for (int i = 2; i < count; i++) {
-      int cur = src.getInt();
-      int curDelta = cur - prev;
-      out.putInt(curDelta - prevDelta);
-      prev = cur;
-      prevDelta = curDelta;
-    }
-    out.flip();
-    return out;
-  }
-
-  @Override
-  protected ByteBuffer encodeLong(ByteBuffer src, int count) {
-    ByteBuffer out = ByteBuffer.allocateDirect(count * Long.BYTES);
-    if (count == 0) {
-      out.flip();
-      return out;
-    }
-    long prev = src.getLong();
-    out.putLong(prev);
-    if (count == 1) {
-      out.flip();
-      return out;
-    }
-    long prevDelta = src.getLong() - prev;
-    out.putLong(prevDelta);
-    prev += prevDelta;
-    for (int i = 2; i < count; i++) {
-      long cur = src.getLong();
-      long curDelta = cur - prev;
-      out.putLong(curDelta - prevDelta);
-      prev = cur;
-      prevDelta = curDelta;
-    }
-    out.flip();
-    return out;
-  }
-
-  @Override
-  protected ByteBuffer decodeInt(ByteBuffer src, int count) {
-    ByteBuffer out = ByteBuffer.allocateDirect(count * Integer.BYTES);
-    int prev = src.getInt();
-    out.putInt(prev);
+  protected void encodeIntInto(ByteBuffer src, int count, ByteBuffer dst) {
+    int srcOffset = src.position();
+    int dstOffset = dst.position();
+    int prev = src.getInt(srcOffset);
+    dst.putInt(dstOffset, prev);
     if (count > 1) {
-      int prevDelta = src.getInt();
+      int prevDelta = src.getInt(srcOffset + Integer.BYTES) - prev;
+      dst.putInt(dstOffset + Integer.BYTES, prevDelta);
       prev += prevDelta;
-      out.putInt(prev);
       for (int i = 2; i < count; i++) {
-        int dod = src.getInt();
-        prevDelta += dod;
-        prev += prevDelta;
-        out.putInt(prev);
+        int cur = src.getInt(srcOffset + i * Integer.BYTES);
+        int curDelta = cur - prev;
+        dst.putInt(dstOffset + i * Integer.BYTES, curDelta - prevDelta);
+        prev = cur;
+        prevDelta = curDelta;
       }
     }
-    out.flip();
-    return out;
+    src.position(srcOffset + count * Integer.BYTES);
+    dst.position(dstOffset + count * Integer.BYTES);
   }
 
   @Override
-  protected ByteBuffer decodeLong(ByteBuffer src, int count) {
-    ByteBuffer out = ByteBuffer.allocateDirect(count * Long.BYTES);
-    long prev = src.getLong();
-    out.putLong(prev);
+  protected void encodeLongInto(ByteBuffer src, int count, ByteBuffer dst) {
+    int srcOffset = src.position();
+    int dstOffset = dst.position();
+    long prev = src.getLong(srcOffset);
+    dst.putLong(dstOffset, prev);
     if (count > 1) {
-      long prevDelta = src.getLong();
+      long prevDelta = src.getLong(srcOffset + Long.BYTES) - prev;
+      dst.putLong(dstOffset + Long.BYTES, prevDelta);
       prev += prevDelta;
-      out.putLong(prev);
       for (int i = 2; i < count; i++) {
-        long dod = src.getLong();
-        prevDelta += dod;
-        prev += prevDelta;
-        out.putLong(prev);
+        long cur = src.getLong(srcOffset + i * Long.BYTES);
+        long curDelta = cur - prev;
+        dst.putLong(dstOffset + i * Long.BYTES, curDelta - prevDelta);
+        prev = cur;
+        prevDelta = curDelta;
       }
     }
-    out.flip();
-    return out;
+    src.position(srcOffset + count * Long.BYTES);
+    dst.position(dstOffset + count * Long.BYTES);
   }
 
   @Override
   protected void decodeIntInto(ByteBuffer src, int count, ByteBuffer dst) {
-    int prev = src.getInt();
-    dst.putInt(prev);
+    int srcOffset = src.position();
+    int dstOffset = dst.position();
+    int prev = src.getInt(srcOffset);
+    dst.putInt(dstOffset, prev);
     if (count > 1) {
-      int prevDelta = src.getInt();
+      int prevDelta = src.getInt(srcOffset + Integer.BYTES);
       prev += prevDelta;
-      dst.putInt(prev);
+      dst.putInt(dstOffset + Integer.BYTES, prev);
       for (int i = 2; i < count; i++) {
-        int dod = src.getInt();
+        int dod = src.getInt(srcOffset + i * Integer.BYTES);
         prevDelta += dod;
         prev += prevDelta;
-        dst.putInt(prev);
+        dst.putInt(dstOffset + i * Integer.BYTES, prev);
       }
     }
+    src.position(srcOffset + count * Integer.BYTES);
+    dst.position(dstOffset + count * Integer.BYTES);
   }
 
   @Override
   protected void decodeLongInto(ByteBuffer src, int count, ByteBuffer dst) {
-    long prev = src.getLong();
-    dst.putLong(prev);
+    int srcOffset = src.position();
+    int dstOffset = dst.position();
+    long prev = src.getLong(srcOffset);
+    dst.putLong(dstOffset, prev);
     if (count > 1) {
-      long prevDelta = src.getLong();
+      long prevDelta = src.getLong(srcOffset + Long.BYTES);
       prev += prevDelta;
-      dst.putLong(prev);
+      dst.putLong(dstOffset + Long.BYTES, prev);
       for (int i = 2; i < count; i++) {
-        long dod = src.getLong();
+        long dod = src.getLong(srcOffset + i * Long.BYTES);
         prevDelta += dod;
         prev += prevDelta;
-        dst.putLong(prev);
+        dst.putLong(dstOffset + i * Long.BYTES, prev);
       }
     }
+    src.position(srcOffset + count * Long.BYTES);
+    dst.position(dstOffset + count * Long.BYTES);
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/GorillaCodecDefinition.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/GorillaCodecDefinition.java
@@ -105,12 +105,12 @@ final class GorillaCodecDefinition implements ChunkCodecHandler<GorillaCodecDefi
   }
 
   @Override
-  public boolean requiresDirectDstBuffer() {
+  public boolean requiresDirectDecodeDstBuffer() {
     return false;
   }
 
   @Override
-  public int maxEncodedSize(Options options, int inputSize) {
+  public int maxEncodedSize(Options options, CodecContext ctx, int inputSize) {
     // Worst case: every value is incompressible XOR → control bits + leading + width + full bits.
     // Approx 2*elementBits + 13 bits per value. Round up generously to elementBits * 2 + 16 bits.
     // Cheap upper bound: header + 2 * inputSize bytes.
@@ -125,7 +125,9 @@ final class GorillaCodecDefinition implements ChunkCodecHandler<GorillaCodecDefi
   }
 
   @Override
-  public ByteBuffer encode(Options options, CodecContext ctx, ByteBuffer src) {
+  public void encode(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) {
+    src.order(ByteOrder.BIG_ENDIAN);
+    dst.clear();
     int remaining = src.remaining();
     DataType dt = ctx.getDataType();
     if (dt != DataType.INT && dt != DataType.LONG) {
@@ -143,27 +145,31 @@ final class GorillaCodecDefinition implements ChunkCodecHandler<GorillaCodecDefi
     int leadingBits = isLong ? 6 : 5;
     int widthBits = isLong ? 6 : 5;
 
-    ByteBuffer out = ByteBuffer.allocateDirect(maxEncodedSize(options, remaining));
-    out.put((byte) (isLong ? 1 : 0));
-    out.putInt(count);
+    int encodedSizeBound = maxEncodedSize(options, ctx, remaining);
+    if (encodedSizeBound > dst.capacity()) {
+      throw new IllegalArgumentException(
+          "GORILLA: encoded size bound " + encodedSizeBound + " exceeds dst capacity " + dst.capacity());
+    }
+    dst.put((byte) (isLong ? 1 : 0));
+    dst.putInt(count);
     if (count == 0) {
-      out.flip();
-      return out;
+      dst.flip();
+      return;
     }
 
     // First value verbatim
     long prev = isLong ? src.getLong() : (long) src.getInt();
     if (isLong) {
-      out.putLong(prev);
+      dst.putLong(prev);
     } else {
-      out.putInt((int) prev);
+      dst.putInt((int) prev);
     }
     if (count == 1) {
-      out.flip();
-      return out;
+      dst.flip();
+      return;
     }
 
-    BitWriter writer = new BitWriter(out);
+    BitWriter writer = new BitWriter(dst);
     int prevLeading = -1; // sentinel: no previous window
     int prevWidth = -1;
 
@@ -214,31 +220,12 @@ final class GorillaCodecDefinition implements ChunkCodecHandler<GorillaCodecDefi
     }
 
     writer.flush();
-    out.flip();
-    return out;
+    dst.flip();
   }
 
   @Override
-  public ByteBuffer decode(Options options, CodecContext ctx, ByteBuffer src) {
-    src = src.duplicate().order(ByteOrder.BIG_ENDIAN);
-    byte flag = src.get();
-    int count = src.getInt();
-    validateHeader(flag, count, ctx);
-    if (count == 0) {
-      ensureFullyConsumed(src);
-      return ByteBuffer.allocateDirect(0);
-    }
-    boolean isLong = flag == 1;
-    int elementSize = isLong ? Long.BYTES : Integer.BYTES;
-    ByteBuffer out = ByteBuffer.allocateDirect(decodedSize(count, elementSize));
-    decodeValues(src, count, isLong, out);
-    out.flip();
-    return out;
-  }
-
-  @Override
-  public void decodeInto(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) {
-    src = src.duplicate().order(ByteOrder.BIG_ENDIAN);
+  public void decode(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) {
+    src.order(ByteOrder.BIG_ENDIAN);
     dst.clear();
     byte flag = src.get();
     int count = src.getInt();
@@ -346,15 +333,6 @@ final class GorillaCodecDefinition implements ChunkCodecHandler<GorillaCodecDefi
       }
     }
     reader.ensureFullyConsumed();
-  }
-
-  private static int decodedSize(int count, int elementSize) {
-    long decodedSize = (long) count * elementSize;
-    if (decodedSize > Integer.MAX_VALUE) {
-      throw new IllegalStateException(
-          "GORILLA: decoded size " + decodedSize + " exceeds Integer.MAX_VALUE. Segment may be corrupt.");
-    }
-    return (int) decodedSize;
   }
 
   private static void ensureFullyConsumed(ByteBuffer src) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/GzipCodecDefinition.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/GzipCodecDefinition.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 import java.util.zip.Inflater;
-import org.apache.pinot.segment.spi.memory.CleanerUtil;
 
 
 /// Legacy `GZIP`-named compression codec backed by the default [java.util.zip.Deflater], which
@@ -102,57 +101,40 @@ final class GzipCodecDefinition implements ChunkCodecHandler<GzipCodecDefinition
   }
 
   @Override
-  public ByteBuffer encode(Options options, CodecContext ctx, ByteBuffer src) throws IOException {
+  public void encode(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) throws IOException {
     int uncompressedSize = src.remaining();
-    ByteBuffer out = ByteBuffer.allocateDirect(maxEncodedSize(options, uncompressedSize));
+    int encodedSizeBound = maxEncodedSize(options, ctx, uncompressedSize);
+    if (encodedSizeBound > dst.capacity()) {
+      throw new IllegalArgumentException(
+          "GZIP: encoded size bound " + encodedSizeBound + " exceeds dst capacity " + dst.capacity());
+    }
+    dst.clear();
+    dst.limit(dst.capacity() - Integer.BYTES);
     Deflater deflater = DEFLATER.get();
-    boolean succeeded = false;
+    deflater.reset();
     try {
-      out.limit(out.capacity() - Integer.BYTES);
-      deflater.reset();
-      deflater.setInput(src.duplicate());
+      deflater.setInput(src);
       deflater.finish();
       while (!deflater.finished()) {
-        if (!out.hasRemaining()) {
-          throw new IOException("GZIP encode exceeded maximum encoded size " + out.capacity()
+        if (!dst.hasRemaining()) {
+          throw new IOException("GZIP encode exceeded maximum encoded size " + dst.capacity()
               + " before deflater finished. Segment build aborted.");
         }
-        int encoded = deflater.deflate(out);
+        int encoded = deflater.deflate(dst);
         if (encoded == 0 && !deflater.finished()) {
           throw new IOException("GZIP deflater made no progress before finishing");
         }
       }
-      out.limit(out.capacity());
-      out.putInt(uncompressedSize);
-      out.flip();
-      succeeded = true;
-      return out;
+      dst.limit(dst.capacity());
+      dst.putInt(uncompressedSize);
+      dst.flip();
     } finally {
       deflater.reset();
-      if (!succeeded) {
-        CleanerUtil.cleanQuietly(out);
-      }
     }
   }
 
   @Override
-  public ByteBuffer decode(Options options, CodecContext ctx, ByteBuffer src) throws IOException {
-    int decompressedSize = readDecompressedSize(src);
-    ByteBuffer out = ByteBuffer.allocateDirect(decompressedSize);
-    boolean succeeded = false;
-    try {
-      inflateInto(src, out, decompressedSize);
-      succeeded = true;
-      return out;
-    } finally {
-      if (!succeeded) {
-        CleanerUtil.cleanQuietly(out);
-      }
-    }
-  }
-
-  @Override
-  public void decodeInto(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) throws IOException {
+  public void decode(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) throws IOException {
     dst.clear();
     int decompressedSize = readDecompressedSize(src);
     if (decompressedSize > dst.capacity()) {
@@ -163,7 +145,7 @@ final class GzipCodecDefinition implements ChunkCodecHandler<GzipCodecDefinition
   }
 
   @Override
-  public int maxEncodedSize(Options options, int inputSize) {
+  public int maxEncodedSize(Options options, CodecContext ctx, int inputSize) {
     // DEFLATE worst-case expansion + 4-byte appended uncompressed-size footer
     if (inputSize < 0) {
       throw new IllegalArgumentException("GZIP inputSize must be non-negative: " + inputSize);
@@ -177,7 +159,7 @@ final class GzipCodecDefinition implements ChunkCodecHandler<GzipCodecDefinition
   }
 
   @Override
-  public boolean requiresDirectDstBuffer() {
+  public boolean requiresDirectDecodeDstBuffer() {
     return false;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/Lz4CodecDefinition.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/Lz4CodecDefinition.java
@@ -94,53 +94,29 @@ final class Lz4CodecDefinition implements ChunkCodecHandler<Lz4CodecDefinition.O
   }
 
   @Override
-  public ByteBuffer encode(Options options, CodecContext ctx, ByteBuffer src) throws IOException {
-    // LZ4 JNI requires both buffers be direct; mirror the Snappy/Zstd defensive copy.
+  public void encode(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) throws IOException {
+    if (!dst.isDirect()) {
+      throw new IllegalArgumentException("LZ4 encode requires a direct destination buffer");
+    }
+    dst.clear();
+    // LZ4 JNI requires both buffers be direct. Production callers already supply direct input;
+    // copy heap input when necessary without taking ownership of the caller's source buffer.
     ByteBuffer directSrc = CodecBufferUtils.toDirectBuffer(src);
-    ByteBuffer out = null;
-    boolean succeeded = false;
     try {
       int maxSize = Native.COMPRESSOR.maxCompressedLength(directSrc.remaining());
-      out = ByteBuffer.allocateDirect(maxSize);
-      Native.COMPRESSOR.compress(directSrc, out);
-      out.flip();
-      succeeded = true;
-      return out;
+      if (maxSize > dst.capacity()) {
+        throw new IllegalArgumentException(
+            "LZ4: encoded size bound " + maxSize + " exceeds dst capacity " + dst.capacity());
+      }
+      Native.COMPRESSOR.compress(directSrc, dst);
+      dst.flip();
     } finally {
       CodecBufferUtils.cleanDirectCopy(src, directSrc);
-      if (!succeeded) {
-        CodecBufferUtils.cleanQuietly(out);
-      }
     }
   }
 
   @Override
-  public ByteBuffer decode(Options options, CodecContext ctx, ByteBuffer src) throws IOException {
-    ByteBuffer directSrc = CodecBufferUtils.toDirectBuffer(src);
-    ByteBuffer out = null;
-    boolean succeeded = false;
-    try {
-      int decompressedLength = CodecBufferUtils.checkDeclaredDecompressedSize(
-          LZ4DecompressorWithLength.getDecompressedLength(directSrc), "LZ4", "length prefix");
-      out = ByteBuffer.allocateDirect(decompressedLength);
-      Native.DECOMPRESSOR.decompress(directSrc, out);
-      if (out.position() != decompressedLength) {
-        throw new IOException("LZ4 decoded " + out.position() + " bytes but expected " + decompressedLength
-            + ". Segment may be corrupt.");
-      }
-      out.flip();
-      succeeded = true;
-      return out;
-    } finally {
-      CodecBufferUtils.cleanDirectCopy(src, directSrc);
-      if (!succeeded) {
-        CodecBufferUtils.cleanQuietly(out);
-      }
-    }
-  }
-
-  @Override
-  public void decodeInto(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) throws IOException {
+  public void decode(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) throws IOException {
     dst.clear();
     ByteBuffer directSrc = CodecBufferUtils.toDirectBuffer(src);
     try {
@@ -162,13 +138,13 @@ final class Lz4CodecDefinition implements ChunkCodecHandler<Lz4CodecDefinition.O
   }
 
   @Override
-  public int maxEncodedSize(Options options, int inputSize) {
+  public int maxEncodedSize(Options options, CodecContext ctx, int inputSize) {
     // LZ4CompressorWithLength adds a 4-byte length prefix before the compressed payload
     return Native.FACTORY.fastCompressor().maxCompressedLength(inputSize) + Integer.BYTES;
   }
 
   @Override
-  public boolean requiresDirectDstBuffer() {
+  public boolean requiresDirectDecodeDstBuffer() {
     return false;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/SnappyCodecDefinition.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/SnappyCodecDefinition.java
@@ -34,7 +34,7 @@ import org.xerial.snappy.Snappy;
 /// The name {@value #NAME} is a frozen on-disk API contract stored verbatim in segment file
 /// headers. It must never be changed or reused for a different algorithm.
 ///
-/// Note: [#decodeInto()] requires a direct [ByteBuffer] for `dst` because the
+/// Note: [#decode()] requires a direct [ByteBuffer] for `dst` because the
 /// Snappy JNI `uncompress(ByteBuffer, ByteBuffer)` overload requires both buffers to be direct.
 /// Also, that JNI overload writes at `dst.position()` but does *not* advance it; the
 /// returned byte count is used to set `dst.limit()` explicitly.
@@ -87,58 +87,28 @@ final class SnappyCodecDefinition implements ChunkCodecHandler<SnappyCodecDefini
   }
 
   @Override
-  public ByteBuffer encode(Options options, CodecContext ctx, ByteBuffer src) throws IOException {
+  public void encode(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) throws IOException {
+    if (!dst.isDirect()) {
+      throw new IllegalArgumentException("Snappy encode requires a direct destination buffer");
+    }
+    dst.clear();
     ByteBuffer directSrc = CodecBufferUtils.toDirectBuffer(src);
-    ByteBuffer out = null;
-    boolean succeeded = false;
     try {
       int maxSize = Snappy.maxCompressedLength(directSrc.remaining());
-      out = ByteBuffer.allocateDirect(maxSize);
-      int compressedSize = Snappy.compress(directSrc, out);
-      out.limit(compressedSize);
-      out.position(0);
-      succeeded = true;
-      return out;
+      if (maxSize > dst.capacity()) {
+        throw new IllegalArgumentException(
+            "Snappy: encoded size bound " + maxSize + " exceeds dst capacity " + dst.capacity());
+      }
+      int compressedSize = Snappy.compress(directSrc, dst);
+      dst.limit(compressedSize);
+      dst.position(0);
     } finally {
       CodecBufferUtils.cleanDirectCopy(src, directSrc);
-      if (!succeeded) {
-        CodecBufferUtils.cleanQuietly(out);
-      }
     }
   }
 
   @Override
-  public ByteBuffer decode(Options options, CodecContext ctx, ByteBuffer src) throws IOException {
-    // Snappy JNI requires direct buffers — convert before reading the size header so the heap
-    // fallback path actually works (Snappy.uncompressedLength does not accept heap input).
-    ByteBuffer directSrc = CodecBufferUtils.toDirectBuffer(src);
-    ByteBuffer out = null;
-    boolean succeeded = false;
-    try {
-      int decompressedSize = CodecBufferUtils.checkDeclaredDecompressedSize(
-          Snappy.uncompressedLength(directSrc.duplicate()), "Snappy", "varint length header");
-      out = ByteBuffer.allocateDirect(decompressedSize);
-      // Snappy JNI writes at dst.position() but does NOT advance it; use returned count to set limit
-      int written = Snappy.uncompress(directSrc, out);
-      if (written != decompressedSize) {
-        throw new IOException(
-            "Snappy decode size mismatch: expected " + decompressedSize + ", got " + written
-                + ". Segment may be corrupt.");
-      }
-      out.limit(written);
-      out.position(0);
-      succeeded = true;
-      return out;
-    } finally {
-      CodecBufferUtils.cleanDirectCopy(src, directSrc);
-      if (!succeeded) {
-        CodecBufferUtils.cleanQuietly(out);
-      }
-    }
-  }
-
-  @Override
-  public void decodeInto(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) throws IOException {
+  public void decode(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) throws IOException {
     dst.clear();
     // Snappy JNI requires direct buffers — convert before reading the size header.
     ByteBuffer directSrc = CodecBufferUtils.toDirectBuffer(src);
@@ -164,12 +134,12 @@ final class SnappyCodecDefinition implements ChunkCodecHandler<SnappyCodecDefini
   }
 
   @Override
-  public int maxEncodedSize(Options options, int inputSize) {
+  public int maxEncodedSize(Options options, CodecContext ctx, int inputSize) {
     return Snappy.maxCompressedLength(inputSize);
   }
 
   @Override
-  public boolean requiresDirectDstBuffer() {
+  public boolean requiresDirectDecodeDstBuffer() {
     return true;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/T64CodecDefinition.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/T64CodecDefinition.java
@@ -110,28 +110,28 @@ final class T64CodecDefinition implements ChunkCodecHandler<T64CodecDefinition.O
   }
 
   @Override
-  public boolean requiresDirectDstBuffer() {
+  public boolean requiresDirectDecodeDstBuffer() {
     return false;
   }
 
   @Override
-  public int maxEncodedSize(Options options, int inputSize) {
+  public int maxEncodedSize(Options options, CodecContext ctx, int inputSize) {
     // The on-disk size is 5-byte frame header + per-block (baseline + bitWidth + packed).
     // A partial last block still writes a full `elementSize * BLOCK_SIZE` packed-payload of
     // bit-packed slots (zero-filled at the tail), so payload size scales with **block count**,
     // not with input value count.
     //
-    // Element size isn't knowable from inputSize alone (the SPI passes only byte count), so we
-    // use the LONG worst case (elementSize = Long.BYTES) which is a valid upper bound for both
-    // INT and LONG inputs. Block count is bounded above using the smaller element size,
-    // Integer.BYTES, since inputSize / (Integer.BYTES * BLOCK_SIZE) ≥ inputSize / (Long.BYTES *
-    // BLOCK_SIZE) for any element size in {Integer.BYTES, Long.BYTES}.
     if (inputSize < 0) {
       throw new IllegalArgumentException("T64 inputSize must be non-negative: " + inputSize);
     }
-    long approxBlocks = ((long) inputSize + BLOCK_SIZE * Integer.BYTES - 1)
-        / (BLOCK_SIZE * Integer.BYTES);
-    long bound = 1L + Integer.BYTES + approxBlocks * (Long.BYTES + 1L + Long.BYTES * BLOCK_SIZE);
+    DataType dataType = ctx.getDataType();
+    if (dataType != DataType.INT && dataType != DataType.LONG) {
+      throw new IllegalArgumentException("T64 does not support stored type: " + dataType);
+    }
+    int elementSize = dataType.size();
+    long approxBlocks = ((long) inputSize + BLOCK_SIZE * elementSize - 1)
+        / (BLOCK_SIZE * elementSize);
+    long bound = 1L + Integer.BYTES + approxBlocks * (elementSize + 1L + (long) elementSize * BLOCK_SIZE);
     if (bound > Integer.MAX_VALUE) {
       throw new IllegalArgumentException("T64 maximum encoded size exceeds Integer.MAX_VALUE: " + bound);
     }
@@ -139,7 +139,9 @@ final class T64CodecDefinition implements ChunkCodecHandler<T64CodecDefinition.O
   }
 
   @Override
-  public ByteBuffer encode(Options options, CodecContext ctx, ByteBuffer src) {
+  public void encode(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) {
+    src.order(ByteOrder.BIG_ENDIAN);
+    dst.clear();
     int remaining = src.remaining();
     DataType dt = ctx.getDataType();
     if (dt != DataType.INT && dt != DataType.LONG) {
@@ -153,12 +155,15 @@ final class T64CodecDefinition implements ChunkCodecHandler<T64CodecDefinition.O
     int count = remaining / elementSize;
     boolean isLong = dt == DataType.LONG;
 
-    // Worst-case allocation upper bound — see maxEncodedSize.
+    // Worst-case output-size upper bound — see maxEncodedSize.
     int numBlocks = (count + BLOCK_SIZE - 1) / BLOCK_SIZE;
     int worstCase = 1 + Integer.BYTES + numBlocks * (elementSize + 1 + elementSize * BLOCK_SIZE);
-    ByteBuffer out = ByteBuffer.allocateDirect(worstCase);
-    out.put((byte) (isLong ? 1 : 0));
-    out.putInt(count);
+    if (worstCase > dst.capacity()) {
+      throw new IllegalArgumentException(
+          "T64: encoded size bound " + worstCase + " exceeds dst capacity " + dst.capacity());
+    }
+    dst.put((byte) (isLong ? 1 : 0));
+    dst.putInt(count);
 
     // Reusable per-encode scratch buffer for packed-bytes; sized for the worst case
     // `elementSize * BLOCK_SIZE` bytes (when bitWidth == elementBits) so it never needs to grow.
@@ -198,45 +203,26 @@ final class T64CodecDefinition implements ChunkCodecHandler<T64CodecDefinition.O
 
       // Baseline + bitWidth header.
       if (isLong) {
-        out.putLong(min);
+        dst.putLong(min);
       } else {
-        out.putInt((int) min);
+        dst.putInt((int) min);
       }
-      out.put((byte) bitWidth);
+      dst.put((byte) bitWidth);
 
       if (bitWidth == 0) {
         continue; // all values equal min; no packed bytes
       }
 
       // Pack BLOCK_SIZE values; missing tail slots get zero (i.e. baseline).
-      packBits(blockValues, blockCount, min, bitWidth, out, packedBuf);
+      packBits(blockValues, blockCount, min, bitWidth, dst, packedBuf);
     }
 
-    out.flip();
-    return out;
+    dst.flip();
   }
 
   @Override
-  public ByteBuffer decode(Options options, CodecContext ctx, ByteBuffer src) {
-    src = src.duplicate().order(ByteOrder.BIG_ENDIAN);
-    byte flag = src.get();
-    int count = src.getInt();
-    validateHeader(flag, count, ctx);
-    if (count == 0) {
-      ensureFullyConsumed(src);
-      return ByteBuffer.allocateDirect(0);
-    }
-    boolean isLong = flag == 1;
-    int elementSize = isLong ? Long.BYTES : Integer.BYTES;
-    ByteBuffer out = ByteBuffer.allocateDirect(decodedSize(count, elementSize));
-    decodeBlocks(src, count, isLong, out);
-    out.flip();
-    return out;
-  }
-
-  @Override
-  public void decodeInto(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) {
-    src = src.duplicate().order(ByteOrder.BIG_ENDIAN);
+  public void decode(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) {
+    src.order(ByteOrder.BIG_ENDIAN);
     dst.clear();
     byte flag = src.get();
     int count = src.getInt();
@@ -310,9 +296,7 @@ final class T64CodecDefinition implements ChunkCodecHandler<T64CodecDefinition.O
   /// Decode one or more T64 blocks until `count` values have been read, appending the
   /// resulting INT/LONG values to `dst`.
   private static void decodeBlocks(ByteBuffer src, int count, boolean isLong, ByteBuffer dst) {
-    // Reusable per-decode scratch buffer; sized for the worst case (bitWidth = elementBits).
     int elementSize = isLong ? Long.BYTES : Integer.BYTES;
-    byte[] packedBuf = new byte[elementSize * BLOCK_SIZE];
     int remainingValues = count;
     while (remainingValues > 0) {
       long baseline = isLong ? src.getLong() : src.getInt();
@@ -337,44 +321,50 @@ final class T64CodecDefinition implements ChunkCodecHandler<T64CodecDefinition.O
         }
       } else {
         int packedBytes = (bitWidth * BLOCK_SIZE + 7) / 8;
-        src.get(packedBuf, 0, packedBytes);
-        long bitCursor = 0;
-        if (isLong) {
-          for (int i = 0; i < blockCount; i++) {
-            long v = readBits(packedBuf, bitCursor, bitWidth) + baseline;
-            dst.putLong(v);
-            bitCursor += bitWidth;
-          }
-        } else {
-          for (int i = 0; i < blockCount; i++) {
-            int v = (int) (readBits(packedBuf, bitCursor, bitWidth) + baseline);
-            dst.putInt(v);
-            bitCursor += bitWidth;
-          }
+        if (packedBytes > src.remaining()) {
+          throw new IllegalStateException(
+              "T64: packed block requires " + packedBytes + " bytes but only " + src.remaining()
+                  + " remain. Segment may be corrupt.");
         }
-        // The encoder reserves fixed-width slots for the missing tail of a partial block and
-        // writes them as zero. Reject non-canonical non-zero tail slots rather than silently
-        // accepting alternate bytes for the same value sequence.
-        for (int i = blockCount; i < BLOCK_SIZE; i++) {
-          if (readBits(packedBuf, bitCursor, bitWidth) != 0) {
+        int packedOffset = src.position();
+        long bitCursor = 0;
+        int loadedWordIndex = -1;
+        long loadedWord = 0;
+        long valueMask = bitWidth == Long.SIZE ? -1L : (1L << bitWidth) - 1L;
+        for (int i = 0; i < BLOCK_SIZE; i++) {
+          int wordIndex = (int) (bitCursor >>> 6);
+          int bitInWord = (int) (bitCursor & 63);
+          if (loadedWordIndex != wordIndex) {
+            loadedWord = Long.reverseBytes(src.getLong(packedOffset + wordIndex * Long.BYTES));
+            loadedWordIndex = wordIndex;
+          }
+          long value = loadedWord >>> bitInWord;
+          if (bitInWord != 0 && bitWidth > Long.SIZE - bitInWord) {
+            loadedWordIndex++;
+            loadedWord = Long.reverseBytes(src.getLong(packedOffset + loadedWordIndex * Long.BYTES));
+            value |= loadedWord << (Long.SIZE - bitInWord);
+          }
+          value &= valueMask;
+          if (i < blockCount) {
+            if (isLong) {
+              dst.putLong(value + baseline);
+            } else {
+              dst.putInt((int) (value + baseline));
+            }
+          } else if (value != 0) {
+            // The encoder reserves fixed-width slots for the missing tail of a partial block and
+            // writes them as zero. Reject non-canonical non-zero tail slots rather than silently
+            // accepting alternate bytes for the same value sequence.
             throw new IllegalStateException(
                 "T64: non-zero padding slot in final block. Segment may be corrupt.");
           }
           bitCursor += bitWidth;
         }
+        src.position(packedOffset + packedBytes);
       }
       remainingValues -= blockCount;
     }
     ensureFullyConsumed(src);
-  }
-
-  private static int decodedSize(int count, int elementSize) {
-    long decodedSize = (long) count * elementSize;
-    if (decodedSize > Integer.MAX_VALUE) {
-      throw new IllegalStateException(
-          "T64: decoded size " + decodedSize + " exceeds Integer.MAX_VALUE. Segment may be corrupt.");
-    }
-    return (int) decodedSize;
   }
 
   private static void ensureFullyConsumed(ByteBuffer src) {
@@ -407,28 +397,5 @@ final class T64CodecDefinition implements ChunkCodecHandler<T64CodecDefinition.O
       valueShift += take;
       bitsRemaining -= take;
     }
-  }
-
-  /// Read `bitWidth` bits from `buf` starting at `bitOffset`.
-  private static long readBits(byte[] buf, long bitOffset, int bitWidth) {
-    long byteIndex = bitOffset >>> 3;
-    int bitInByte = (int) (bitOffset & 7);
-    long out = 0L;
-    int shift = 0;
-    int bitsRemaining = bitWidth;
-    int idx = (int) byteIndex;
-    while (bitsRemaining > 0) {
-      long b = ((long) buf[idx]) & 0xFFL;
-      int available = 8 - bitInByte;
-      int take = Math.min(available, bitsRemaining);
-      // `take` is in [1..8] (bounded by `available`), so a byte-sized mask always suffices.
-      long mask = (1L << take) - 1L;
-      out |= ((b >>> bitInByte) & mask) << shift;
-      shift += take;
-      bitsRemaining -= take;
-      idx++;
-      bitInByte = 0;
-    }
-    return out;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/ZstdCodecDefinition.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/ZstdCodecDefinition.java
@@ -132,72 +132,40 @@ final class ZstdCodecDefinition implements ChunkCodecHandler<ZstdCodecDefinition
   }
 
   @Override
-  public ByteBuffer encode(Options options, CodecContext ctx, ByteBuffer src) throws IOException {
+  public void encode(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) throws IOException {
+    if (!dst.isDirect()) {
+      throw new IllegalArgumentException("Zstd encode requires a direct destination buffer");
+    }
+    dst.clear();
     ByteBuffer directSrc = CodecBufferUtils.toDirectBuffer(src);
-    ByteBuffer out = null;
-    boolean succeeded = false;
     try {
       long bound = Zstd.compressBound(directSrc.remaining());
       if (bound > Integer.MAX_VALUE) {
         throw new IOException("Zstd compressBound " + bound + " exceeds Integer.MAX_VALUE for input of "
             + directSrc.remaining() + " bytes");
       }
-      out = ByteBuffer.allocateDirect((int) bound);
-      long result = Zstd.compress(out, directSrc, options.getLevel());
+      if (bound > dst.capacity()) {
+        throw new IllegalArgumentException(
+            "Zstd: encoded size bound " + bound + " exceeds dst capacity " + dst.capacity());
+      }
+      long result = Zstd.compress(dst, directSrc, options.getLevel());
       if (Zstd.isError(result)) {
         throw new IOException("Zstd compression failed: " + Zstd.getErrorName(result));
       }
-      out.flip();
-      succeeded = true;
-      return out;
+      dst.position(0);
+      dst.limit((int) result);
     } finally {
       CodecBufferUtils.cleanDirectCopy(src, directSrc);
-      if (!succeeded) {
-        CodecBufferUtils.cleanQuietly(out);
-      }
     }
   }
 
   @Override
-  public ByteBuffer decode(Options options, CodecContext ctx, ByteBuffer src) throws IOException {
-    ByteBuffer directSrc = CodecBufferUtils.toDirectBuffer(src);
-    ByteBuffer out = null;
-    boolean succeeded = false;
-    try {
-      long decompressedSize = Zstd.getFrameContentSize(directSrc);
-      // Zstd uses negative sentinel values for an unknown or invalid content size. Zero is a known,
-      // valid content size for an empty frame and must be allowed through to decompression.
-      if (decompressedSize < 0) {
-        throw new IOException("Zstd: cannot determine decompressed size from frame header");
-      }
-      out = ByteBuffer.allocateDirect(
-          CodecBufferUtils.checkDeclaredDecompressedSize(decompressedSize, "Zstd", "frame header"));
-      long result = Zstd.decompress(out, directSrc);
-      if (Zstd.isError(result)) {
-        throw new IOException("Zstd decompression failed: " + Zstd.getErrorName(result));
-      }
-      if (result != decompressedSize) {
-        throw new IOException("Zstd decoded " + result + " bytes but frame declared " + decompressedSize
-            + ". Segment may be corrupt.");
-      }
-      out.flip();
-      succeeded = true;
-      return out;
-    } finally {
-      CodecBufferUtils.cleanDirectCopy(src, directSrc);
-      if (!succeeded) {
-        CodecBufferUtils.cleanQuietly(out);
-      }
-    }
-  }
-
-  @Override
-  public void decodeInto(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) throws IOException {
+  public void decode(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) throws IOException {
     dst.clear();
     ByteBuffer directSrc = CodecBufferUtils.toDirectBuffer(src);
     try {
       long declaredDecompressedSize = Zstd.getFrameContentSize(directSrc);
-      // As in decode(), zero is a valid known size; only Zstd's negative sentinel values are errors.
+      // Zero is a valid known size; only Zstd's negative sentinel values are errors.
       if (declaredDecompressedSize < 0) {
         throw new IOException("Zstd: cannot determine decompressed size from frame header");
       }
@@ -222,7 +190,7 @@ final class ZstdCodecDefinition implements ChunkCodecHandler<ZstdCodecDefinition
   }
 
   @Override
-  public int maxEncodedSize(Options options, int inputSize) {
+  public int maxEncodedSize(Options options, CodecContext ctx, int inputSize) {
     long bound = Zstd.compressBound(inputSize);
     if (bound > Integer.MAX_VALUE) {
       throw new IllegalArgumentException(
@@ -232,7 +200,7 @@ final class ZstdCodecDefinition implements ChunkCodecHandler<ZstdCodecDefinition
   }
 
   @Override
-  public boolean requiresDirectDstBuffer() {
+  public boolean requiresDirectDecodeDstBuffer() {
     return true;
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/ChunkCodecHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/ChunkCodecHandlerTest.java
@@ -1,0 +1,222 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.io.codec;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.pinot.segment.spi.memory.CleanerUtil;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+
+/// Real-codec coverage of caller-owned destinations, independent of the forward-index format.
+public class ChunkCodecHandlerTest {
+  private enum SourceKind {
+    HEAP, DIRECT, DIRECT_SLICE
+  }
+
+  @DataProvider(name = "codecs")
+  public Object[][] codecs() {
+    return new Object[][]{
+        {Lz4CodecDefinition.INSTANCE, Lz4CodecDefinition.OPTIONS, DataType.BYTES},
+        {SnappyCodecDefinition.INSTANCE, SnappyCodecDefinition.OPTIONS, DataType.BYTES},
+        {GzipCodecDefinition.INSTANCE, GzipCodecDefinition.OPTIONS, DataType.BYTES},
+        {ZstdCodecDefinition.INSTANCE, ZstdCodecDefinition.INSTANCE.parseOptions(List.of()), DataType.BYTES},
+        {ZstdCodecDefinition.INSTANCE, ZstdCodecDefinition.INSTANCE.parseOptions(List.of("1")), DataType.BYTES},
+        {DeltaCodecDefinition.INSTANCE, DeltaCodecDefinition.OPTIONS, DataType.INT},
+        {DeltaCodecDefinition.INSTANCE, DeltaCodecDefinition.OPTIONS, DataType.LONG},
+        {DeltaDeltaCodecDefinition.INSTANCE, DeltaDeltaCodecDefinition.OPTIONS, DataType.INT},
+        {DeltaDeltaCodecDefinition.INSTANCE, DeltaDeltaCodecDefinition.OPTIONS, DataType.LONG},
+        {T64CodecDefinition.INSTANCE, T64CodecDefinition.OPTIONS, DataType.INT},
+        {T64CodecDefinition.INSTANCE, T64CodecDefinition.OPTIONS, DataType.LONG},
+        {GorillaCodecDefinition.INSTANCE, GorillaCodecDefinition.OPTIONS, DataType.INT},
+        {GorillaCodecDefinition.INSTANCE, GorillaCodecDefinition.OPTIONS, DataType.LONG}
+    };
+  }
+
+  @Test(dataProvider = "codecs")
+  public <O extends CodecOptions> void testCallerDestinationContract(ChunkCodecHandler<O> codec, O options,
+      DataType dataType) throws IOException {
+    CodecContext context = new CodecContext(dataType);
+    byte[] input = input(dataType);
+    int bound = codec.maxEncodedSize(options, context, input.length);
+    for (SourceKind kind : SourceKind.values()) {
+      ByteBuffer sourceOwner = kind == SourceKind.HEAP ? ByteBuffer.allocate(bound + input.length + 7)
+          : ByteBuffer.allocateDirect(bound + input.length + 7);
+      try (GuardedDestination encoded = new GuardedDestination(bound);
+          GuardedDestination decoded = new GuardedDestination(input.length)) {
+        // Reuse the same destinations for a full chunk, an empty chunk, and a single value.
+        for (int length : new int[]{input.length, 0, dataType == DataType.BYTES ? 1 : dataType.size()}) {
+          byte[] expected = Arrays.copyOf(input, length);
+          ByteBuffer source = source(sourceOwner, ByteBuffer.wrap(expected), kind);
+          encoded.dirty();
+          codec.encode(options, context, source, encoded._view);
+          assertEquals(encoded._view.position(), 0, codec.name());
+          assertTrue(encoded._view.remaining() <= codec.maxEncodedSize(options, context, length), codec.name());
+          encoded.assertGuards();
+
+          source = source(sourceOwner, encoded._view, kind);
+          decoded.dirty();
+          codec.decode(options, context, source, decoded._view);
+          assertBytes(decoded._view, expected);
+          decoded.assertGuards();
+        }
+      } finally {
+        CleanerUtil.cleanQuietly(sourceOwner);
+      }
+    }
+  }
+
+  @Test(dataProvider = "codecs")
+  public <O extends CodecOptions> void testRejectsUndersizedDestinationsAndRecovers(ChunkCodecHandler<O> codec,
+      O options, DataType dataType) throws IOException {
+    CodecContext context = new CodecContext(dataType);
+    byte[] input = input(dataType);
+    try (GuardedDestination encoded = new GuardedDestination(codec.maxEncodedSize(options, context, input.length));
+        GuardedDestination noSpace = new GuardedDestination(0);
+        GuardedDestination shortDecoded = new GuardedDestination(input.length - 1);
+        GuardedDestination decoded = new GuardedDestination(input.length)) {
+      IllegalArgumentException encodeFailure = expectThrows(IllegalArgumentException.class,
+          () -> codec.encode(options, context, ByteBuffer.wrap(input), noSpace._view));
+      assertTrue(encodeFailure.getMessage().contains("capacity"), encodeFailure.getMessage());
+      noSpace.assertGuards();
+      codec.encode(options, context, ByteBuffer.wrap(input), encoded._view);
+
+      IllegalArgumentException decodeFailure = expectThrows(IllegalArgumentException.class,
+          () -> codec.decode(options, context, encoded._view.duplicate(), shortDecoded._view));
+      assertTrue(decodeFailure.getMessage().contains("capacity"), decodeFailure.getMessage());
+      shortDecoded.assertGuards();
+      codec.decode(options, context, encoded._view.duplicate(), decoded._view);
+      assertBytes(decoded._view, input);
+      encoded.assertGuards();
+      decoded.assertGuards();
+    }
+  }
+
+  @Test(dataProvider = "codecs")
+  public <O extends CodecOptions> void testHeapDestinationRequirements(ChunkCodecHandler<O> codec, O options,
+      DataType dataType) throws IOException {
+    CodecContext context = new CodecContext(dataType);
+    byte[] input = input(dataType);
+    int bound = codec.maxEncodedSize(options, context, input.length);
+    ByteBuffer heapEncoded = ByteBuffer.allocate(bound);
+    // Encoding and decoding have different requirements: LZ4 can decode into heap memory.
+    boolean directEncode = codec instanceof Lz4CodecDefinition || codec instanceof SnappyCodecDefinition
+        || codec instanceof ZstdCodecDefinition;
+    if (directEncode) {
+      IllegalArgumentException failure = expectThrows(IllegalArgumentException.class,
+          () -> codec.encode(options, context, ByteBuffer.wrap(input), heapEncoded));
+      assertTrue(failure.getMessage().contains("direct"), failure.getMessage());
+    } else {
+      codec.encode(options, context, ByteBuffer.wrap(input), heapEncoded);
+      ByteBuffer heapDecoded = ByteBuffer.allocate(input.length);
+      codec.decode(options, context, heapEncoded, heapDecoded);
+      assertBytes(heapDecoded, input);
+    }
+
+    try (GuardedDestination encoded = new GuardedDestination(bound)) {
+      codec.encode(options, context, ByteBuffer.wrap(input), encoded._view);
+      ByteBuffer heapDecoded = ByteBuffer.allocate(input.length);
+      // Native-only decoders require callers to supply direct buffers; the executor validates that precondition.
+      if (!codec.requiresDirectDecodeDstBuffer()) {
+        codec.decode(options, context, encoded._view, heapDecoded);
+        assertBytes(heapDecoded, input);
+      }
+    }
+  }
+
+  private static byte[] input(DataType dataType) {
+    if (dataType == DataType.BYTES) {
+      byte[] input = new byte[257];
+      for (int i = 0; i < input.length; i++) {
+        input[i] = (byte) ((i * 31) ^ (i >>> 3));
+      }
+      return input;
+    }
+    ByteBuffer input = ByteBuffer.allocate(65 * dataType.size());
+    long[] values = dataType == DataType.INT ? new long[]{Integer.MIN_VALUE, Integer.MAX_VALUE, -1, 0, 1}
+        : new long[]{Long.MIN_VALUE, Long.MAX_VALUE, -1, 0, 1};
+    for (int i = 0; i < 65; i++) {
+      if (dataType == DataType.INT) {
+        input.putInt((int) values[i % values.length]);
+      } else {
+        input.putLong(values[i % values.length]);
+      }
+    }
+    return input.array();
+  }
+
+  private static ByteBuffer source(ByteBuffer owner, ByteBuffer bytes, SourceKind kind) {
+    int offset = kind == SourceKind.DIRECT_SLICE ? 7 : 0;
+    owner.clear().position(offset);
+    owner.put(bytes.duplicate()).flip().position(offset);
+    return (kind == SourceKind.DIRECT_SLICE ? owner.slice() : owner).order(ByteOrder.LITTLE_ENDIAN);
+  }
+
+  private static void assertBytes(ByteBuffer actual, byte[] expected) {
+    assertEquals(actual.position(), 0);
+    assertEquals(actual.limit(), expected.length);
+    byte[] bytes = new byte[actual.remaining()];
+    actual.duplicate().get(bytes);
+    assertEquals(bytes, expected);
+  }
+
+  /// Owns the direct allocation; only the guarded slice is passed to the codec.
+  private static final class GuardedDestination implements AutoCloseable {
+    private static final int GUARD_SIZE = 7;
+    private static final byte SENTINEL = (byte) 0xA5;
+    private final ByteBuffer _owner;
+    private final ByteBuffer _view;
+
+    private GuardedDestination(int capacity) {
+      _owner = ByteBuffer.allocateDirect(capacity + 2 * GUARD_SIZE);
+      while (_owner.hasRemaining()) {
+        _owner.put(SENTINEL);
+      }
+      ByteBuffer view = _owner.duplicate().clear();
+      view.position(GUARD_SIZE).limit(GUARD_SIZE + capacity);
+      _view = view.slice();
+    }
+
+    private void dirty() {
+      _view.clear().limit(Math.min(1, _view.capacity()));
+      _view.position(_view.limit());
+    }
+
+    private void assertGuards() {
+      for (int i = 0; i < GUARD_SIZE; i++) {
+        assertEquals(_owner.get(i), SENTINEL, "prefix guard");
+        assertEquals(_owner.get(_owner.capacity() - 1 - i), SENTINEL, "suffix guard");
+      }
+    }
+
+    @Override
+    public void close() {
+      CleanerUtil.cleanQuietly(_owner);
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecPipelineExecutorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecPipelineExecutorTest.java
@@ -23,11 +23,20 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.segment.spi.memory.CleanerUtil;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.segment.local.io.codec.CodecTestUtils.encode;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertThrows;
@@ -38,6 +47,8 @@ import static org.testng.Assert.expectThrows;
 /// Format-independent round-trip and resource-bound tests for [CodecPipelineExecutor].
 public class CodecPipelineExecutorTest {
   private static final byte[] INPUT = createInput();
+  private static final int MAX_STAGE_SIZE = 1024 * 1024;
+  private static final long MAX_WORK_SIZE = 32L * MAX_STAGE_SIZE;
 
   @DataProvider(name = "singleCodecAndInputKind")
   public Object[][] singleCodecAndInputKind() {
@@ -53,51 +64,203 @@ public class CodecPipelineExecutorTest {
   @Test(dataProvider = "singleCodecAndInputKind")
   public void testSingleCodecRoundTrip(String spec, boolean directInput) throws Exception {
     CodecPipelineExecutor executor = CodecPipelineExecutor.create(spec, DataType.BYTES);
-    ByteBuffer encoded = executor.encode(inputBuffer(directInput));
-
-    assertTrue(encoded.remaining() <= executor.maxEncodedSize(INPUT.length));
-    assertBytesEqual(executor.decode(encoded.duplicate()));
-
-    ByteBuffer destination = ByteBuffer.allocateDirect(INPUT.length);
-    int maxIntermediateSize = executor.maxEncodedSize(INPUT.length);
-    executor.decode(encoded.duplicate(), destination, INPUT.length, maxIntermediateSize,
-        (long) maxIntermediateSize * 32);
-    assertBytesEqual(destination);
+    ByteBuffer input = inputBuffer(directInput);
+    try {
+      ByteBuffer encoded = encode(executor, input);
+      assertTrue(encoded.remaining() <= executor.maxEncodedSize(INPUT.length));
+      assertBytesEqual(decode(executor, encoded, INPUT.length));
+    } finally {
+      CleanerUtil.cleanQuietly(input);
+    }
   }
 
   @Test
   public void testMultiCompressionRoundTrips() throws Exception {
     for (String spec : new String[]{"LZ4,SNAPPY", "GZIP,ZSTD(5)", "SNAPPY,LZ4,GZIP"}) {
       CodecPipelineExecutor executor = CodecPipelineExecutor.create(spec, DataType.BYTES);
-      ByteBuffer encoded = executor.encode(inputBuffer(false));
-      assertBytesEqual(executor.decode(encoded.duplicate()));
-
-      ByteBuffer destination = ByteBuffer.allocateDirect(INPUT.length);
-      int maxIntermediateSize = executor.maxEncodedSize(INPUT.length);
-      executor.decode(encoded.duplicate(), destination, INPUT.length, maxIntermediateSize,
-          (long) maxIntermediateSize * 32);
-      assertBytesEqual(destination);
+      ByteBuffer encoded = encode(executor, inputBuffer(false));
+      assertBytesEqual(decode(executor, encoded, INPUT.length));
     }
   }
 
   @Test
   public void testCallerOwnedScratchReusesDirectBuffers()
       throws Exception {
-    CodecPipelineExecutor executor = CodecPipelineExecutor.create("LZ4,SNAPPY,GZIP", DataType.BYTES);
-    ByteBuffer encoded = executor.encode(inputBuffer(false));
-    int maxIntermediateSize = executor.maxEncodedSize(INPUT.length);
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create("LZ4,SNAPPY,GZIP,ZSTD", DataType.BYTES);
+    ByteBuffer encoded = encode(executor, inputBuffer(false));
+    int maxStageSize = executor.maxEncodedSize(INPUT.length);
+    ByteBuffer destination = ByteBuffer.allocateDirect(INPUT.length);
     try (CodecPipelineExecutor.DecodeScratch scratch = new CodecPipelineExecutor.DecodeScratch()) {
-      ByteBuffer firstDestination = ByteBuffer.allocateDirect(INPUT.length);
-      executor.decode(encoded.duplicate(), firstDestination, INPUT.length, maxIntermediateSize,
-          (long) maxIntermediateSize * 32, scratch);
-      assertBytesEqual(firstDestination);
+      executor.decode(encoded.duplicate(), destination, INPUT.length, maxStageSize,
+          (long) maxStageSize * 32, scratch);
+      assertBytesEqual(destination);
       assertEquals(scratch.allocationCount(), 2);
+      assertEquals(scratch.viewCreationCount(), 3);
 
-      ByteBuffer secondDestination = ByteBuffer.allocateDirect(INPUT.length);
-      executor.decode(encoded.duplicate(), secondDestination, INPUT.length, maxIntermediateSize,
-          (long) maxIntermediateSize * 32, scratch);
-      assertBytesEqual(secondDestination);
+      executor.decode(encoded.duplicate(), destination, INPUT.length, maxStageSize,
+          (long) maxStageSize * 32, scratch);
+      assertBytesEqual(destination);
       assertEquals(scratch.allocationCount(), 2, "Repeated decode must reuse both ping-pong buffers");
+      assertEquals(scratch.viewCreationCount(), 3, "Repeated decode must reuse stage-bounded views");
+    } finally {
+      CleanerUtil.cleanQuietly(destination);
+    }
+  }
+
+  @Test
+  public void testCallerOwnedEncodeScratchReusesDirectBuffers() throws Exception {
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create(
+        "DELTA,DELTADELTA,T64,LZ4,SNAPPY,GZIP,ZSTD", DataType.INT);
+    int maxStageSize = executor.maxEncodedSize(INPUT.length);
+    try (CodecPipelineExecutor.EncodeScratch scratch = new CodecPipelineExecutor.EncodeScratch()) {
+      ByteBuffer firstInput = inputBuffer(false);
+      ByteBuffer firstEncoded = executor.encode(firstInput, maxStageSize, (long) maxStageSize * 32, scratch);
+      assertEquals(firstInput.position(), 0, "encode must not consume the caller's input view");
+      assertBytesEqual(decode(executor, firstEncoded.duplicate(), INPUT.length));
+      assertEquals(scratch.allocationCount(), 2);
+      assertEquals(scratch.viewCreationCount(), 8);
+
+      ByteBuffer secondEncoded = executor.encode(firstInput, maxStageSize,
+          (long) maxStageSize * 32, scratch);
+      assertBytesEqual(decode(executor, secondEncoded.duplicate(), INPUT.length));
+      assertEquals(scratch.allocationCount(), 2, "Repeated encode must reuse both ping-pong buffers");
+      assertEquals(scratch.viewCreationCount(), 8, "Repeated encode must reuse source and stage-bounded views");
+    }
+  }
+
+  @Test
+  public void testEncodeScratchResetsReturnedViewByteOrder() throws Exception {
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create("DELTA", DataType.INT);
+    ByteBuffer input = inputBuffer(false);
+    try (CodecPipelineExecutor.EncodeScratch scratch = new CodecPipelineExecutor.EncodeScratch()) {
+      ByteBuffer firstEncoded = executor.encode(input, INPUT.length, INPUT.length, scratch);
+      firstEncoded.order(ByteOrder.LITTLE_ENDIAN);
+
+      ByteBuffer secondEncoded = executor.encode(input, INPUT.length, INPUT.length, scratch);
+      assertEquals(secondEncoded.order(), ByteOrder.BIG_ENDIAN);
+      assertBytesEqual(decode(executor, secondEncoded.duplicate(), INPUT.length));
+      assertEquals(scratch.allocationCount(), 1);
+      assertEquals(scratch.viewCreationCount(), 2);
+    }
+  }
+
+  @Test
+  public void testEncodeScratchRefreshesCachedSourceWindow() throws Exception {
+    byte[] firstWindow = INPUT.clone();
+    for (int i = 0; i < firstWindow.length; i++) {
+      firstWindow[i] ^= 0x5A;
+    }
+    ByteBuffer source = ByteBuffer.allocateDirect(INPUT.length * 2).order(ByteOrder.LITTLE_ENDIAN);
+    source.put(firstWindow).put(INPUT).flip();
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create("DELTA,T64,LZ4", DataType.INT);
+    try (CodecPipelineExecutor.EncodeScratch scratch = new CodecPipelineExecutor.EncodeScratch()) {
+      source.position(INPUT.length).limit(INPUT.length * 2);
+      ByteBuffer secondEncoded = executor.encode(source, MAX_STAGE_SIZE, MAX_WORK_SIZE, scratch);
+      assertBytesEqual(decode(executor, secondEncoded.duplicate(), INPUT.length), INPUT);
+      assertEquals(source.position(), INPUT.length);
+      assertEquals(source.limit(), INPUT.length * 2);
+      assertEquals(source.order(), ByteOrder.LITTLE_ENDIAN);
+      int warmViewCount = scratch.viewCreationCount();
+
+      source.limit(INPUT.length).position(0);
+      ByteBuffer firstEncoded = executor.encode(source, MAX_STAGE_SIZE, MAX_WORK_SIZE, scratch);
+      assertBytesEqual(decode(executor, firstEncoded.duplicate(), INPUT.length), firstWindow);
+      assertEquals(source.position(), 0);
+      assertEquals(source.limit(), INPUT.length);
+      assertEquals(source.order(), ByteOrder.LITTLE_ENDIAN);
+      assertEquals(scratch.viewCreationCount(), warmViewCount,
+          "Moving the same source view must refresh its window without creating another view");
+    } finally {
+      CleanerUtil.cleanQuietly(source);
+    }
+  }
+
+  @Test
+  public void testScratchGrowsShrinksAndReplacesDestination() throws Exception {
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create("LZ4,SNAPPY,GZIP,ZSTD", DataType.BYTES);
+    ByteBuffer destination = ByteBuffer.allocateDirect(INPUT.length).order(ByteOrder.LITTLE_ENDIAN);
+    ByteBuffer replacement = ByteBuffer.allocateDirect(INPUT.length).order(ByteOrder.LITTLE_ENDIAN);
+    int[] sizes = {32, INPUT.length, 32, 32};
+    try (CodecPipelineExecutor.EncodeScratch encodeScratch = new CodecPipelineExecutor.EncodeScratch();
+        CodecPipelineExecutor.DecodeScratch decodeScratch = new CodecPipelineExecutor.DecodeScratch()) {
+      for (int i = 0; i < sizes.length; i++) {
+        byte[] expected = Arrays.copyOf(INPUT, sizes[i]);
+        ByteBuffer source = ByteBuffer.allocate(sizes[i] + 4);
+        source.position(4);
+        source.put(expected).flip().position(4).order(ByteOrder.LITTLE_ENDIAN);
+        ByteBuffer encoded = executor.encode(source, MAX_STAGE_SIZE, MAX_WORK_SIZE, encodeScratch);
+        assertEquals(source.position(), 4);
+        assertEquals(source.limit(), sizes[i] + 4);
+        assertEquals(source.order(), ByteOrder.LITTLE_ENDIAN);
+
+        ByteBuffer output = i == sizes.length - 1 ? replacement : destination;
+        int previousViewCount = decodeScratch.viewCreationCount();
+        executor.decode(encoded, output, sizes[i], MAX_STAGE_SIZE, MAX_WORK_SIZE, decodeScratch);
+        assertBytesEqual(output, expected);
+        assertEquals(output.order(), ByteOrder.LITTLE_ENDIAN);
+        assertEquals(encodeScratch.allocationCount(), i == 0 ? 2 : 4);
+        assertEquals(decodeScratch.allocationCount(), i == 0 ? 2 : 4);
+        if (i == sizes.length - 1) {
+          assertEquals(decodeScratch.viewCreationCount(), previousViewCount,
+              "Replacing the final destination must not recreate unchanged intermediate views");
+        }
+      }
+    } finally {
+      CleanerUtil.cleanQuietly(destination);
+      CleanerUtil.cleanQuietly(replacement);
+    }
+  }
+
+  @Test
+  public void testWarmLargeScratchRejectsSmallCorruptInnerFrame() throws Exception {
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create("GZIP,GZIP", DataType.BYTES);
+    byte[] smallInput = new byte[32];
+    ByteBuffer smallEncoded = encode(executor, ByteBuffer.wrap(smallInput));
+    ByteBuffer corrupt = ByteBuffer.allocate(smallEncoded.remaining()).put(smallEncoded.duplicate()).flip();
+    int smallIntermediateBound = CodecPipelineExecutor.create("GZIP", DataType.BYTES)
+        .maxEncodedSize(smallInput.length);
+    // The outer GZIP footer controls an intermediate output, not the final destination size.
+    corrupt.putInt(corrupt.limit() - Integer.BYTES, smallIntermediateBound + 1);
+    ByteBuffer destination = ByteBuffer.allocateDirect(INPUT.length);
+    try (CodecPipelineExecutor.DecodeScratch scratch = new CodecPipelineExecutor.DecodeScratch()) {
+      executor.decode(encode(executor, inputBuffer(false)), destination, INPUT.length, MAX_STAGE_SIZE, MAX_WORK_SIZE,
+          scratch);
+      assertBytesEqual(destination);
+      assertEquals(scratch.allocationCount(), 1);
+
+      IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+          () -> executor.decode(corrupt, destination, smallInput.length, MAX_STAGE_SIZE, MAX_WORK_SIZE, scratch));
+      assertTrue(exception.getMessage().contains("exceeds dst capacity " + smallIntermediateBound),
+          exception.getMessage());
+      assertEquals(scratch.allocationCount(), 1, "A corrupt frame must not grow a warm workspace");
+      executor.decode(smallEncoded, destination, smallInput.length, MAX_STAGE_SIZE, MAX_WORK_SIZE, scratch);
+      assertBytesEqual(destination, smallInput);
+      assertEquals(scratch.allocationCount(), 1);
+    } finally {
+      CleanerUtil.cleanQuietly(destination);
+    }
+  }
+
+  @Test
+  public void testScratchCloseIsIdempotentAndRejectsReuse() throws Exception {
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create("LZ4,GZIP", DataType.BYTES);
+    ByteBuffer destination = ByteBuffer.allocateDirect(INPUT.length);
+    try (CodecPipelineExecutor.EncodeScratch encodeScratch = new CodecPipelineExecutor.EncodeScratch();
+        CodecPipelineExecutor.DecodeScratch decodeScratch = new CodecPipelineExecutor.DecodeScratch()) {
+      ByteBuffer encoded = executor.encode(inputBuffer(false), MAX_STAGE_SIZE, MAX_WORK_SIZE, encodeScratch);
+      executor.decode(encoded, destination, INPUT.length, MAX_STAGE_SIZE, MAX_WORK_SIZE, decodeScratch);
+      assertBytesEqual(destination);
+      encodeScratch.close();
+      encodeScratch.close();
+      decodeScratch.close();
+      decodeScratch.close();
+      assertThrows(IllegalStateException.class,
+          () -> executor.encode(inputBuffer(false), MAX_STAGE_SIZE, MAX_WORK_SIZE, encodeScratch));
+      assertThrows(IllegalStateException.class,
+          () -> executor.decode(ByteBuffer.allocate(0), destination, INPUT.length, MAX_STAGE_SIZE, MAX_WORK_SIZE,
+              decodeScratch));
+    } finally {
+      CleanerUtil.cleanQuietly(destination);
     }
   }
 
@@ -112,6 +275,96 @@ public class CodecPipelineExecutorTest {
         "ZSTD(5),GZIP");
     assertEquals(CodecPipelineExecutor.create("lz4,snappy", DataType.INT).getCanonicalSpec(),
         "LZ4,SNAPPY");
+  }
+
+  @Test(timeOut = 20_000)
+  public void testSharedExecutorWithWorkerOwnedScratch() throws Exception {
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create("LZ4,SNAPPY,GZIP,ZSTD", DataType.BYTES);
+    int workers = 3;
+    CountDownLatch ready = new CountDownLatch(workers);
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(workers);
+    List<Future<?>> futures = new ArrayList<>();
+    try {
+      for (int worker = 0; worker < workers; worker++) {
+        int workerId = worker;
+        futures.add(pool.submit(() -> {
+          ByteBuffer destination = ByteBuffer.allocateDirect(256);
+          try (CodecPipelineExecutor.EncodeScratch encodeScratch = new CodecPipelineExecutor.EncodeScratch();
+              CodecPipelineExecutor.DecodeScratch decodeScratch = new CodecPipelineExecutor.DecodeScratch()) {
+            ready.countDown();
+            assertTrue(start.await(5, TimeUnit.SECONDS), "Workers were not released");
+            for (int round = 0; round < 16; round++) {
+              byte[] expected = Arrays.copyOf(INPUT, 128 + 64 * (round & 1));
+              for (int i = 0; i < expected.length; i++) {
+                expected[i] ^= (byte) (workerId + round);
+              }
+              ByteBuffer encoded = executor.encode(ByteBuffer.wrap(expected), MAX_STAGE_SIZE, MAX_WORK_SIZE,
+                  encodeScratch);
+              executor.decode(encoded, destination, expected.length, MAX_STAGE_SIZE, MAX_WORK_SIZE, decodeScratch);
+              assertBytesEqual(destination, expected);
+            }
+          } finally {
+            CleanerUtil.cleanQuietly(destination);
+          }
+          return null;
+        }));
+      }
+      assertTrue(ready.await(5, TimeUnit.SECONDS), "Workers did not become ready");
+      start.countDown();
+      for (Future<?> future : futures) {
+        future.get(5, TimeUnit.SECONDS);
+      }
+    } finally {
+      start.countDown();
+      pool.shutdownNow();
+      assertTrue(pool.awaitTermination(5, TimeUnit.SECONDS), "Codec workers did not terminate");
+    }
+  }
+
+  @Test(timeOut = 20_000)
+  public void testSharedSourceWithWorkerOwnedScratch() throws Exception {
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create("DELTA,T64,LZ4", DataType.INT);
+    ByteBuffer source = ByteBuffer.allocateDirect(INPUT.length + 8).order(ByteOrder.LITTLE_ENDIAN);
+    source.position(4).put(INPUT).flip().position(4);
+    int workers = 4;
+    CountDownLatch ready = new CountDownLatch(workers);
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(workers);
+    List<Future<?>> futures = new ArrayList<>();
+    try {
+      for (int worker = 0; worker < workers; worker++) {
+        futures.add(pool.submit(() -> {
+          ByteBuffer destination = ByteBuffer.allocateDirect(INPUT.length);
+          try (CodecPipelineExecutor.EncodeScratch encodeScratch = new CodecPipelineExecutor.EncodeScratch();
+              CodecPipelineExecutor.DecodeScratch decodeScratch = new CodecPipelineExecutor.DecodeScratch()) {
+            ready.countDown();
+            assertTrue(start.await(5, TimeUnit.SECONDS), "Workers were not released");
+            for (int round = 0; round < 32; round++) {
+              ByteBuffer encoded = executor.encode(source, MAX_STAGE_SIZE, MAX_WORK_SIZE, encodeScratch);
+              executor.decode(encoded, destination, INPUT.length, MAX_STAGE_SIZE, MAX_WORK_SIZE, decodeScratch);
+              assertBytesEqual(destination);
+            }
+          } finally {
+            CleanerUtil.cleanQuietly(destination);
+          }
+          return null;
+        }));
+      }
+      assertTrue(ready.await(5, TimeUnit.SECONDS), "Workers did not become ready");
+      start.countDown();
+      for (Future<?> future : futures) {
+        future.get(10, TimeUnit.SECONDS);
+      }
+      assertEquals(source.position(), 4);
+      assertEquals(source.limit(), INPUT.length + 4);
+      assertEquals(source.order(), ByteOrder.LITTLE_ENDIAN);
+    } finally {
+      start.countDown();
+      pool.shutdownNow();
+      assertTrue(pool.awaitTermination(5, TimeUnit.SECONDS), "Codec workers did not terminate");
+      CleanerUtil.cleanQuietly(source);
+    }
   }
 
   @Test
@@ -135,9 +388,10 @@ public class CodecPipelineExecutorTest {
   public void testDirectDestinationRequirement() throws Exception {
     for (String spec : new String[]{"SNAPPY", "ZSTD", "SNAPPY,GZIP"}) {
       CodecPipelineExecutor executor = CodecPipelineExecutor.create(spec, DataType.BYTES);
-      ByteBuffer encoded = executor.encode(inputBuffer(false));
+      ByteBuffer encoded = encode(executor, inputBuffer(false));
       IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-          () -> executor.decode(encoded.duplicate(), ByteBuffer.allocate(INPUT.length), INPUT.length));
+          () -> decode(executor, encoded, ByteBuffer.allocate(INPUT.length), INPUT.length, MAX_STAGE_SIZE,
+              MAX_WORK_SIZE));
       assertTrue(exception.getMessage().contains("requires a direct ByteBuffer"), exception.getMessage());
     }
   }
@@ -146,9 +400,9 @@ public class CodecPipelineExecutorTest {
   public void testHeapDestinationWhenNoStageRequiresDirectBuffer() throws Exception {
     for (String spec : new String[]{"LZ4", "GZIP", "LZ4,GZIP", "GZIP,SNAPPY"}) {
       CodecPipelineExecutor executor = CodecPipelineExecutor.create(spec, DataType.BYTES);
-      ByteBuffer encoded = executor.encode(inputBuffer(true));
+      ByteBuffer encoded = encode(executor, inputBuffer(false));
       ByteBuffer destination = ByteBuffer.allocate(INPUT.length);
-      executor.decode(encoded.duplicate(), destination, INPUT.length, executor.maxEncodedSize(INPUT.length));
+      decode(executor, encoded, destination, INPUT.length, MAX_STAGE_SIZE, MAX_WORK_SIZE);
       assertBytesEqual(destination);
     }
   }
@@ -157,7 +411,7 @@ public class CodecPipelineExecutorTest {
   public void testComposedMaximumEncodedSizeBoundsActualOutput() throws Exception {
     CodecPipelineExecutor executor = CodecPipelineExecutor.create("LZ4,SNAPPY,GZIP,ZSTD", DataType.BYTES);
     int bound = executor.maxEncodedSize(INPUT.length);
-    ByteBuffer encoded = executor.encode(inputBuffer(true));
+    ByteBuffer encoded = encode(executor, inputBuffer(false));
     assertTrue(encoded.remaining() <= bound, encoded.remaining() + " > " + bound);
   }
 
@@ -178,34 +432,48 @@ public class CodecPipelineExecutorTest {
   }
 
   @Test
-  public void testDecodePerStageIntermediateCap() throws Exception {
+  public void testRejectedBoundsDoNotAllocateAndScratchCanRecover() throws Exception {
     CodecPipelineExecutor executor = CodecPipelineExecutor.create("LZ4,SNAPPY", DataType.BYTES);
-    ByteBuffer encoded = executor.encode(inputBuffer(false));
-    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-        () -> executor.decode(encoded.duplicate(), ByteBuffer.allocateDirect(INPUT.length), INPUT.length,
-            INPUT.length));
-    assertTrue(exception.getMessage().contains("maximum encoded size"), exception.getMessage());
-  }
+    ByteBuffer validEncoded = encode(executor, inputBuffer(false));
+    ByteBuffer destination = ByteBuffer.allocateDirect(INPUT.length);
+    try {
+      for (boolean cumulative : new boolean[]{false, true}) {
+        int stageLimit = cumulative ? MAX_STAGE_SIZE : INPUT.length;
+        long workLimit = cumulative ? INPUT.length : MAX_WORK_SIZE;
+        String expectedMessage = cumulative ? "cumulative stage-output bound" : "maximum encoded size";
+        try (CodecPipelineExecutor.EncodeScratch encodeScratch = new CodecPipelineExecutor.EncodeScratch();
+            CodecPipelineExecutor.DecodeScratch decodeScratch = new CodecPipelineExecutor.DecodeScratch()) {
+          IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+              () -> executor.encode(inputBuffer(false), stageLimit, workLimit, encodeScratch));
+          assertTrue(exception.getMessage().contains(expectedMessage), exception.getMessage());
+          assertEquals(encodeScratch.allocationCount(), 0);
+          exception = expectThrows(IllegalArgumentException.class,
+              () -> executor.decode(validEncoded.duplicate(), destination, INPUT.length, stageLimit, workLimit,
+                  decodeScratch));
+          assertTrue(exception.getMessage().contains(expectedMessage), exception.getMessage());
+          assertEquals(decodeScratch.allocationCount(), 0);
 
-  @Test
-  public void testDecodeCumulativeIntermediateCap() throws Exception {
-    CodecPipelineExecutor executor = CodecPipelineExecutor.create("LZ4,SNAPPY", DataType.BYTES);
-    ByteBuffer encoded = executor.encode(inputBuffer(false));
-    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-        () -> executor.decode(encoded.duplicate(), ByteBuffer.allocateDirect(INPUT.length), INPUT.length,
-            Integer.MAX_VALUE, INPUT.length));
-    assertTrue(exception.getMessage().contains("cumulative stage-output bound"), exception.getMessage());
+          ByteBuffer recovered = executor.encode(inputBuffer(false), MAX_STAGE_SIZE, MAX_WORK_SIZE, encodeScratch);
+          executor.decode(recovered, destination, INPUT.length, MAX_STAGE_SIZE, MAX_WORK_SIZE, decodeScratch);
+          assertBytesEqual(destination);
+          assertEquals(encodeScratch.allocationCount(), 2);
+          assertEquals(decodeScratch.allocationCount(), 1);
+        }
+      }
+    } finally {
+      CleanerUtil.cleanQuietly(destination);
+    }
   }
 
   @Test
   public void testDecodeRejectsUnexpectedFinalSize() throws Exception {
     CodecPipelineExecutor executor = CodecPipelineExecutor.create("GZIP", DataType.BYTES);
-    ByteBuffer encoded = executor.encode(inputBuffer(false));
+    ByteBuffer encoded = encode(executor, inputBuffer(false));
     int expectedDecodedSize = INPUT.length - 1;
-    int maxIntermediateSize = executor.maxEncodedSize(INPUT.length);
+    int maxStageSize = executor.maxEncodedSize(INPUT.length);
     IOException exception = expectThrows(IOException.class,
-        () -> executor.decode(encoded.duplicate(), ByteBuffer.allocate(INPUT.length), expectedDecodedSize,
-            maxIntermediateSize, Long.MAX_VALUE));
+        () -> decode(executor, encoded.duplicate(), ByteBuffer.allocate(INPUT.length), expectedDecodedSize,
+            maxStageSize, Long.MAX_VALUE));
     assertTrue(exception.getMessage().contains("but expected " + expectedDecodedSize), exception.getMessage());
   }
 
@@ -217,11 +485,18 @@ public class CodecPipelineExecutorTest {
         () -> executor.maxEncodedSize(INPUT.length, INPUT.length - 1));
     assertThrows(IllegalArgumentException.class,
         () -> executor.maxEncodedSize(INPUT.length, Integer.MAX_VALUE, INPUT.length - 1L));
+    try (CodecPipelineExecutor.DecodeScratch scratch = new CodecPipelineExecutor.DecodeScratch()) {
+      IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+          () -> executor.decode(ByteBuffer.allocate(0), ByteBuffer.allocate(INPUT.length), INPUT.length,
+              INPUT.length - 1, Long.MAX_VALUE, scratch));
+      assertTrue(exception.getMessage().contains("maxStageSize"), exception.getMessage());
+    }
   }
 
   @Test
   public void testPublicRuntimeSurfaceIsBounded() throws ReflectiveOperationException {
     assertTrue(Modifier.isPublic(CodecPipelineExecutor.class.getModifiers()));
+    assertTrue(Modifier.isPublic(CodecPipelineExecutor.EncodeScratch.class.getModifiers()));
     assertTrue(Modifier.isPublic(CodecPipelineExecutor.DecodeScratch.class.getModifiers()));
     for (Class<?> closedType : new Class<?>[]{
         ChunkCodecHandler.class, CodecContext.class, CodecDefinition.class, CodecKind.class, CodecOptions.class,
@@ -235,11 +510,17 @@ public class CodecPipelineExecutorTest {
     Method testFactory = CodecPipelineExecutor.class.getDeclaredMethod(
         "create", String.class, CodecContext.class, CodecRegistry.class);
     assertFalse(Modifier.isPublic(testFactory.getModifiers()));
-    Method allocationReturningDecode = CodecPipelineExecutor.class.getDeclaredMethod("decode", ByteBuffer.class);
-    assertFalse(Modifier.isPublic(allocationReturningDecode.getModifiers()));
-    Method boundedDecode = CodecPipelineExecutor.class.getDeclaredMethod("decode", ByteBuffer.class,
-        ByteBuffer.class, int.class, int.class, long.class);
-    assertFalse(Modifier.isPublic(boundedDecode.getModifiers()));
+    assertThrows(NoSuchMethodException.class,
+        () -> CodecPipelineExecutor.class.getDeclaredMethod("encode", ByteBuffer.class));
+    assertThrows(NoSuchMethodException.class,
+        () -> CodecPipelineExecutor.class.getDeclaredMethod("decode", ByteBuffer.class));
+    Method reusableBoundedEncode = CodecPipelineExecutor.class.getDeclaredMethod("encode", ByteBuffer.class,
+        int.class, long.class, CodecPipelineExecutor.EncodeScratch.class);
+    assertTrue(Modifier.isPublic(reusableBoundedEncode.getModifiers()));
+    assertEquals(Arrays.stream(CodecPipelineExecutor.class.getDeclaredMethods())
+        .filter(method -> method.getName().equals("encode")).count(), 1L);
+    assertEquals(Arrays.stream(CodecPipelineExecutor.class.getDeclaredMethods())
+        .filter(method -> method.getName().equals("decode")).count(), 1L);
     Method reusableBoundedDecode = CodecPipelineExecutor.class.getDeclaredMethod("decode", ByteBuffer.class,
         ByteBuffer.class, int.class, int.class, long.class, CodecPipelineExecutor.DecodeScratch.class);
     assertTrue(Modifier.isPublic(reusableBoundedDecode.getModifiers()));
@@ -250,44 +531,60 @@ public class CodecPipelineExecutorTest {
     return buffer.put(INPUT).flip();
   }
 
+  private static ByteBuffer decode(CodecPipelineExecutor executor, ByteBuffer encoded, int decodedSize)
+      throws IOException {
+    ByteBuffer destination = ByteBuffer.allocateDirect(decodedSize);
+    try {
+      decode(executor, encoded, destination, decodedSize, MAX_STAGE_SIZE, MAX_WORK_SIZE);
+      return ByteBuffer.allocate(decodedSize).put(destination).flip();
+    } finally {
+      CleanerUtil.cleanQuietly(destination);
+    }
+  }
+
+  private static void decode(CodecPipelineExecutor executor, ByteBuffer encoded, ByteBuffer destination,
+      int decodedSize, int maxStageSize, long maxWorkSize) throws IOException {
+    try (CodecPipelineExecutor.DecodeScratch scratch = new CodecPipelineExecutor.DecodeScratch()) {
+      executor.decode(encoded, destination, decodedSize, maxStageSize, maxWorkSize, scratch);
+    }
+  }
+
   private static void assertTypedTransformIgnoresCallerByteOrder(String spec, DataType dataType, long[] values)
       throws Exception {
     int decodedSize = values.length * dataType.size();
     ByteBuffer canonicalInput = ByteBuffer.allocateDirect(decodedSize).order(ByteOrder.BIG_ENDIAN);
-    for (long value : values) {
-      if (dataType == DataType.INT) {
-        canonicalInput.putInt((int) value);
-      } else {
-        canonicalInput.putLong(value);
-      }
-    }
-    canonicalInput.flip();
-
-    CodecPipelineExecutor executor = CodecPipelineExecutor.create(spec, dataType);
-    int maxIntermediateSize = Math.max(decodedSize, executor.maxEncodedSize(decodedSize));
-
-    // A LITTLE_ENDIAN input view must still be interpreted as persisted big-endian typed words.
-    ByteBuffer littleEndianInput = canonicalInput.duplicate().order(ByteOrder.LITTLE_ENDIAN);
-    ByteBuffer encodedFromLittleEndian = executor.encode(littleEndianInput);
-    assertEquals(littleEndianInput.position(), 0, "encode must not consume the caller's input view");
-    assertEquals(littleEndianInput.order(), ByteOrder.LITTLE_ENDIAN);
     ByteBuffer bigEndianDestination = ByteBuffer.allocateDirect(decodedSize).order(ByteOrder.BIG_ENDIAN);
-    try (CodecPipelineExecutor.DecodeScratch scratch = new CodecPipelineExecutor.DecodeScratch()) {
-      executor.decode(encodedFromLittleEndian, bigEndianDestination, decodedSize, maxIntermediateSize,
-          Long.MAX_VALUE, scratch);
-    }
-    assertTypedValues(bigEndianDestination, dataType, values, spec + " LITTLE_ENDIAN encode view");
-
-    // A LITTLE_ENDIAN destination view must receive the same canonical big-endian bytes without
-    // changing the caller's configured order.
-    ByteBuffer encodedFromBigEndian = executor.encode(canonicalInput.duplicate());
     ByteBuffer littleEndianDestination = ByteBuffer.allocateDirect(decodedSize).order(ByteOrder.LITTLE_ENDIAN);
-    try (CodecPipelineExecutor.DecodeScratch scratch = new CodecPipelineExecutor.DecodeScratch()) {
-      executor.decode(encodedFromBigEndian, littleEndianDestination, decodedSize, maxIntermediateSize,
-          Long.MAX_VALUE, scratch);
+    try {
+      for (long value : values) {
+        if (dataType == DataType.INT) {
+          canonicalInput.putInt((int) value);
+        } else {
+          canonicalInput.putLong(value);
+        }
+      }
+      canonicalInput.flip();
+      CodecPipelineExecutor executor = CodecPipelineExecutor.create(spec, dataType);
+      int maxStageSize = Math.max(decodedSize, executor.maxEncodedSize(decodedSize));
+
+      // A LITTLE_ENDIAN input view must still be interpreted as persisted big-endian typed words.
+      ByteBuffer littleEndianInput = canonicalInput.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+      ByteBuffer encodedFromLittleEndian = encode(executor, littleEndianInput);
+      assertEquals(littleEndianInput.position(), 0, "encode must not consume the caller's input view");
+      assertEquals(littleEndianInput.order(), ByteOrder.LITTLE_ENDIAN);
+      decode(executor, encodedFromLittleEndian, bigEndianDestination, decodedSize, maxStageSize, MAX_WORK_SIZE);
+      assertTypedValues(bigEndianDestination, dataType, values, spec + " LITTLE_ENDIAN encode view");
+
+      // Preserve the caller's LITTLE_ENDIAN destination order while writing canonical big-endian bytes.
+      ByteBuffer encodedFromBigEndian = encode(executor, canonicalInput.duplicate());
+      decode(executor, encodedFromBigEndian, littleEndianDestination, decodedSize, maxStageSize, MAX_WORK_SIZE);
+      assertEquals(littleEndianDestination.order(), ByteOrder.LITTLE_ENDIAN);
+      assertTypedValues(littleEndianDestination, dataType, values, spec + " LITTLE_ENDIAN decode destination");
+    } finally {
+      CleanerUtil.cleanQuietly(canonicalInput);
+      CleanerUtil.cleanQuietly(bigEndianDestination);
+      CleanerUtil.cleanQuietly(littleEndianDestination);
     }
-    assertEquals(littleEndianDestination.order(), ByteOrder.LITTLE_ENDIAN);
-    assertTypedValues(littleEndianDestination, dataType, values, spec + " LITTLE_ENDIAN decode destination");
   }
 
   private static void assertTypedValues(ByteBuffer actual, DataType dataType, long[] expected, String message) {
@@ -303,9 +600,13 @@ public class CodecPipelineExecutorTest {
   }
 
   private static void assertBytesEqual(ByteBuffer actual) {
+    assertBytesEqual(actual, INPUT);
+  }
+
+  private static void assertBytesEqual(ByteBuffer actual, byte[] expected) {
     byte[] bytes = new byte[actual.remaining()];
     actual.duplicate().get(bytes);
-    assertTrue(Arrays.equals(bytes, INPUT));
+    assertEquals(bytes, expected);
   }
 
   private static byte[] createInput() {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecPipelineValidatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecPipelineValidatorTest.java
@@ -287,27 +287,22 @@ public class CodecPipelineValidatorTest {
     }
 
     @Override
-    public ByteBuffer encode(CodecOptions options, CodecContext ctx, ByteBuffer src) {
+    public void encode(CodecOptions options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) {
       throw new UnsupportedOperationException("Validation-only test codec");
     }
 
     @Override
-    public ByteBuffer decode(CodecOptions options, CodecContext ctx, ByteBuffer src) {
+    public void decode(CodecOptions options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) {
       throw new UnsupportedOperationException("Validation-only test codec");
     }
 
     @Override
-    public void decodeInto(CodecOptions options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) {
-      throw new UnsupportedOperationException("Validation-only test codec");
-    }
-
-    @Override
-    public int maxEncodedSize(CodecOptions options, int inputSize) {
+    public int maxEncodedSize(CodecOptions options, CodecContext ctx, int inputSize) {
       return inputSize;
     }
 
     @Override
-    public boolean requiresDirectDstBuffer() {
+    public boolean requiresDirectDecodeDstBuffer() {
       return false;
     }
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecRegistryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecRegistryTest.java
@@ -114,30 +114,24 @@ public class CodecRegistryTest {
     }
 
     @Override
-    public ByteBuffer encode(CodecOptions options, CodecContext ctx, ByteBuffer src)
+    public void encode(CodecOptions options, CodecContext ctx, ByteBuffer src, ByteBuffer dst)
         throws IOException {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public ByteBuffer decode(CodecOptions options, CodecContext ctx, ByteBuffer src)
+    public void decode(CodecOptions options, CodecContext ctx, ByteBuffer src, ByteBuffer dst)
         throws IOException {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public void decodeInto(CodecOptions options, CodecContext ctx, ByteBuffer src, ByteBuffer dst)
-        throws IOException {
+    public int maxEncodedSize(CodecOptions options, CodecContext ctx, int inputSize) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public int maxEncodedSize(CodecOptions options, int inputSize) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean requiresDirectDstBuffer() {
+    public boolean requiresDirectDecodeDstBuffer() {
       return false;
     }
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecTestUtils.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecTestUtils.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.io.codec;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+
+/// Test-owned buffers for codec fixtures. Decoded sizes must come from the fixture, never its frame header.
+final class CodecTestUtils {
+  private CodecTestUtils() {
+  }
+
+  static ByteBuffer encode(CodecPipelineExecutor executor, ByteBuffer source) throws IOException {
+    try (CodecPipelineExecutor.EncodeScratch scratch = new CodecPipelineExecutor.EncodeScratch()) {
+      ByteBuffer encoded = executor.encode(source, Integer.MAX_VALUE, Long.MAX_VALUE, scratch);
+      return ByteBuffer.allocate(encoded.remaining()).put(encoded).flip();
+    }
+  }
+
+  static void decode(CodecPipelineExecutor executor, ByteBuffer source, ByteBuffer destination, int decodedSize)
+      throws IOException {
+    decode(executor, source, destination, decodedSize, Integer.MAX_VALUE);
+  }
+
+  static void decode(CodecPipelineExecutor executor, ByteBuffer source, ByteBuffer destination, int decodedSize,
+      int maxStageSize) throws IOException {
+    try (CodecPipelineExecutor.DecodeScratch scratch = new CodecPipelineExecutor.DecodeScratch()) {
+      executor.decode(source, destination, decodedSize, maxStageSize, Long.MAX_VALUE, scratch);
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CompressionCodecCorruptInputTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CompressionCodecCorruptInputTest.java
@@ -51,22 +51,23 @@ public class CompressionCodecCorruptInputTest {
   public void testLz4DecodeRejectsGarbage() {
     // A 0xFF length-prefix decodes to a negative/huge length → out-of-range guard must fire.
     assertThrows(Exception.class,
-        () -> Lz4CodecDefinition.INSTANCE.decode(Lz4CodecDefinition.OPTIONS, CTX, garbage(64)));
+        () -> Lz4CodecDefinition.INSTANCE.decode(Lz4CodecDefinition.OPTIONS, CTX, garbage(64),
+            ByteBuffer.allocateDirect(64)));
   }
 
   @Test
   public void testZstdDecodeRejectsGarbage() {
     assertThrows(Exception.class,
         () -> ZstdCodecDefinition.INSTANCE.decode(ZstdCodecDefinition.INSTANCE.parseOptions(List.of()), CTX,
-            garbage(64)));
+            garbage(64), ByteBuffer.allocateDirect(64)));
   }
 
   @Test
-  public void testZstdDecodeIntoRejectsOversizedDeclaredSize() {
-    // decodeInto must apply the shared sanity cap before its later destination-capacity check.
+  public void testZstdDecodeRejectsOversizedDeclaredSize() {
+    // Apply the shared sanity cap before the later destination-capacity check.
     ByteBuffer dst = ByteBuffer.allocateDirect(16);
     IOException exception = expectThrows(IOException.class,
-        () -> ZstdCodecDefinition.INSTANCE.decodeInto(
+        () -> ZstdCodecDefinition.INSTANCE.decode(
             ZstdCodecDefinition.INSTANCE.parseOptions(List.of()), CTX, oversizedZstdFrame(), dst));
     assertTrue(exception.getMessage().contains("out of range"), exception.getMessage());
   }
@@ -84,26 +85,17 @@ public class CompressionCodecCorruptInputTest {
   @Test
   public void testSnappyDecodeRejectsGarbage() {
     assertThrows(Exception.class,
-        () -> SnappyCodecDefinition.INSTANCE.decode(SnappyCodecDefinition.OPTIONS, CTX, garbage(64)));
+        () -> SnappyCodecDefinition.INSTANCE.decode(SnappyCodecDefinition.OPTIONS, CTX, garbage(64),
+            ByteBuffer.allocateDirect(64)));
   }
 
   @Test
   public void testSnappyDecodeRejectsOversizedDeclaredSize() {
-    // The sanity cap must fire before any allocation driven by the untrusted header. The declared size is
+    // The sanity cap must fire before the destination-capacity guard. The declared size is
     // the smallest rejected value (cap + 1), pinning the inclusive boundary: exactly 1 GiB is accepted.
     IOException exception = expectThrows(IOException.class,
-        () -> SnappyCodecDefinition.INSTANCE.decode(SnappyCodecDefinition.OPTIONS, CTX, oversizedSnappyFrame()));
-    assertTrue(exception.getMessage().contains("out of range"), exception.getMessage());
-  }
-
-  @Test
-  public void testSnappyDecodeIntoRejectsOversizedDeclaredSize() {
-    // decodeInto is the path the bounded executor uses in production; it must reject with the size-cap
-    // IOException, not the later dst-capacity IllegalArgumentException.
-    ByteBuffer dst = ByteBuffer.allocateDirect(16);
-    IOException exception = expectThrows(IOException.class,
-        () -> SnappyCodecDefinition.INSTANCE.decodeInto(SnappyCodecDefinition.OPTIONS, CTX,
-            oversizedSnappyFrame(), dst));
+        () -> SnappyCodecDefinition.INSTANCE.decode(SnappyCodecDefinition.OPTIONS, CTX,
+            oversizedSnappyFrame(), ByteBuffer.allocateDirect(16)));
     assertTrue(exception.getMessage().contains("out of range"), exception.getMessage());
   }
 
@@ -118,7 +110,8 @@ public class CompressionCodecCorruptInputTest {
   @Test
   public void testGzipDecodeRejectsGarbage() {
     IOException exception = expectThrows(IOException.class,
-        () -> GzipCodecDefinition.INSTANCE.decode(GzipCodecDefinition.OPTIONS, CTX, garbage(64)));
+        () -> GzipCodecDefinition.INSTANCE.decode(GzipCodecDefinition.OPTIONS, CTX, garbage(64),
+            ByteBuffer.allocate(64)));
     assertTrue(exception.getMessage().contains("invalid decompressed size"), exception.getMessage());
   }
 
@@ -126,7 +119,8 @@ public class CompressionCodecCorruptInputTest {
   public void testGzipDecodeRejectsTruncatedFooter() {
     // Fewer than 4 bytes cannot carry the uncompressed-size footer GZIP appends.
     IOException exception = expectThrows(IOException.class,
-        () -> GzipCodecDefinition.INSTANCE.decode(GzipCodecDefinition.OPTIONS, CTX, garbage(2)));
+        () -> GzipCodecDefinition.INSTANCE.decode(GzipCodecDefinition.OPTIONS, CTX, garbage(2),
+            ByteBuffer.allocate(0)));
     assertTrue(exception.getMessage().contains("too short"), exception.getMessage());
   }
 
@@ -135,7 +129,7 @@ public class CompressionCodecCorruptInputTest {
     ByteBuffer encoded = encodeGzip(new byte[256]);
     encoded.putInt(encoded.limit() - Integer.BYTES, 128);
     IOException exception = expectThrows(IOException.class,
-        () -> GzipCodecDefinition.INSTANCE.decode(GzipCodecDefinition.OPTIONS, CTX, encoded));
+        () -> GzipCodecDefinition.INSTANCE.decode(GzipCodecDefinition.OPTIONS, CTX, encoded, ByteBuffer.allocate(256)));
     assertTrue(exception.getMessage().contains("expands beyond footer-declared size"), exception.getMessage());
   }
 
@@ -144,7 +138,7 @@ public class CompressionCodecCorruptInputTest {
     ByteBuffer encoded = encodeGzip(new byte[256]);
     encoded.putInt(encoded.limit() - Integer.BYTES, 0);
     IOException exception = expectThrows(IOException.class,
-        () -> GzipCodecDefinition.INSTANCE.decode(GzipCodecDefinition.OPTIONS, CTX, encoded));
+        () -> GzipCodecDefinition.INSTANCE.decode(GzipCodecDefinition.OPTIONS, CTX, encoded, ByteBuffer.allocate(256)));
     assertTrue(exception.getMessage().contains("expands beyond footer-declared size"), exception.getMessage());
   }
 
@@ -154,7 +148,7 @@ public class CompressionCodecCorruptInputTest {
     int checksumByte = encoded.limit() - Integer.BYTES - 1;
     encoded.put(checksumByte, (byte) (encoded.get(checksumByte) ^ 0x01));
     IOException exception = expectThrows(IOException.class,
-        () -> GzipCodecDefinition.INSTANCE.decode(GzipCodecDefinition.OPTIONS, CTX, encoded));
+        () -> GzipCodecDefinition.INSTANCE.decode(GzipCodecDefinition.OPTIONS, CTX, encoded, ByteBuffer.allocate(256)));
     assertTrue(exception.getMessage().contains("GZIP decompression failed"), exception.getMessage());
   }
 
@@ -165,8 +159,9 @@ public class CompressionCodecCorruptInputTest {
     Arrays.fill(values, (byte) 0x5A);
     ByteBuffer encoded = encodeGzip(values).order(ByteOrder.LITTLE_ENDIAN);
 
-    assertDecodedEquals(values,
-        GzipCodecDefinition.INSTANCE.decode(GzipCodecDefinition.OPTIONS, CTX, encoded));
+    ByteBuffer destination = ByteBuffer.allocate(values.length);
+    GzipCodecDefinition.INSTANCE.decode(GzipCodecDefinition.OPTIONS, CTX, encoded, destination);
+    assertDecodedEquals(values, destination);
   }
 
   @Test
@@ -181,21 +176,22 @@ public class CompressionCodecCorruptInputTest {
     framed.put(encoded.duplicate()).flip();
     framed.position(prefixLength);
 
-    assertDecodedEquals(values,
-        GzipCodecDefinition.INSTANCE.decode(GzipCodecDefinition.OPTIONS, CTX, framed));
+    ByteBuffer destination = ByteBuffer.allocate(values.length);
+    GzipCodecDefinition.INSTANCE.decode(GzipCodecDefinition.OPTIONS, CTX, framed, destination);
+    assertDecodedEquals(values, destination);
   }
 
   @Test
   public void testGzipMaxEncodedSizeRejectsOverflow() {
     assertThrows(IllegalArgumentException.class,
-        () -> GzipCodecDefinition.INSTANCE.maxEncodedSize(GzipCodecDefinition.OPTIONS, Integer.MAX_VALUE));
+        () -> GzipCodecDefinition.INSTANCE.maxEncodedSize(GzipCodecDefinition.OPTIONS, CTX, Integer.MAX_VALUE));
   }
 
   @Test
   public void testMultiStageDecodeBoundsInnerSnappyOutput() throws Exception {
     // A valid Snappy frame that expands to 1 MiB is far larger than the four-byte final INT
-    // chunk declared by the outer format. The executor must use Snappy.decodeInto() with a
-    // four-byte scratch bound instead of letting Snappy.decode() allocate from its inner header.
+    // chunk declared by the outer format. The executor must supply a four-byte scratch bound
+    // instead of sizing the destination from the inner frame header.
     byte[] compressed = Snappy.compress(new byte[1024 * 1024]);
     // Keep only a small prefix: it contains Snappy's claimed decoded length and stays below the
     // executor's outer encoded-size bound, so this specifically exercises the inner-frame guard.
@@ -206,7 +202,7 @@ public class CompressionCodecCorruptInputTest {
         "DELTA,SNAPPY", CTX, CodecRegistry.DEFAULT);
 
     IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-        () -> executor.decode(encoded, decoded, Integer.BYTES));
+        () -> CodecTestUtils.decode(executor, encoded, decoded, Integer.BYTES));
     assertTrue(exception.getMessage().contains("Snappy: decompressed size"), exception.getMessage());
   }
 
@@ -217,14 +213,15 @@ public class CompressionCodecCorruptInputTest {
     CodecPipelineExecutor executor = CodecPipelineExecutor.create("GZIP", CTX, CodecRegistry.DEFAULT);
 
     IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-        () -> executor.decode(encoded, decoded, Integer.BYTES, 128));
+        () -> CodecTestUtils.decode(executor, encoded, decoded, Integer.BYTES, 128));
     assertTrue(exception.getMessage().contains("Encoded input size"), exception.getMessage());
   }
 
   private static ByteBuffer encodeGzip(byte[] values) throws Exception {
-    ByteBuffer source = ByteBuffer.allocateDirect(values.length);
-    source.put(values).flip();
-    return GzipCodecDefinition.INSTANCE.encode(GzipCodecDefinition.OPTIONS, CTX, source);
+    ByteBuffer encoded = ByteBuffer.allocate(
+        GzipCodecDefinition.INSTANCE.maxEncodedSize(GzipCodecDefinition.OPTIONS, CTX, values.length));
+    GzipCodecDefinition.INSTANCE.encode(GzipCodecDefinition.OPTIONS, CTX, ByteBuffer.wrap(values), encoded);
+    return encoded;
   }
 
   private static void assertDecodedEquals(byte[] expected, ByteBuffer decoded) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/DeltaCodecRoundTripTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/DeltaCodecRoundTripTest.java
@@ -133,13 +133,13 @@ public class DeltaCodecRoundTripTest {
     misaligned.put((byte) 1).put((byte) 2).put((byte) 3).flip();
 
     IllegalArgumentException encodeException = expectThrows(IllegalArgumentException.class,
-        () -> executor.encode(misaligned.duplicate()));
+        () -> CodecTestUtils.encode(executor, misaligned.duplicate()));
     assertTrue(encodeException.getMessage().contains("not a multiple of element size"),
         encodeException.getMessage());
 
     ByteBuffer dst = ByteBuffer.allocateDirect(Integer.BYTES);
     IllegalArgumentException decodeException = expectThrows(IllegalArgumentException.class,
-        () -> executor.decode(misaligned.duplicate(), dst, Integer.BYTES));
+        () -> CodecTestUtils.decode(executor, misaligned.duplicate(), dst, Integer.BYTES));
     assertTrue(decodeException.getMessage().contains("not a multiple of element size"),
         decodeException.getMessage());
   }
@@ -152,16 +152,11 @@ public class DeltaCodecRoundTripTest {
       src.putInt(value);
     }
     src.flip();
-    ByteBuffer encoded = executor.encode(src.duplicate());
-
-    // Allocating decode path.
-    int[] decoded = readInts(executor.decode(encoded.duplicate()), values.length);
-    assertTrue(Arrays.equals(decoded, values),
-        describeMismatch(spec, Arrays.toString(values), Arrays.toString(decoded)));
+    ByteBuffer encoded = CodecTestUtils.encode(executor, src.duplicate());
 
     // Bounded decode-into path (the segment-reader entry point).
     ByteBuffer dst = ByteBuffer.allocateDirect(decodedSize);
-    executor.decode(encoded.duplicate(), dst, decodedSize);
+    CodecTestUtils.decode(executor, encoded.duplicate(), dst, decodedSize);
     int[] decodedInto = readInts(dst, values.length);
     assertTrue(Arrays.equals(decodedInto, values),
         describeMismatch(spec, Arrays.toString(values), Arrays.toString(decodedInto)));
@@ -175,16 +170,11 @@ public class DeltaCodecRoundTripTest {
       src.putLong(value);
     }
     src.flip();
-    ByteBuffer encoded = executor.encode(src.duplicate());
-
-    // Allocating decode path.
-    long[] decoded = readLongs(executor.decode(encoded.duplicate()), values.length);
-    assertTrue(Arrays.equals(decoded, values),
-        describeMismatch(spec, Arrays.toString(values), Arrays.toString(decoded)));
+    ByteBuffer encoded = CodecTestUtils.encode(executor, src.duplicate());
 
     // Bounded decode-into path (the segment-reader entry point).
     ByteBuffer dst = ByteBuffer.allocateDirect(decodedSize);
-    executor.decode(encoded.duplicate(), dst, decodedSize);
+    CodecTestUtils.decode(executor, encoded.duplicate(), dst, decodedSize);
     long[] decodedInto = readLongs(dst, values.length);
     assertTrue(Arrays.equals(decodedInto, values),
         describeMismatch(spec, Arrays.toString(values), Arrays.toString(decodedInto)));
@@ -192,13 +182,8 @@ public class DeltaCodecRoundTripTest {
 
   private static void assertIntDecodeFixture(String spec, byte[] encoded, int[] expected) throws IOException {
     CodecPipelineExecutor executor = CodecPipelineExecutor.create(spec, INT_CTX, CodecRegistry.DEFAULT);
-    int[] decoded = readInts(
-        executor.decode(ByteBuffer.wrap(encoded).order(ByteOrder.LITTLE_ENDIAN)), expected.length);
-    assertTrue(Arrays.equals(decoded, expected),
-        describeMismatch(spec, Arrays.toString(expected), Arrays.toString(decoded)));
-
     ByteBuffer dst = ByteBuffer.allocateDirect(expected.length * Integer.BYTES);
-    executor.decode(ByteBuffer.wrap(encoded).order(ByteOrder.LITTLE_ENDIAN), dst, dst.capacity());
+    CodecTestUtils.decode(executor, ByteBuffer.wrap(encoded).order(ByteOrder.LITTLE_ENDIAN), dst, dst.capacity());
     int[] decodedInto = readInts(dst, expected.length);
     assertTrue(Arrays.equals(decodedInto, expected),
         describeMismatch(spec, Arrays.toString(expected), Arrays.toString(decodedInto)));
@@ -206,13 +191,8 @@ public class DeltaCodecRoundTripTest {
 
   private static void assertLongDecodeFixture(String spec, byte[] encoded, long[] expected) throws IOException {
     CodecPipelineExecutor executor = CodecPipelineExecutor.create(spec, LONG_CTX, CodecRegistry.DEFAULT);
-    long[] decoded = readLongs(
-        executor.decode(ByteBuffer.wrap(encoded).order(ByteOrder.LITTLE_ENDIAN)), expected.length);
-    assertTrue(Arrays.equals(decoded, expected),
-        describeMismatch(spec, Arrays.toString(expected), Arrays.toString(decoded)));
-
     ByteBuffer dst = ByteBuffer.allocateDirect(expected.length * Long.BYTES);
-    executor.decode(ByteBuffer.wrap(encoded).order(ByteOrder.LITTLE_ENDIAN), dst, dst.capacity());
+    CodecTestUtils.decode(executor, ByteBuffer.wrap(encoded).order(ByteOrder.LITTLE_ENDIAN), dst, dst.capacity());
     long[] decodedInto = readLongs(dst, expected.length);
     assertTrue(Arrays.equals(decodedInto, expected),
         describeMismatch(spec, Arrays.toString(expected), Arrays.toString(decodedInto)));

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/GorillaCodecDefinitionTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/GorillaCodecDefinitionTest.java
@@ -56,11 +56,10 @@ public class GorillaCodecDefinitionTest {
       src.putInt(v);
     }
     src.flip();
-    ByteBuffer encoded = CODEC.encode(OPTS, INT_CTX, src);
-    assertDecodedInts(CODEC.decode(OPTS, INT_CTX, encoded.duplicate()), values);
+    ByteBuffer encoded = encode(INT_CTX, src);
 
     ByteBuffer dst = ByteBuffer.allocateDirect(values.length * Integer.BYTES);
-    CODEC.decodeInto(OPTS, INT_CTX, encoded.duplicate(), dst);
+    CODEC.decode(OPTS, INT_CTX, encoded.duplicate(), dst);
     assertDecodedInts(dst, values);
   }
 
@@ -78,11 +77,10 @@ public class GorillaCodecDefinitionTest {
       src.putLong(v);
     }
     src.flip();
-    ByteBuffer encoded = CODEC.encode(OPTS, LONG_CTX, src);
-    assertDecodedLongs(CODEC.decode(OPTS, LONG_CTX, encoded.duplicate()), values);
+    ByteBuffer encoded = encode(LONG_CTX, src);
 
     ByteBuffer dst = ByteBuffer.allocateDirect(values.length * Long.BYTES);
-    CODEC.decodeInto(OPTS, LONG_CTX, encoded.duplicate(), dst);
+    CODEC.decode(OPTS, LONG_CTX, encoded.duplicate(), dst);
     assertDecodedLongs(dst, values);
   }
 
@@ -227,9 +225,9 @@ public class GorillaCodecDefinitionTest {
 
     CodecPipelineExecutor executor = CodecPipelineExecutor.create(
         "DELTADELTA,GORILLA,ZSTD(3)", LONG_CTX, CodecRegistry.DEFAULT);
-    ByteBuffer encoded = executor.encode(src.duplicate());
+    ByteBuffer encoded = CodecTestUtils.encode(executor, src.duplicate());
     ByteBuffer decoded = ByteBuffer.allocateDirect(src.remaining());
-    executor.decode(encoded, decoded, src.remaining());
+    CodecTestUtils.decode(executor, encoded, decoded, src.remaining());
     assertDecodedLongs(decoded, values);
   }
 
@@ -241,16 +239,16 @@ public class GorillaCodecDefinitionTest {
     buf.put((byte) 7);
     buf.putInt(1);
     buf.flip();
-    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf));
+    assertThrows(IllegalStateException.class,
+        () -> CODEC.decode(OPTS, INT_CTX, buf, ByteBuffer.allocate(Integer.BYTES)));
   }
 
   @Test
   public void testInvalidFlagWithZeroCountThrows() {
     ByteBuffer buf = ByteBuffer.allocateDirect(5);
     buf.put((byte) 7).putInt(0).flip();
-    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf.duplicate()));
     assertThrows(IllegalStateException.class,
-        () -> CODEC.decodeInto(OPTS, INT_CTX, buf.duplicate(), ByteBuffer.allocateDirect(0)));
+        () -> CODEC.decode(OPTS, INT_CTX, buf.duplicate(), ByteBuffer.allocate(0)));
   }
 
   @Test
@@ -258,9 +256,7 @@ public class GorillaCodecDefinitionTest {
     ByteBuffer longFrame = ByteBuffer.allocateDirect(5);
     longFrame.put((byte) 1).putInt(0).flip();
     assertThrows(IllegalStateException.class,
-        () -> CODEC.decode(OPTS, INT_CTX, longFrame.duplicate()));
-    assertThrows(IllegalStateException.class,
-        () -> CODEC.decodeInto(OPTS, INT_CTX, longFrame.duplicate(), ByteBuffer.allocateDirect(0)));
+        () -> CODEC.decode(OPTS, INT_CTX, longFrame.duplicate(), ByteBuffer.allocate(0)));
   }
 
   @Test
@@ -269,7 +265,7 @@ public class GorillaCodecDefinitionTest {
     buf.put((byte) 0);
     buf.putInt(-1);
     buf.flip();
-    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf));
+    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf, ByteBuffer.allocate(0)));
   }
 
   @Test
@@ -284,7 +280,8 @@ public class GorillaCodecDefinitionTest {
     // 10000000 = 0x80
     buf.put((byte) 0x80);
     buf.flip();
-    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf));
+    assertThrows(IllegalStateException.class,
+        () -> CODEC.decode(OPTS, INT_CTX, buf, ByteBuffer.allocate(2 * Integer.BYTES)));
   }
 
   @Test
@@ -295,17 +292,15 @@ public class GorillaCodecDefinitionTest {
         src.putInt(value);
       }
       src.flip();
-      ByteBuffer withTrailingByte = appendByte(CODEC.encode(OPTS, INT_CTX, src));
+      ByteBuffer withTrailingByte = appendByte(encode(INT_CTX, src));
 
       assertThrows(IllegalStateException.class,
-          () -> CODEC.decode(OPTS, INT_CTX, withTrailingByte.duplicate()));
-      assertThrows(IllegalStateException.class,
-          () -> CODEC.decodeInto(OPTS, INT_CTX, withTrailingByte.duplicate(),
+          () -> CODEC.decode(OPTS, INT_CTX, withTrailingByte.duplicate(),
               ByteBuffer.allocateDirect(values.length * Integer.BYTES)));
 
       CodecPipelineExecutor executor = CodecPipelineExecutor.create("GORILLA", INT_CTX, CodecRegistry.DEFAULT);
       assertThrows(RuntimeException.class,
-          () -> executor.decode(withTrailingByte.duplicate(),
+          () -> CodecTestUtils.decode(executor, withTrailingByte.duplicate(),
               ByteBuffer.allocateDirect(values.length * Integer.BYTES), values.length * Integer.BYTES));
     }
   }
@@ -314,14 +309,14 @@ public class GorillaCodecDefinitionTest {
   public void testNonZeroPaddingBitsRejected() {
     ByteBuffer src = ByteBuffer.allocateDirect(2 * Integer.BYTES);
     src.putInt(7).putInt(7).flip();
-    ByteBuffer encoded = CODEC.encode(OPTS, INT_CTX, src);
+    ByteBuffer encoded = encode(INT_CTX, src);
     encoded.put(encoded.limit() - 1, (byte) 1);
 
     assertThrows(IllegalStateException.class,
-        () -> CODEC.decode(OPTS, INT_CTX, encoded.duplicate()));
+        () -> CODEC.decode(OPTS, INT_CTX, encoded.duplicate(), ByteBuffer.allocate(2 * Integer.BYTES)));
     CodecPipelineExecutor executor = CodecPipelineExecutor.create("GORILLA", INT_CTX, CodecRegistry.DEFAULT);
     assertThrows(IllegalStateException.class,
-        () -> executor.decode(encoded.duplicate(), ByteBuffer.allocateDirect(2 * Integer.BYTES),
+        () -> CodecTestUtils.decode(executor, encoded.duplicate(), ByteBuffer.allocateDirect(2 * Integer.BYTES),
             2 * Integer.BYTES));
   }
 
@@ -335,8 +330,9 @@ public class GorillaCodecDefinitionTest {
         0, 0, 0, 0,
         (byte) 0xFE, 0x08
     };
-    assertDecodedInts(
-        CODEC.decode(OPTS, INT_CTX, ByteBuffer.wrap(encodedInt).order(ByteOrder.LITTLE_ENDIAN)), new int[]{0, 1});
+    ByteBuffer intDestination = ByteBuffer.allocate(2 * Integer.BYTES);
+    CODEC.decode(OPTS, INT_CTX, ByteBuffer.wrap(encodedInt).order(ByteOrder.LITTLE_ENDIAN), intDestination);
+    assertDecodedInts(intDestination, new int[]{0, 1});
 
     byte[] encodedLong = {
         1,
@@ -345,10 +341,8 @@ public class GorillaCodecDefinitionTest {
         (byte) 0xFF, 0x02
     };
     long[] expectedLongs = {0L, 1L};
-    assertDecodedLongs(
-        CODEC.decode(OPTS, LONG_CTX, ByteBuffer.wrap(encodedLong).order(ByteOrder.LITTLE_ENDIAN)), expectedLongs);
     ByteBuffer dst = ByteBuffer.allocateDirect(expectedLongs.length * Long.BYTES);
-    CODEC.decodeInto(OPTS, LONG_CTX, ByteBuffer.wrap(encodedLong).order(ByteOrder.LITTLE_ENDIAN), dst);
+    CODEC.decode(OPTS, LONG_CTX, ByteBuffer.wrap(encodedLong).order(ByteOrder.LITTLE_ENDIAN), dst);
     assertDecodedLongs(dst, expectedLongs);
   }
 
@@ -369,7 +363,13 @@ public class GorillaCodecDefinitionTest {
   @Test
   public void testMaxEncodedSizeRejectsOverflow() {
     assertThrows(IllegalArgumentException.class,
-        () -> CODEC.maxEncodedSize(OPTS, Integer.MAX_VALUE));
+        () -> CODEC.maxEncodedSize(OPTS, INT_CTX, Integer.MAX_VALUE));
+  }
+
+  private static ByteBuffer encode(CodecContext context, ByteBuffer source) {
+    ByteBuffer encoded = ByteBuffer.allocate(CODEC.maxEncodedSize(OPTS, context, source.remaining()));
+    CODEC.encode(OPTS, context, source, encoded);
+    return encoded;
   }
 
   private static ByteBuffer appendByte(ByteBuffer buffer) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/T64CodecDefinitionTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/T64CodecDefinitionTest.java
@@ -58,11 +58,10 @@ public class T64CodecDefinitionTest {
       src.putInt(v);
     }
     src.flip();
-    ByteBuffer encoded = CODEC.encode(OPTS, INT_CTX, src);
-    assertDecodedInts(CODEC.decode(OPTS, INT_CTX, encoded.duplicate()), values);
+    ByteBuffer encoded = encode(INT_CTX, src);
 
     ByteBuffer dst = ByteBuffer.allocateDirect(values.length * Integer.BYTES);
-    CODEC.decodeInto(OPTS, INT_CTX, encoded.duplicate(), dst);
+    CODEC.decode(OPTS, INT_CTX, encoded.duplicate(), dst);
     assertDecodedInts(dst, values);
   }
 
@@ -80,11 +79,10 @@ public class T64CodecDefinitionTest {
       src.putLong(v);
     }
     src.flip();
-    ByteBuffer encoded = CODEC.encode(OPTS, LONG_CTX, src);
-    assertDecodedLongs(CODEC.decode(OPTS, LONG_CTX, encoded.duplicate()), values);
+    ByteBuffer encoded = encode(LONG_CTX, src);
 
     ByteBuffer dst = ByteBuffer.allocateDirect(values.length * Long.BYTES);
-    CODEC.decodeInto(OPTS, LONG_CTX, encoded.duplicate(), dst);
+    CODEC.decode(OPTS, LONG_CTX, encoded.duplicate(), dst);
     assertDecodedLongs(dst, values);
   }
 
@@ -245,9 +243,9 @@ public class T64CodecDefinitionTest {
 
     CodecPipelineExecutor executor = CodecPipelineExecutor.create("DELTA,T64,LZ4", INT_CTX,
         CodecRegistry.DEFAULT);
-    ByteBuffer encoded = executor.encode(src.duplicate());
+    ByteBuffer encoded = CodecTestUtils.encode(executor, src.duplicate());
     ByteBuffer decoded = ByteBuffer.allocateDirect(src.remaining());
-    executor.decode(encoded, decoded, src.remaining());
+    CodecTestUtils.decode(executor, encoded, decoded, src.remaining());
     assertDecodedInts(decoded, values);
   }
 
@@ -259,7 +257,8 @@ public class T64CodecDefinitionTest {
     buf.put((byte) 7); // invalid flag
     buf.putInt(1);
     buf.flip();
-    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf));
+    assertThrows(IllegalStateException.class,
+        () -> CODEC.decode(OPTS, INT_CTX, buf, ByteBuffer.allocate(Integer.BYTES)));
   }
 
   @Test
@@ -269,7 +268,7 @@ public class T64CodecDefinitionTest {
     buf.put((byte) 42); // invalid flag
     buf.putInt(0); // count = 0
     buf.flip();
-    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf));
+    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf, ByteBuffer.allocate(0)));
   }
 
   @Test
@@ -277,9 +276,7 @@ public class T64CodecDefinitionTest {
     ByteBuffer longFrame = ByteBuffer.allocateDirect(5);
     longFrame.put((byte) 1).putInt(0).flip();
     assertThrows(IllegalStateException.class,
-        () -> CODEC.decode(OPTS, INT_CTX, longFrame.duplicate()));
-    assertThrows(IllegalStateException.class,
-        () -> CODEC.decodeInto(OPTS, INT_CTX, longFrame.duplicate(), ByteBuffer.allocateDirect(0)));
+        () -> CODEC.decode(OPTS, INT_CTX, longFrame.duplicate(), ByteBuffer.allocate(0)));
   }
 
   @Test
@@ -288,7 +285,7 @@ public class T64CodecDefinitionTest {
     buf.put((byte) 0);
     buf.putInt(-1);
     buf.flip();
-    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf));
+    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf, ByteBuffer.allocate(0)));
   }
 
   @Test
@@ -300,7 +297,8 @@ public class T64CodecDefinitionTest {
     buf.putInt(0); // baseline
     buf.put((byte) 33); // invalid bitWidth for INT
     buf.flip();
-    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf));
+    assertThrows(IllegalStateException.class,
+        () -> CODEC.decode(OPTS, INT_CTX, buf, ByteBuffer.allocate(64 * Integer.BYTES)));
   }
 
   @Test
@@ -311,17 +309,15 @@ public class T64CodecDefinitionTest {
         src.putInt(value);
       }
       src.flip();
-      ByteBuffer withTrailingByte = appendByte(CODEC.encode(OPTS, INT_CTX, src));
+      ByteBuffer withTrailingByte = appendByte(encode(INT_CTX, src));
 
       assertThrows(IllegalStateException.class,
-          () -> CODEC.decode(OPTS, INT_CTX, withTrailingByte.duplicate()));
-      assertThrows(IllegalStateException.class,
-          () -> CODEC.decodeInto(OPTS, INT_CTX, withTrailingByte.duplicate(),
+          () -> CODEC.decode(OPTS, INT_CTX, withTrailingByte.duplicate(),
               ByteBuffer.allocateDirect(values.length * Integer.BYTES)));
 
       CodecPipelineExecutor executor = CodecPipelineExecutor.create("T64", INT_CTX, CodecRegistry.DEFAULT);
       assertThrows(RuntimeException.class,
-          () -> executor.decode(withTrailingByte.duplicate(),
+          () -> CodecTestUtils.decode(executor, withTrailingByte.duplicate(),
               ByteBuffer.allocateDirect(values.length * Integer.BYTES), values.length * Integer.BYTES));
     }
   }
@@ -330,21 +326,21 @@ public class T64CodecDefinitionTest {
   public void testNonZeroPartialBlockPaddingRejected() {
     ByteBuffer src = ByteBuffer.allocateDirect(4 * Integer.BYTES);
     src.putInt(0).putInt(1).putInt(2).putInt(3).flip();
-    ByteBuffer encoded = CODEC.encode(OPTS, INT_CTX, src);
+    ByteBuffer encoded = encode(INT_CTX, src);
     encoded.put(encoded.limit() - 1, (byte) 1);
 
     assertThrows(IllegalStateException.class,
-        () -> CODEC.decode(OPTS, INT_CTX, encoded.duplicate()));
+        () -> CODEC.decode(OPTS, INT_CTX, encoded.duplicate(), ByteBuffer.allocate(4 * Integer.BYTES)));
     CodecPipelineExecutor executor = CodecPipelineExecutor.create("T64", INT_CTX, CodecRegistry.DEFAULT);
     assertThrows(IllegalStateException.class,
-        () -> executor.decode(encoded.duplicate(), ByteBuffer.allocateDirect(4 * Integer.BYTES),
+        () -> CodecTestUtils.decode(executor, encoded.duplicate(), ByteBuffer.allocateDirect(4 * Integer.BYTES),
             4 * Integer.BYTES));
   }
 
   @Test
   public void testMisalignedInputSizeThrows() {
     ByteBuffer buf = ByteBuffer.allocateDirect(7); // not a multiple of INT size
-    assertThrows(IllegalArgumentException.class, () -> CODEC.encode(OPTS, INT_CTX, buf));
+    assertThrows(IllegalArgumentException.class, () -> encode(INT_CTX, buf));
   }
 
   @Test
@@ -382,8 +378,8 @@ public class T64CodecDefinitionTest {
       src.putInt(v);
     }
     src.flip();
-    ByteBuffer encoded = CODEC.encode(OPTS, INT_CTX, src);
-    int max = CODEC.maxEncodedSize(OPTS, count * Integer.BYTES);
+    ByteBuffer encoded = encode(INT_CTX, src);
+    int max = CODEC.maxEncodedSize(OPTS, INT_CTX, count * Integer.BYTES);
     assertTrue(encoded.remaining() <= max,
         "count=" + count + " encoded.remaining()=" + encoded.remaining()
             + " exceeds maxEncodedSize=" + max);
@@ -400,8 +396,8 @@ public class T64CodecDefinitionTest {
       src.putLong(v);
     }
     src.flip();
-    ByteBuffer encoded = CODEC.encode(OPTS, LONG_CTX, src);
-    int max = CODEC.maxEncodedSize(OPTS, count * Long.BYTES);
+    ByteBuffer encoded = encode(LONG_CTX, src);
+    int max = CODEC.maxEncodedSize(OPTS, LONG_CTX, count * Long.BYTES);
     assertTrue(encoded.remaining() <= max,
         "count=" + count + " encoded.remaining()=" + encoded.remaining()
             + " exceeds maxEncodedSize=" + max);
@@ -410,7 +406,18 @@ public class T64CodecDefinitionTest {
   @Test
   public void testMaxEncodedSizeRejectsOverflow() {
     assertThrows(IllegalArgumentException.class,
-        () -> CODEC.maxEncodedSize(OPTS, Integer.MAX_VALUE));
+        () -> CODEC.maxEncodedSize(OPTS, INT_CTX, Integer.MAX_VALUE));
+    assertThrows(IllegalArgumentException.class,
+        () -> CODEC.maxEncodedSize(OPTS, LONG_CTX, Integer.MAX_VALUE));
+  }
+
+  @Test
+  public void testMaxEncodedSizeUsesStoredType() {
+    int oneMiB = 1 << 20;
+    assertEquals(CODEC.maxEncodedSize(OPTS, INT_CTX, oneMiB), 1_069_061);
+    assertEquals(CODEC.maxEncodedSize(OPTS, LONG_CTX, oneMiB), 1_067_013);
+    assertThrows(IllegalArgumentException.class,
+        () -> CODEC.maxEncodedSize(OPTS, new CodecContext(DataType.DOUBLE), oneMiB));
   }
 
   // ---------- Wire-format byte-layout pin test ----------
@@ -426,7 +433,7 @@ public class T64CodecDefinitionTest {
       src.putInt(v);
     }
     src.flip();
-    ByteBuffer encoded = CODEC.encode(OPTS, INT_CTX, src);
+    ByteBuffer encoded = encode(INT_CTX, src);
 
     // Frame: flag=0 (INT), count=4, then one block:
     //   baseline = 0 (int, 4 bytes big-endian — the ByteBuffer default)
@@ -470,11 +477,25 @@ public class T64CodecDefinitionTest {
     encoded[14] = (byte) 0xE4;
     long[] expected = {0L, 1L, 2L, 3L};
 
-    assertDecodedLongs(
-        CODEC.decode(OPTS, LONG_CTX, ByteBuffer.wrap(encoded).order(ByteOrder.LITTLE_ENDIAN)), expected);
     ByteBuffer dst = ByteBuffer.allocateDirect(expected.length * Long.BYTES);
-    CODEC.decodeInto(OPTS, LONG_CTX, ByteBuffer.wrap(encoded).order(ByteOrder.LITTLE_ENDIAN), dst);
+    CODEC.decode(OPTS, LONG_CTX, ByteBuffer.wrap(encoded).order(ByteOrder.LITTLE_ENDIAN), dst);
     assertDecodedLongs(dst, expected);
+  }
+
+  @Test
+  public void testDecodeHonorsOffsetSlice() {
+    int[] values = {0, 1, 2, 3};
+    ByteBuffer input = ByteBuffer.allocate(values.length * Integer.BYTES);
+    for (int value : values) {
+      input.putInt(value);
+    }
+    ByteBuffer encoded = encode(INT_CTX, input.flip());
+    ByteBuffer framed = ByteBuffer.allocate(encoded.remaining() + 11);
+    framed.position(7);
+    framed.put(encoded).flip().position(7);
+    ByteBuffer output = ByteBuffer.allocate(values.length * Integer.BYTES);
+    CODEC.decode(OPTS, INT_CTX, framed.slice().order(ByteOrder.LITTLE_ENDIAN), output);
+    assertDecodedInts(output, values);
   }
 
   // ---------- Parameterized bit-width × position coverage ----------
@@ -522,6 +543,12 @@ public class T64CodecDefinitionTest {
       values[i] = (i % 2 == 0) ? 0 : range;
     }
     roundTripInt(values);
+  }
+
+  private static ByteBuffer encode(CodecContext context, ByteBuffer source) {
+    ByteBuffer encoded = ByteBuffer.allocate(CODEC.maxEncodedSize(OPTS, context, source.remaining()));
+    CODEC.encode(OPTS, context, source, encoded);
+    return encoded;
   }
 
   private static ByteBuffer appendByte(ByteBuffer buffer) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/ZstdCodecDefinitionTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/ZstdCodecDefinitionTest.java
@@ -34,14 +34,12 @@ public class ZstdCodecDefinitionTest {
 
   @Test
   public void testEmptyInputRoundTrip() throws Exception {
-    ByteBuffer encoded = CODEC.encode(OPTIONS, CONTEXT, ByteBuffer.allocateDirect(0));
+    ByteBuffer encoded = ByteBuffer.allocateDirect(CODEC.maxEncodedSize(OPTIONS, CONTEXT, 0));
+    CODEC.encode(OPTIONS, CONTEXT, ByteBuffer.allocateDirect(0), encoded);
     assertTrue(encoded.hasRemaining(), "An empty input should still produce a Zstd frame");
 
-    ByteBuffer decoded = CODEC.decode(OPTIONS, CONTEXT, encoded.duplicate());
-    assertEquals(decoded.remaining(), 0);
-
     ByteBuffer destination = ByteBuffer.allocateDirect(0);
-    CODEC.decodeInto(OPTIONS, CONTEXT, encoded.duplicate(), destination);
+    CODEC.decode(OPTIONS, CONTEXT, encoded.duplicate(), destination);
     assertEquals(destination.position(), 0);
     assertEquals(destination.limit(), 0);
     assertEquals(destination.remaining(), 0);


### PR DESCRIPTION
## Summary

Extracts the codec runtime from #19307 into an independently reviewable prerequisite.

- Replaces the unreleased allocating handler API with destination-based `encode` and `decode` methods.
- Uses bounded caller-owned scratch with reusable direct buffers and capacity-limited stage views.
- Keeps executor construction as pure parse/validate; immutable executors are retained by lifecycle owners.
- Preserves source state and byte order, including reused source windows and concurrent calls with separate scratch.
- Uses real codecs only; no mocks.

V7 reader/writer routing, table-config validation, and reload integration remain in #19307.

## Review changes

- Removed the process-wide plan/alias cache and all cache-only tests.
- Reused `encodedStageBounds()` for both encode and decode bounds.
- Renamed the decode-only direct-buffer contract to `requiresDirectDecodeDstBuffer()`.
- Renamed decode's stage limit to `maxStageSize` throughout API documentation, validation, callers, and tests.
- Retained the reviewed T64 word-at-a-time decode, stored-type-aware bounds, and indexed DELTA/DELTADELTA paths.

## Validation

- Rebased onto `master` at `a13a7ce49ab`; exactly one commit.
- 295 segment-local codec tests and 14 SPI codec/parser tests pass (309 total).
- Spotless, Checkstyle, license formatting, and license checks pass for `pinot-segment-local`.
- Independent eight-domain review passes with no remaining findings.
- Matched JMH remains favorable: T64 decode improves 31.7–93.8%; `DELTA,DELTADELTA` improves 28.1%, or 3.8% with LZ4, with warmed allocations reduced to profiler noise.
- Warning-enabled `test-compile` fails identically on exact `master` and this PR at `ZstandardDecompressor.java:51` because `org.jetbrains.annotations.NotNull` metadata is absent; normal builds and tests pass.
