### PR TITLE
[controller] Reject deletion of consuming realtime segments

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/SegmentAdminClient.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/SegmentAdminClient.java
@@ -422,6 +422,17 @@ public class SegmentAdminClient extends BaseServiceAdminClient {
   public String deleteSegmentsByTimeWindow(String tableName, String tableType, long startTimestampMs,
       long endTimestampMs, boolean excludeOverlapping, boolean excludeReplacedSegments, String retentionPeriod)
       throws PinotAdminException {
+    return deleteSegmentsByTimeWindow(tableName, tableType, startTimestampMs, endTimestampMs, excludeOverlapping,
+        excludeReplacedSegments, retentionPeriod, false);
+  }
+
+  /// Deletes segments in a time window.
+  ///
+  /// @param force when true, delete realtime segments even if a replica is still CONSUMING
+  public String deleteSegmentsByTimeWindow(String tableName, String tableType, long startTimestampMs,
+      long endTimestampMs, boolean excludeOverlapping, boolean excludeReplacedSegments, String retentionPeriod,
+      boolean force)
+      throws PinotAdminException {
     Map<String, String> queryParams = new HashMap<>();
     queryParams.put("startTimestamp", String.valueOf(startTimestampMs));
     queryParams.put("endTimestamp", String.valueOf(endTimestampMs));
@@ -432,6 +443,9 @@ public class SegmentAdminClient extends BaseServiceAdminClient {
     }
     if (retentionPeriod != null) {
       queryParams.put("retention", retentionPeriod);
+    }
+    if (force) {
+      queryParams.put("force", "true");
     }
 
     JsonNode response = _transport.executeDelete(_controllerAddress, "/segments/" + tableName + "/choose",

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/SegmentAdminClient.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/SegmentAdminClient.java
@@ -305,9 +305,25 @@ public class SegmentAdminClient extends BaseServiceAdminClient {
   /// @throws PinotAdminException If the request fails
   public String deleteSegment(String tableName, String segmentName, String retentionPeriod)
       throws PinotAdminException {
+    return deleteSegment(tableName, segmentName, retentionPeriod, false);
+  }
+
+  /// Deletes a specific segment.
+  ///
+  /// @param tableName Name of the table
+  /// @param segmentName Name of the segment
+  /// @param retentionPeriod Retention period for the segment (optional)
+  /// @param force when true, delete realtime segments even if a replica is still CONSUMING
+  /// @return Success response
+  /// @throws PinotAdminException If the request fails
+  public String deleteSegment(String tableName, String segmentName, String retentionPeriod, boolean force)
+      throws PinotAdminException {
     Map<String, String> queryParams = new HashMap<>();
     if (retentionPeriod != null) {
       queryParams.put("retention", retentionPeriod);
+    }
+    if (force) {
+      queryParams.put("force", "true");
     }
 
     JsonNode response = _transport.executeDelete(_controllerAddress,
@@ -333,6 +349,13 @@ public class SegmentAdminClient extends BaseServiceAdminClient {
   public String deleteMultipleSegments(String tableName, String tableType, String segmentNames,
       String retentionPeriod)
       throws PinotAdminException {
+    return deleteMultipleSegments(tableName, tableType, segmentNames, retentionPeriod, false);
+  }
+
+  /// Deletes multiple segments, optionally forcing deletion of CONSUMING realtime replicas.
+  public String deleteMultipleSegments(String tableName, String tableType, String segmentNames,
+      String retentionPeriod, boolean force)
+      throws PinotAdminException {
     Map<String, String> queryParams = new HashMap<>();
     if (tableType == null) {
       org.apache.pinot.spi.config.table.TableType inferred = org.apache.pinot.spi.utils.builder.TableNameBuilder
@@ -351,6 +374,9 @@ public class SegmentAdminClient extends BaseServiceAdminClient {
     if (retentionPeriod != null) {
       queryParams.put("retention", retentionPeriod);
     }
+    if (force) {
+      queryParams.put("force", "true");
+    }
 
     JsonNode response = _transport.executeDelete(_controllerAddress, "/segments/" + tableName,
         queryParams.isEmpty() ? null : queryParams, _headers);
@@ -360,8 +386,14 @@ public class SegmentAdminClient extends BaseServiceAdminClient {
   public String deleteMultipleSegments(String tableName, String tableType, List<String> segments,
       String retentionPeriod)
       throws PinotAdminException {
+    return deleteMultipleSegments(tableName, tableType, segments, retentionPeriod, false);
+  }
+
+  public String deleteMultipleSegments(String tableName, String tableType, List<String> segments,
+      String retentionPeriod, boolean force)
+      throws PinotAdminException {
     String segmentNames = (segments == null || segments.isEmpty()) ? null : String.join(",", segments);
-    return deleteMultipleSegments(tableName, tableType, segmentNames, retentionPeriod);
+    return deleteMultipleSegments(tableName, tableType, segmentNames, retentionPeriod, force);
   }
 
   /// Deletes segments specified in JSON array payload.
@@ -372,8 +404,17 @@ public class SegmentAdminClient extends BaseServiceAdminClient {
   /// @throws PinotAdminException If the request fails
   public String deleteSegments(String tableName, String segmentDeleteRequest)
       throws PinotAdminException {
+    return deleteSegments(tableName, segmentDeleteRequest, false);
+  }
+
+  /// Deletes segments specified in JSON array payload.
+  ///
+  /// @param force when true, delete realtime segments even if a replica is still CONSUMING
+  public String deleteSegments(String tableName, String segmentDeleteRequest, boolean force)
+      throws PinotAdminException {
+    Map<String, String> queryParams = force ? Map.of("force", "true") : null;
     JsonNode response = _transport.executePost(_controllerAddress, "/segments/" + tableName + "/delete",
-        segmentDeleteRequest, null, _headers);
+        segmentDeleteRequest, queryParams, _headers);
     return response.toString();
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -24,7 +24,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -391,6 +393,35 @@ public class HelixHelper {
       }
     };
     updateIdealState(helixManager, tableName, updater, DEFAULT_RETRY_POLICY);
+  }
+
+  /// Atomically validates and removes segments from IdealState. This guarded operation is the sole updater in its
+  /// versioned compare-and-set, and the validator is invoked again whenever the update retries after a concurrent
+  /// version change.
+  ///
+  /// @param helixManager Helix manager used to access the cluster
+  /// @param tableName table resource name
+  /// @param segments segments to remove
+  /// @param idealStateValidator read-only validator invoked before any segment is removed; returns whether deletion is
+  ///                             allowed
+  /// @return whether validation allowed the delete
+  public static boolean removeSegmentsFromIdealStateWithValidation(HelixManager helixManager, String tableName,
+      final List<String> segments, Predicate<IdealState> idealStateValidator) {
+    AtomicBoolean validationPassed = new AtomicBoolean();
+    Function<IdealState, IdealState> updater = idealState -> {
+      boolean currentValidationPassed = idealStateValidator.test(idealState);
+      validationPassed.set(currentValidationPassed);
+      if (!currentValidationPassed) {
+        return idealState;
+      }
+      Set<String> partitionSet = idealState.getPartitionSet();
+      if (partitionSet != null) {
+        partitionSet.removeAll(segments);
+      }
+      return idealState;
+    };
+    IdealStateSingleCommit.updateIdealState(helixManager, tableName, updater, DEFAULT_RETRY_POLICY, true);
+    return validationPassed.get();
   }
 
   /// Returns the config for all the instances in the cluster.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -148,8 +148,12 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
 public class PinotSegmentRestletResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotSegmentRestletResource.class);
   private static final String CONSUMING_SEGMENT_DELETE_NOTE =
-      "Realtime segment deletion is rejected while any target has a CONSUMING replica. Pause the table, poll "
-          + "/tables/{tableName}/pauseStatus until consumingSegments is empty, then retry.";
+      "Realtime segment deletion is rejected while any target has a CONSUMING replica unless force=true. "
+          + "Prefer pausing the table and polling /tables/{tableName}/pauseStatus until consumingSegments is empty, "
+          + "then retry. Use force=true only to recover a table by deleting CONSUMING segments.";
+  private static final String FORCE_DELETE_CONSUMING_PARAM =
+      "Force deletion of realtime segments that still have a CONSUMING replica. Default is false. "
+          + "Use only for table recovery; prefer pausing consumption first.";
 
   @Inject
   ControllerConf _controllerConf;
@@ -526,11 +530,13 @@ public class PinotSegmentRestletResource {
       @ApiParam(value = "Retention period for the table segments (e.g. 12h, 3d); If not set, the retention period "
           + "will default to the first config that's not null: the table config, then to cluster setting, then '7d'. "
           + "Using 0d or -1d will instantly delete segments without retention")
-      @QueryParam("retention") String retentionPeriod, @Context HttpHeaders headers) {
+      @QueryParam("retention") String retentionPeriod,
+      @ApiParam(value = FORCE_DELETE_CONSUMING_PARAM, defaultValue = "false")
+      @QueryParam("force") @DefaultValue("false") boolean force, @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     segmentName = URIUtils.decode(segmentName);
     String tableNameWithType = getExistingTable(tableName, segmentName);
-    deleteSegmentsInternal(tableNameWithType, List.of(segmentName), retentionPeriod);
+    deleteSegmentsInternal(tableNameWithType, List.of(segmentName), retentionPeriod, force);
     return new SuccessResponse("Segment deleted");
   }
 
@@ -550,7 +556,9 @@ public class PinotSegmentRestletResource {
           + "Using 0d or -1d will instantly delete segments without retention")
       @QueryParam("retention") String retentionPeriod,
       @ApiParam(value = "Segment names to be deleted if not provided deletes all segments by default",
-          allowMultiple = true) @QueryParam("segments") List<String> segments, @Context HttpHeaders headers) {
+          allowMultiple = true) @QueryParam("segments") List<String> segments,
+      @ApiParam(value = FORCE_DELETE_CONSUMING_PARAM, defaultValue = "false")
+      @QueryParam("force") @DefaultValue("false") boolean force, @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     TableType tableType = Constants.validateTableType(tableTypeStr);
     if (tableType == null) {
@@ -560,11 +568,11 @@ public class PinotSegmentRestletResource {
         ResourceUtils.getExistingTableNamesWithType(_pinotHelixResourceManager, tableName, tableType, LOGGER).get(0);
     if (segments.isEmpty()) {
       deleteSegmentsInternal(tableNameWithType,
-          _pinotHelixResourceManager.getSegmentsFromPropertyStore(tableNameWithType), retentionPeriod);
+          _pinotHelixResourceManager.getSegmentsFromPropertyStore(tableNameWithType), retentionPeriod, force);
       return new SuccessResponse("All segments of table " + tableNameWithType + " deleted");
     } else {
       int numSegments = segments.size();
-      deleteSegmentsInternal(tableNameWithType, segments, retentionPeriod);
+      deleteSegmentsInternal(tableNameWithType, segments, retentionPeriod, force);
       if (numSegments <= 5) {
         return new SuccessResponse("Deleted segments: " + segments + " from table: " + tableNameWithType);
       } else {
@@ -587,14 +595,16 @@ public class PinotSegmentRestletResource {
       @ApiParam(value = "Retention period for the table segments (e.g. 12h, 3d); If not set, the retention period "
           + "will default to the first config that's not null: the table config, then to cluster setting, then '7d'. "
           + "Using 0d or -1d will instantly delete segments without retention")
-      @QueryParam("retention") String retentionPeriod, List<String> segments, @Context HttpHeaders headers) {
+      @QueryParam("retention") String retentionPeriod,
+      @ApiParam(value = FORCE_DELETE_CONSUMING_PARAM, defaultValue = "false")
+      @QueryParam("force") @DefaultValue("false") boolean force, List<String> segments, @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     int numSegments = segments.size();
     if (numSegments == 0) {
       throw new ControllerApplicationException(LOGGER, "Segments must be provided", Status.BAD_REQUEST);
     }
     String tableNameWithType = getExistingTable(tableName, segments.get(0));
-    deleteSegmentsInternal(tableNameWithType, segments, retentionPeriod);
+    deleteSegmentsInternal(tableNameWithType, segments, retentionPeriod, force);
     if (numSegments <= 5) {
       return new SuccessResponse("Deleted segments: " + segments + " from table: " + tableNameWithType);
     } else {
@@ -629,7 +639,9 @@ public class PinotSegmentRestletResource {
       @ApiParam(value = "Retention period for the table segments (e.g. 12h, 3d); If not set, the retention period "
           + "will default to the first config that's not null: the table config, then to cluster setting, then '7d'. "
           + "Using 0d or -1d will instantly delete segments without retention")
-      @QueryParam("retention") String retentionPeriod, @Context HttpHeaders headers) {
+      @QueryParam("retention") String retentionPeriod,
+      @ApiParam(value = FORCE_DELETE_CONSUMING_PARAM, defaultValue = "false")
+      @QueryParam("force") @DefaultValue("false") boolean force, @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     if (Strings.isNullOrEmpty(startTimestampStr) || Strings.isNullOrEmpty(endTimestampStr)) {
       throw new ControllerApplicationException(LOGGER, "start and end timestamp must by non empty", Status.BAD_REQUEST);
@@ -645,16 +657,16 @@ public class PinotSegmentRestletResource {
         continue;
       }
       String tableNameWithType = TableNameBuilder.forType(tableType).tableNameWithType(tableName);
-      deleteSegmentsInternal(tableNameWithType, segments, retentionPeriod);
+      deleteSegmentsInternal(tableNameWithType, segments, retentionPeriod, force);
     }
     return new SuccessResponse("Deleted " + numSegments + " segments from table: " + tableName);
   }
 
   private void deleteSegmentsInternal(String tableNameWithType, List<String> segments,
-      @Nullable String retentionPeriod) {
+      @Nullable String retentionPeriod, boolean force) {
     PinotResourceManagerResponse response;
     try {
-      response = _pinotHelixResourceManager.deleteSegments(tableNameWithType, segments, retentionPeriod);
+      response = _pinotHelixResourceManager.deleteSegments(tableNameWithType, segments, retentionPeriod, force);
     } catch (ConsumingSegmentDeletionException e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Status.BAD_REQUEST, e);
     }
@@ -969,7 +981,8 @@ public class PinotSegmentRestletResource {
           + "For each segment provided, it identifies the partition and deletes all segments "
           + "with sequence numbers >= the provided segment in that partition. "
           + "When force flag is true, it bypasses checks for pauseless being enabled and table being paused. "
-          + "The force flag does not bypass CONSUMING segment protection. "
+          + "The force flag does not bypass CONSUMING segment protection; use DELETE /segments/{tableName} with "
+          + "force=true to recover a table by deleting CONSUMING segments. "
           + "The retention period controls how long deleted segments are retained before permanent removal. "
           + "It follows this precedence: input parameter → table config → cluster setting → 7d default. "
           + "Use 0d or -1d for immediate deletion without retention. " + CONSUMING_SEGMENT_DELETE_NOTE)
@@ -1048,7 +1061,7 @@ public class PinotSegmentRestletResource {
 
     // Delete all selected partitions as one batch so a blocked segment cannot leave earlier partitions deleted.
     if (!dryRun && !segmentsToDelete.isEmpty()) {
-      deleteSegmentsInternal(tableNameWithType, new ArrayList<>(segmentsToDelete), null);
+      deleteSegmentsInternal(tableNameWithType, new ArrayList<>(segmentsToDelete), null, false);
     }
 
     response.put("tableName", tableNameWithType);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -79,6 +80,7 @@ import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessType;
 import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
+import org.apache.pinot.controller.helix.core.ConsumingSegmentDeletionException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.PinotResourceManagerResponse;
 import org.apache.pinot.controller.util.TableMetadataReader;
@@ -145,6 +147,9 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
 @Path("/")
 public class PinotSegmentRestletResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotSegmentRestletResource.class);
+  private static final String CONSUMING_SEGMENT_DELETE_NOTE =
+      "Realtime segment deletion is rejected while any target has a CONSUMING replica. Pause the table, poll "
+          + "/tables/{tableName}/pauseStatus until consumingSegments is empty, then retry.";
 
   @Inject
   ControllerConf _controllerConf;
@@ -514,7 +519,7 @@ public class PinotSegmentRestletResource {
   @Path("/segments/{tableName}/{segmentName}")
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.DELETE_SEGMENT)
   @Authenticate(AccessType.DELETE)
-  @ApiOperation(value = "Delete a segment", notes = "Delete a segment")
+  @ApiOperation(value = "Delete a segment", notes = CONSUMING_SEGMENT_DELETE_NOTE)
   public SuccessResponse deleteSegment(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") @Encoded String segmentName,
@@ -535,7 +540,8 @@ public class PinotSegmentRestletResource {
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.DELETE_SEGMENT)
   @Authenticate(AccessType.DELETE)
   @ApiOperation(value = "Delete the list of segments provided in the queryParam else all segments",
-      notes = "Delete the list of segments provided in the queryParam else all segments")
+      notes = "Delete the list of segments provided in the queryParam else all segments. "
+          + CONSUMING_SEGMENT_DELETE_NOTE)
   public SuccessResponse deleteMultipleSegments(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "OFFLINE|REALTIME", required = true) @QueryParam("type") String tableTypeStr,
@@ -575,7 +581,7 @@ public class PinotSegmentRestletResource {
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.DELETE_SEGMENT)
   @Authenticate(AccessType.DELETE)
   @ApiOperation(value = "Delete the segments in the JSON array payload",
-      notes = "Delete the segments in the JSON array payload")
+      notes = "Delete the segments in the JSON array payload. " + CONSUMING_SEGMENT_DELETE_NOTE)
   public SuccessResponse deleteSegments(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "Retention period for the table segments (e.g. 12h, 3d); If not set, the retention period "
@@ -605,7 +611,8 @@ public class PinotSegmentRestletResource {
       + " list of segments which has not yet been replaced (determined by segment lineage entries) and can be queried"
       + " from the table. The value is false by default.",
       // TODO: more and more filters can be added later on, like excludeErrorSegments, excludeConsumingSegments, etc.
-      notes = "List all segments")
+      notes = "The OFFLINE and REALTIME parts of a hybrid table are deleted independently. "
+          + CONSUMING_SEGMENT_DELETE_NOTE)
   public SuccessResponse deleteSegmentsWithTimeWindow(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
@@ -645,8 +652,12 @@ public class PinotSegmentRestletResource {
 
   private void deleteSegmentsInternal(String tableNameWithType, List<String> segments,
       @Nullable String retentionPeriod) {
-    PinotResourceManagerResponse response =
-        _pinotHelixResourceManager.deleteSegments(tableNameWithType, segments, retentionPeriod);
+    PinotResourceManagerResponse response;
+    try {
+      response = _pinotHelixResourceManager.deleteSegments(tableNameWithType, segments, retentionPeriod);
+    } catch (ConsumingSegmentDeletionException e) {
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Status.BAD_REQUEST, e);
+    }
     if (!response.isSuccessful()) {
       throw new ControllerApplicationException(LOGGER,
           "Failed to delete segments from table: " + tableNameWithType + ", error message: " + response.getMessage(),
@@ -958,9 +969,10 @@ public class PinotSegmentRestletResource {
           + "For each segment provided, it identifies the partition and deletes all segments "
           + "with sequence numbers >= the provided segment in that partition. "
           + "When force flag is true, it bypasses checks for pauseless being enabled and table being paused. "
+          + "The force flag does not bypass CONSUMING segment protection. "
           + "The retention period controls how long deleted segments are retained before permanent removal. "
           + "It follows this precedence: input parameter → table config → cluster setting → 7d default. "
-          + "Use 0d or -1d for immediate deletion without retention.")
+          + "Use 0d or -1d for immediate deletion without retention. " + CONSUMING_SEGMENT_DELETE_NOTE)
   public String deleteSegmentsFromSequenceNum(
       @ApiParam(value = "Name of the table with type", required = true) @PathParam("tableNameWithType")
       String tableNameWithType,
@@ -1010,6 +1022,7 @@ public class PinotSegmentRestletResource {
 
     Map<String, Object> response = new HashMap<>();
     Map<Integer, Object> partitionDetails = new HashMap<>();
+    Set<String> segmentsToDelete = new TreeSet<>();
 
     for (Integer partitionID : partitionToOldestSegment.keySet()) {
       Set<String> segmentsToDeleteForPartition = partitionIdToSegmentsToDeleteMap.get(partitionID);
@@ -1024,14 +1037,18 @@ public class PinotSegmentRestletResource {
 
       partitionDetails.put(partitionID, partitionInfo);
 
-      // Only perform actual deletion if dryRun is false
       if (!dryRun) {
         LOGGER.info(
-            "Deleting {} segments from segment: {} to segment: {} for partition: {}. Segments being deleted are: {}",
+            "Selected {} segments from segment: {} to segment: {} for partition: {}. Segments selected are: {}",
             segmentsToDeleteForPartition.size(), oldestSegment, latestSegment, partitionID,
             segmentsToDeleteForPartition);
-        deleteSegmentsInternal(tableNameWithType, new ArrayList<>(segmentsToDeleteForPartition), null);
+        segmentsToDelete.addAll(segmentsToDeleteForPartition);
       }
+    }
+
+    // Delete all selected partitions as one batch so a blocked segment cannot leave earlier partitions deleted.
+    if (!dryRun && !segmentsToDelete.isEmpty()) {
+      deleteSegmentsInternal(tableNameWithType, new ArrayList<>(segmentsToDelete), null);
     }
 
     response.put("tableName", tableNameWithType);
@@ -1102,7 +1119,7 @@ public class PinotSegmentRestletResource {
 
   @VisibleForTesting
   Map<Integer, LLCSegmentName> getPartitionIDToOldestSegment(List<String> segments, Set<String> idealStateSegmentsSet) {
-    Map<Integer, LLCSegmentName> partitionToOldestSegment = new HashMap<>();
+    Map<Integer, LLCSegmentName> partitionToOldestSegment = new TreeMap<>();
 
     for (String segment : segments) {
       LLCSegmentName llcSegmentName = LLCSegmentName.of(segment);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/ConsumingSegmentDeletionException.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/ConsumingSegmentDeletionException.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core;
+
+import java.util.List;
+
+
+/// Thrown when a public deletion request targets a realtime segment with a `CONSUMING` replica in IdealState.
+///
+/// The full, immutable blocked-segment list is retained for programmatic callers, while the exception message bounds
+/// both the number and length of displayed names so an accidental delete-all request cannot create an unbounded HTTP
+/// error response. Instances are immutable and safe to share across threads after construction.
+public class ConsumingSegmentDeletionException extends RuntimeException {
+  private static final int MAX_DISPLAYED_SEGMENTS = 10;
+  private static final int MAX_DISPLAYED_SEGMENT_NAME_LENGTH = 128;
+
+  private final String _tableNameWithType;
+  private final List<String> _blockingSegments;
+
+  /// Creates an exception for a rejected realtime-table delete request.
+  ///
+  /// @param tableNameWithType realtime table resource name
+  /// @param blockingSegments target segments with at least one `CONSUMING` replica
+  public ConsumingSegmentDeletionException(String tableNameWithType, List<String> blockingSegments) {
+    super(buildMessage(tableNameWithType, blockingSegments));
+    _tableNameWithType = tableNameWithType;
+    _blockingSegments = List.copyOf(blockingSegments);
+  }
+
+  /// Returns the realtime table resource name associated with the rejected request.
+  public String getTableNameWithType() {
+    return _tableNameWithType;
+  }
+
+  /// Returns the complete immutable list of blocking segments.
+  public List<String> getBlockingSegments() {
+    return _blockingSegments;
+  }
+
+  private static String buildMessage(String tableNameWithType, List<String> blockingSegments) {
+    int blockedCount = blockingSegments.size();
+    int displayedCount = Math.min(blockedCount, MAX_DISPLAYED_SEGMENTS);
+    StringBuilder displayedSegments = new StringBuilder("[");
+    for (int i = 0; i < displayedCount; i++) {
+      if (i > 0) {
+        displayedSegments.append(", ");
+      }
+      String segmentName = blockingSegments.get(i);
+      if (segmentName.length() > MAX_DISPLAYED_SEGMENT_NAME_LENGTH) {
+        displayedSegments.append(segmentName, 0, MAX_DISPLAYED_SEGMENT_NAME_LENGTH - 3).append("...");
+      } else {
+        displayedSegments.append(segmentName);
+      }
+    }
+    displayedSegments.append(']');
+
+    return "Cannot delete " + blockedCount + " segment(s) from realtime table: " + tableNameWithType
+        + " because at least one replica is in CONSUMING state. Blocking segments (showing " + displayedCount
+        + " of " + blockedCount + "): " + displayedSegments + ". Pause the table, poll "
+        + "/tables/{tableName}/pauseStatus until consumingSegments is empty, then retry the deletion.";
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/ConsumingSegmentDeletionException.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/ConsumingSegmentDeletionException.java
@@ -21,7 +21,8 @@ package org.apache.pinot.controller.helix.core;
 import java.util.List;
 
 
-/// Thrown when a public deletion request targets a realtime segment with a `CONSUMING` replica in IdealState.
+/// Thrown when a public deletion request targets a realtime segment with a `CONSUMING` replica in IdealState
+/// and the caller did not set `force=true`.
 ///
 /// The full, immutable blocked-segment list is retained for programmatic callers, while the exception message bounds
 /// both the number and length of displayed names so an accidental delete-all request cannot create an unbounded HTTP
@@ -73,6 +74,7 @@ public class ConsumingSegmentDeletionException extends RuntimeException {
     return "Cannot delete " + blockedCount + " segment(s) from realtime table: " + tableNameWithType
         + " because at least one replica is in CONSUMING state. Blocking segments (showing " + displayedCount
         + " of " + blockedCount + "): " + displayedSegments + ". Pause the table, poll "
-        + "/tables/{tableName}/pauseStatus until consumingSegments is empty, then retry the deletion.";
+        + "/tables/{tableName}/pauseStatus until consumingSegments is empty, then retry the deletion. "
+        + "To recover a table, retry with force=true to delete CONSUMING segments.";
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -50,6 +50,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -1108,6 +1109,9 @@ public class PinotHelixResourceManager {
   ///
   /// Cleanup paths that already coordinated with the lineage lifecycle must call
   /// [#deleteSegmentsForLineageCleanup] instead.
+  /// For realtime tables, the whole batch is also rejected when any target has a `CONSUMING` replica in IdealState.
+  /// That validation and the IdealState removal happen in one versioned updater, so concurrent state transitions are
+  /// revalidated before a retry can remove anything.
   ///
   /// @param tableNameWithType Table name with type suffix
   /// @param segmentNames List of names of segment to be deleted
@@ -1118,8 +1122,8 @@ public class PinotHelixResourceManager {
     return deleteSegmentsInternal(tableNameWithType, segmentNames, retentionPeriod, false);
   }
 
-  /// Lineage-aware delete path that skips the cross-check against the live lineage entries. Reserved for callers
-  /// that have already coordinated with the lineage lifecycle: proactive cleanup in `startReplaceSegments`,
+  /// Lineage-aware delete path that bypasses the public lineage and CONSUMING-state checks. Reserved for internal
+  /// cleanup callers: proactive cleanup in `startReplaceSegments`,
   /// post-revert cleanup in `revertReplaceSegments`, and `RetentionManager`'s lineage-cleanup pass.
   /// External call sites (REST handlers, retention based on table config, minion task generators, push-failure
   /// cleanup) must continue to use the public [#deleteSegments] overloads.
@@ -1129,7 +1133,7 @@ public class PinotHelixResourceManager {
   }
 
   private PinotResourceManagerResponse deleteSegmentsInternal(String tableNameWithType, List<String> segmentNames,
-      @Nullable String retentionPeriod, boolean bypassLineageCheck) {
+      @Nullable String retentionPeriod, boolean bypassPublicDeleteChecks) {
     if (segmentNames.isEmpty()) {
       return PinotResourceManagerResponse.success("No segments to delete");
     }
@@ -1137,11 +1141,11 @@ public class PinotHelixResourceManager {
       LOGGER.info("Trying to delete segments: {} from table: {} ", segmentNames, tableNameWithType);
       Preconditions.checkArgument(TableNameBuilder.isTableResource(tableNameWithType),
           "Table name: %s is not a valid table name with type suffix", tableNameWithType);
-      if (!bypassLineageCheck && isLineageExclusiveDeleteEnabled()) {
+      if (!bypassPublicDeleteChecks && isLineageExclusiveDeleteEnabled()) {
         // Reject the whole batch if any target segment participates in a live lineage entry.
         rejectIfTargetsLineageLockedSegments(tableNameWithType, segmentNames);
       }
-      HelixHelper.removeSegmentsFromIdealState(_helixZkManager, tableNameWithType, segmentNames);
+      removeSegmentsFromIdealState(tableNameWithType, segmentNames, bypassPublicDeleteChecks);
       if (retentionPeriod != null) {
         _segmentDeletionManager.deleteSegments(tableNameWithType, segmentNames,
             TimeUtils.convertPeriodToMillis(retentionPeriod));
@@ -1150,6 +1154,8 @@ public class PinotHelixResourceManager {
         _segmentDeletionManager.deleteSegments(tableNameWithType, segmentNames, tableConfig);
       }
       return PinotResourceManagerResponse.success("Segment " + segmentNames + " deleted");
+    } catch (ConsumingSegmentDeletionException e) {
+      throw e;
     } catch (SegmentsInLineageException e) {
       LOGGER.warn("Refusing to delete segments from table: {}. {}", tableNameWithType, e.getMessage());
       return PinotResourceManagerResponse.failure(e.getMessage());
@@ -1157,6 +1163,39 @@ public class PinotHelixResourceManager {
       LOGGER.error("Caught exception while deleting segment: {} from table: {}", segmentNames, tableNameWithType, e);
       return PinotResourceManagerResponse.failure(e.getMessage());
     }
+  }
+
+  private void removeSegmentsFromIdealState(String tableNameWithType, List<String> segmentNames,
+      boolean bypassPublicDeleteChecks) {
+    if (bypassPublicDeleteChecks || !TableNameBuilder.isRealtimeTableResource(tableNameWithType)) {
+      HelixHelper.removeSegmentsFromIdealState(_helixZkManager, tableNameWithType, segmentNames);
+      return;
+    }
+
+    AtomicReference<List<String>> consumingSegmentsRef = new AtomicReference<>(List.of());
+    boolean validationPassed = HelixHelper.removeSegmentsFromIdealStateWithValidation(_helixZkManager,
+        tableNameWithType, segmentNames, idealState -> {
+          List<String> consumingSegments = getConsumingSegmentsForDeletion(idealState, segmentNames);
+          consumingSegmentsRef.set(consumingSegments);
+          return consumingSegments.isEmpty();
+        });
+    if (!validationPassed) {
+      throw new ConsumingSegmentDeletionException(tableNameWithType, consumingSegmentsRef.get());
+    }
+  }
+
+  @VisibleForTesting
+  List<String> getConsumingSegmentsForDeletion(IdealState idealState, List<String> segmentNames) {
+    List<String> consumingSegments = new ArrayList<>();
+    Set<String> seenSegments = new HashSet<>();
+    for (String segmentName : segmentNames) {
+      Map<String, String> instanceStateMap = idealState.getInstanceStateMap(segmentName);
+      if (instanceStateMap != null && instanceStateMap.containsValue(SegmentStateModel.CONSUMING)
+          && seenSegments.add(segmentName)) {
+        consumingSegments.add(segmentName);
+      }
+    }
+    return consumingSegments;
   }
 
   /// Reads the current segment lineage znode (if any) and throws [SegmentsInLineageException] when the

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1110,6 +1110,8 @@ public class PinotHelixResourceManager {
   /// Cleanup paths that already coordinated with the lineage lifecycle must call
   /// [#deleteSegmentsForLineageCleanup] instead.
   /// For realtime tables, the whole batch is also rejected when any target has a `CONSUMING` replica in IdealState.
+  /// Callers that need to recover a table by deleting CONSUMING segments must use
+  /// [#deleteSegments(String, List, String, boolean)] with `force=true`.
   /// That validation and the IdealState removal happen in one versioned updater, so concurrent state transitions are
   /// revalidated before a retry can remove anything.
   ///
@@ -1119,7 +1121,22 @@ public class PinotHelixResourceManager {
   /// @return Request response
   public PinotResourceManagerResponse deleteSegments(String tableNameWithType, List<String> segmentNames,
       @Nullable String retentionPeriod) {
-    return deleteSegmentsInternal(tableNameWithType, segmentNames, retentionPeriod, false);
+    return deleteSegments(tableNameWithType, segmentNames, retentionPeriod, false);
+  }
+
+  /// Same as [#deleteSegments(String, List, String)] but allows bypassing CONSUMING-replica protection.
+  ///
+  /// Lineage exclusivity checks still apply. `force` only skips the CONSUMING IdealState check so operators can
+  /// recover a table that still has consuming replicas.
+  ///
+  /// @param tableNameWithType Table name with type suffix
+  /// @param segmentNames List of names of segment to be deleted
+  /// @param retentionPeriod The retention period of the deleted segments.
+  /// @param force when true, delete realtime segments even if a replica is still `CONSUMING`
+  /// @return Request response
+  public PinotResourceManagerResponse deleteSegments(String tableNameWithType, List<String> segmentNames,
+      @Nullable String retentionPeriod, boolean force) {
+    return deleteSegmentsInternal(tableNameWithType, segmentNames, retentionPeriod, false, force);
   }
 
   /// Lineage-aware delete path that bypasses the public lineage and CONSUMING-state checks. Reserved for internal
@@ -1129,23 +1146,27 @@ public class PinotHelixResourceManager {
   /// cleanup) must continue to use the public [#deleteSegments] overloads.
   public PinotResourceManagerResponse deleteSegmentsForLineageCleanup(String tableNameWithType,
       List<String> segmentNames) {
-    return deleteSegmentsInternal(tableNameWithType, segmentNames, null, true);
+    return deleteSegmentsInternal(tableNameWithType, segmentNames, null, true, false);
   }
 
   private PinotResourceManagerResponse deleteSegmentsInternal(String tableNameWithType, List<String> segmentNames,
-      @Nullable String retentionPeriod, boolean bypassPublicDeleteChecks) {
+      @Nullable String retentionPeriod, boolean bypassPublicDeleteChecks, boolean force) {
     if (segmentNames.isEmpty()) {
       return PinotResourceManagerResponse.success("No segments to delete");
     }
     try {
-      LOGGER.info("Trying to delete segments: {} from table: {} ", segmentNames, tableNameWithType);
+      LOGGER.info("Trying to delete segments: {} from table: {} (force={})", segmentNames, tableNameWithType, force);
+      if (force && TableNameBuilder.isRealtimeTableResource(tableNameWithType)) {
+        LOGGER.warn("Force-deleting segments from table: {} (CONSUMING replica protection bypassed): {}",
+            tableNameWithType, segmentNames);
+      }
       Preconditions.checkArgument(TableNameBuilder.isTableResource(tableNameWithType),
           "Table name: %s is not a valid table name with type suffix", tableNameWithType);
       if (!bypassPublicDeleteChecks && isLineageExclusiveDeleteEnabled()) {
         // Reject the whole batch if any target segment participates in a live lineage entry.
         rejectIfTargetsLineageLockedSegments(tableNameWithType, segmentNames);
       }
-      removeSegmentsFromIdealState(tableNameWithType, segmentNames, bypassPublicDeleteChecks);
+      removeSegmentsFromIdealState(tableNameWithType, segmentNames, bypassPublicDeleteChecks || force);
       if (retentionPeriod != null) {
         _segmentDeletionManager.deleteSegments(tableNameWithType, segmentNames,
             TimeUtils.convertPeriodToMillis(retentionPeriod));
@@ -1166,8 +1187,8 @@ public class PinotHelixResourceManager {
   }
 
   private void removeSegmentsFromIdealState(String tableNameWithType, List<String> segmentNames,
-      boolean bypassPublicDeleteChecks) {
-    if (bypassPublicDeleteChecks || !TableNameBuilder.isRealtimeTableResource(tableNameWithType)) {
+      boolean bypassConsumingCheck) {
+    if (bypassConsumingCheck || !TableNameBuilder.isRealtimeTableResource(tableNameWithType)) {
       HelixHelper.removeSegmentsFromIdealState(_helixZkManager, tableNameWithType, segmentNames);
       return;
     }
@@ -1229,6 +1250,9 @@ public class PinotHelixResourceManager {
   }
 
   /// Delete a single segment from ideal state and remove it from the local storage.
+  ///
+  /// Realtime segments with a `CONSUMING` replica are rejected. Use
+  /// [#deleteSegments(String, List, String, boolean)] with `force=true` to recover a table.
   ///
   /// @param tableNameWithType Table name with type suffix
   /// @param segmentName Name of segment to be deleted

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1112,8 +1112,9 @@ public class PinotHelixResourceManager {
   /// For realtime tables, the whole batch is also rejected when any target has a `CONSUMING` replica in IdealState.
   /// Callers that need to recover a table by deleting CONSUMING segments must use
   /// [#deleteSegments(String, List, String, boolean)] with `force=true`.
-  /// That validation and the IdealState removal happen in one versioned updater, so concurrent state transitions are
-  /// revalidated before a retry can remove anything.
+  /// The default path runs that CONSUMING check and IdealState removal in one versioned updater, so concurrent
+  /// state transitions are revalidated before a retry can remove anything. `force=true` skips only the CONSUMING
+  /// check and uses the unguarded IdealState remover; lineage exclusivity still applies.
   ///
   /// @param tableNameWithType Table name with type suffix
   /// @param segmentNames List of names of segment to be deleted

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentRestletResourceTest.java
@@ -18,32 +18,53 @@
  */
 package org.apache.pinot.controller.api;
 
+import java.lang.reflect.Field;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
+import org.apache.helix.model.IdealState;
 import org.apache.pinot.client.admin.PinotAdminClient;
+import org.apache.pinot.client.admin.PinotAdminException;
+import org.apache.pinot.client.admin.PinotAdminValidationException;
 import org.apache.pinot.common.lineage.SegmentLineage;
 import org.apache.pinot.common.lineage.SegmentLineageAccessHelper;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.SegmentDeletionManager;
 import org.apache.pinot.controller.utils.SegmentMetadataMockUtils;
+import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 
 public class PinotSegmentRestletResourceTest {
@@ -238,6 +259,142 @@ public class PinotSegmentRestletResourceTest {
         .deleteMultipleSegments(TEST_RAW_OFFLINE_TABLE_NAME, TableType.OFFLINE.toString(), List.of(),
             null);
     assertTrue(reply.contains("All segments of table offlineTableName1_OFFLINE deleted"));
+  }
+
+  @Test
+  public void testRealtimeConsumingSegmentDeleteHttpContracts()
+      throws Exception {
+    String rawTableName = "consumingSegmentDeleteRest";
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(rawTableName);
+    TEST_INSTANCE.addDummySchema(rawTableName);
+    PinotHelixResourceManager resourceManager = TEST_INSTANCE.getHelixResourceManager();
+    try {
+      TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(rawTableName)
+          .setDeletedSegmentsRetentionPeriod("0d")
+          .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap()).build();
+      resourceManager.addTable(tableConfig);
+
+      TestUtils.waitForCondition(aVoid -> getConsumingSegment(resourceManager, realtimeTableName) != null, 60_000L,
+          "Failed to create a consuming segment for table: " + realtimeTableName);
+      String consumingSegment = getConsumingSegment(resourceManager, realtimeTableName);
+      assertNotNull(consumingSegment);
+      String completedSegment = "completedSegment";
+      resourceManager.addNewSegment(realtimeTableName,
+          SegmentMetadataMockUtils.mockSegmentMetadata(realtimeTableName, completedSegment), "downloadUrl");
+      assertFalse(resourceManager.getTableIdealState(realtimeTableName).getInstanceStateMap(completedSegment)
+          .containsValue(SegmentStateModel.CONSUMING));
+
+      PinotAdminClient adminClient = TEST_INSTANCE.getOrCreateAdminClient();
+      PinotAdminValidationException singleDeleteException = expectThrows(PinotAdminValidationException.class,
+          () -> adminClient.getSegmentClient().deleteSegment(realtimeTableName, consumingSegment, null));
+      assertTrue(singleDeleteException.getMessage().contains("status: 400"), singleDeleteException.getMessage());
+      assertTrue(singleDeleteException.getMessage().contains(consumingSegment), singleDeleteException.getMessage());
+      assertTrue(singleDeleteException.getMessage().contains("/tables/{tableName}/pauseStatus"),
+          singleDeleteException.getMessage());
+      assertTrue(singleDeleteException.getMessage().contains("consumingSegments is empty"),
+          singleDeleteException.getMessage());
+
+      URI batchDeleteUri = URI.create(TEST_INSTANCE.getControllerBaseApiUrl() + "/segments/" + rawTableName
+          + "?type=REALTIME&segments=" + completedSegment + "&segments=" + consumingSegment);
+      SimpleHttpResponse batchDeleteResponse =
+          ControllerTest.getHttpClient().sendDeleteRequest(batchDeleteUri, Map.of());
+      assertEquals(batchDeleteResponse.getStatusCode(), 400, batchDeleteResponse.getResponse());
+      assertTrue(batchDeleteResponse.getResponse().contains(consumingSegment), batchDeleteResponse.getResponse());
+      assertTrue(resourceManager.getTableIdealState(realtimeTableName).getPartitionSet()
+          .containsAll(Set.of(completedSegment, consumingSegment)));
+
+      LLCSegmentName currentConsumingSegment = new LLCSegmentName(consumingSegment);
+      String onlineLowerPartitionSegment = new LLCSegmentName(rawTableName,
+          currentConsumingSegment.getPartitionGroupId(), currentConsumingSegment.getSequenceNumber() + 1,
+          System.currentTimeMillis()).getSegmentName();
+      String consumingHigherPartitionSegment = new LLCSegmentName(rawTableName,
+          currentConsumingSegment.getPartitionGroupId() + 1, 0, System.currentTimeMillis()).getSegmentName();
+      HelixHelper.updateIdealState(TEST_INSTANCE.getHelixManager(), realtimeTableName, idealState -> {
+        String server = idealState.getInstanceStateMap(consumingSegment).keySet().iterator().next();
+        idealState.getRecord().setMapField(onlineLowerPartitionSegment,
+            new HashMap<>(Map.of(server, SegmentStateModel.ONLINE)));
+        idealState.getRecord().setMapField(consumingHigherPartitionSegment,
+            new HashMap<>(Map.of(server, SegmentStateModel.CONSUMING)));
+        return idealState;
+      });
+
+      URI forceDeleteUri = URI.create(TEST_INSTANCE.getControllerBaseApiUrl()
+          + "/deleteSegmentsFromSequenceNum/" + realtimeTableName + "?segments=" + onlineLowerPartitionSegment
+          + "&segments=" + consumingHigherPartitionSegment + "&dryRun=false&force=true");
+      SimpleHttpResponse forceDeleteResponse =
+          ControllerTest.getHttpClient().sendDeleteRequest(forceDeleteUri, Map.of());
+      assertEquals(forceDeleteResponse.getStatusCode(), 400, forceDeleteResponse.getResponse());
+      assertTrue(forceDeleteResponse.getResponse().contains(consumingHigherPartitionSegment),
+          forceDeleteResponse.getResponse());
+      assertTrue(resourceManager.getTableIdealState(realtimeTableName).getPartitionSet()
+          .containsAll(Set.of(onlineLowerPartitionSegment, consumingHigherPartitionSegment)));
+
+      Set<String> beforeDeleteAll =
+          Set.copyOf(resourceManager.getTableIdealState(realtimeTableName).getPartitionSet());
+      PinotAdminValidationException deleteAllException = expectThrows(PinotAdminValidationException.class,
+          () -> adminClient.getSegmentClient().deleteMultipleSegments(rawTableName, TableType.REALTIME.name(),
+              List.of(), null));
+      assertTrue(deleteAllException.getMessage().contains("status: 400"), deleteAllException.getMessage());
+      assertEquals(resourceManager.getTableIdealState(realtimeTableName).getPartitionSet(), beforeDeleteAll);
+
+      String successResponse =
+          adminClient.getSegmentClient().deleteSegment(realtimeTableName, completedSegment, null);
+      assertTrue(successResponse.contains("Segment deleted"), successResponse);
+      assertFalse(resourceManager.getTableIdealState(realtimeTableName).getPartitionSet().contains(completedSegment));
+      assertTrue(resourceManager.getTableIdealState(realtimeTableName).getPartitionSet().contains(consumingSegment));
+
+      String failingSegment = "failingCompletedSegment";
+      resourceManager.addNewSegment(realtimeTableName,
+          SegmentMetadataMockUtils.mockSegmentMetadata(realtimeTableName, failingSegment), "downloadUrl");
+      SegmentDeletionManager failingDeletionManager = mock(SegmentDeletionManager.class);
+      doThrow(new RuntimeException("test deletion failure")).when(failingDeletionManager)
+          .deleteSegments(eq(realtimeTableName), anyCollection(), nullable(Long.class));
+      SegmentDeletionManager originalDeletionManager = replaceSegmentDeletionManager(resourceManager,
+          failingDeletionManager);
+      try {
+        PinotAdminException internalError = expectThrows(PinotAdminException.class,
+            () -> adminClient.getSegmentClient().deleteSegment(realtimeTableName, failingSegment, "0d"));
+        assertTrue(internalError.getMessage().contains("status: 500"), internalError.getMessage());
+      } finally {
+        replaceSegmentDeletionManager(resourceManager, originalDeletionManager);
+      }
+
+      // Dropping a realtime table remains the supported unconditional cleanup path.
+      resourceManager.deleteRealtimeTable(rawTableName, "0d");
+      assertNull(resourceManager.getTableIdealState(realtimeTableName));
+    } finally {
+      try {
+        if (resourceManager.getTableIdealState(realtimeTableName) != null) {
+          resourceManager.deleteRealtimeTable(rawTableName, "0d");
+        }
+      } finally {
+        TEST_INSTANCE.deleteSchema(rawTableName);
+      }
+    }
+  }
+
+  private static String getConsumingSegment(PinotHelixResourceManager resourceManager, String realtimeTableName) {
+    IdealState idealState = resourceManager.getTableIdealState(realtimeTableName);
+    if (idealState == null) {
+      return null;
+    }
+    for (String segmentName : idealState.getPartitionSet()) {
+      Map<String, String> stateMap = idealState.getInstanceStateMap(segmentName);
+      if (stateMap != null && stateMap.containsValue(SegmentStateModel.CONSUMING)) {
+        return segmentName;
+      }
+    }
+    return null;
+  }
+
+  private static SegmentDeletionManager replaceSegmentDeletionManager(PinotHelixResourceManager resourceManager,
+      SegmentDeletionManager replacement)
+      throws ReflectiveOperationException {
+    Field field = PinotHelixResourceManager.class.getDeclaredField("_segmentDeletionManager");
+    field.setAccessible(true);
+    SegmentDeletionManager previous = (SegmentDeletionManager) field.get(resourceManager);
+    field.set(resourceManager, replacement);
+    return previous;
   }
 
   private void checkCrcRequest(PinotAdminClient adminClient, String tableName,

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentRestletResourceTest.java
@@ -254,6 +254,14 @@ public class PinotSegmentRestletResourceTest {
         .deleteMultipleSegments(TEST_RAW_OFFLINE_TABLE_NAME, TableType.OFFLINE.toString(), List.of("segment1"), null);
     assertTrue(reply.contains("Deleted segments: [segment1] from table: offlineTableName1_OFFLINE"));
 
+    // force=true is a no-op extra for OFFLINE tables and must still succeed.
+    URI forceOfflineUri = URI.create(TEST_INSTANCE.getControllerBaseApiUrl() + "/segments/"
+        + TEST_RAW_OFFLINE_TABLE_NAME + "/segment2?force=true");
+    SimpleHttpResponse forceOfflineResponse =
+        ControllerTest.getHttpClient().sendDeleteRequest(forceOfflineUri, Map.of());
+    assertEquals(forceOfflineResponse.getStatusCode(), 200, forceOfflineResponse.getResponse());
+    assertFalse(resourceManager.getTableIdealState(offlineTableName).getPartitionSet().contains("segment2"));
+
     // case 2: delete all remaining segments
     reply = adminClient.getSegmentClient()
         .deleteMultipleSegments(TEST_RAW_OFFLINE_TABLE_NAME, TableType.OFFLINE.toString(), List.of(),
@@ -293,6 +301,7 @@ public class PinotSegmentRestletResourceTest {
           singleDeleteException.getMessage());
       assertTrue(singleDeleteException.getMessage().contains("consumingSegments is empty"),
           singleDeleteException.getMessage());
+      assertTrue(singleDeleteException.getMessage().contains("force=true"), singleDeleteException.getMessage());
 
       URI batchDeleteUri = URI.create(TEST_INSTANCE.getControllerBaseApiUrl() + "/segments/" + rawTableName
           + "?type=REALTIME&segments=" + completedSegment + "&segments=" + consumingSegment);
@@ -358,6 +367,32 @@ public class PinotSegmentRestletResourceTest {
       } finally {
         replaceSegmentDeletionManager(resourceManager, originalDeletionManager);
       }
+
+      String forceOnlineSegment = "forceOnlineSegment";
+      String forceConsumingSegment = "forceConsumingSegment";
+      HelixHelper.updateIdealState(TEST_INSTANCE.getHelixManager(), realtimeTableName, idealState -> {
+        String server = idealState.getInstanceStateMap(consumingSegment).keySet().iterator().next();
+        idealState.getRecord().setMapField(forceOnlineSegment,
+            new HashMap<>(Map.of(server, SegmentStateModel.ONLINE)));
+        idealState.getRecord().setMapField(forceConsumingSegment,
+            new HashMap<>(Map.of(server, SegmentStateModel.CONSUMING)));
+        return idealState;
+      });
+
+      URI mixedForceUri = URI.create(TEST_INSTANCE.getControllerBaseApiUrl() + "/segments/" + rawTableName
+          + "?type=REALTIME&segments=" + forceOnlineSegment + "&segments=" + forceConsumingSegment + "&force=true");
+      SimpleHttpResponse mixedForceResponse =
+          ControllerTest.getHttpClient().sendDeleteRequest(mixedForceUri, Map.of());
+      assertEquals(mixedForceResponse.getStatusCode(), 200, mixedForceResponse.getResponse());
+      assertFalse(resourceManager.getTableIdealState(realtimeTableName).getPartitionSet()
+          .contains(forceOnlineSegment));
+      assertFalse(resourceManager.getTableIdealState(realtimeTableName).getPartitionSet()
+          .contains(forceConsumingSegment));
+
+      String forceSingleResponse =
+          adminClient.getSegmentClient().deleteSegment(realtimeTableName, consumingSegment, null, true);
+      assertTrue(forceSingleResponse.contains("Segment deleted"), forceSingleResponse);
+      assertFalse(resourceManager.getTableIdealState(realtimeTableName).getPartitionSet().contains(consumingSegment));
 
       // Dropping a realtime table remains the supported unconditional cleanup path.
       resourceManager.deleteRealtimeTable(rawTableName, "0d");

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -29,8 +29,14 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
@@ -86,6 +92,7 @@ import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamMetadata;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
+import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.spi.utils.CommonConstants.Segment;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
@@ -100,10 +107,15 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -1862,6 +1874,205 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     // Cleanup
     assertTrue(ZKMetadataProvider.removeSegmentZKMetadata(_propertyStore, OFFLINE_TABLE_NAME, segName1));
     assertTrue(ZKMetadataProvider.removeSegmentZKMetadata(_propertyStore, OFFLINE_TABLE_NAME, segName2));
+  }
+
+  @Test
+  public void testRejectConsumingSegmentDeleteAtomically()
+      throws Exception {
+    String tableNameWithType = "consumingDeleteBatch_REALTIME";
+    String onlineSegment = "onlineSegment";
+    String consumingSegment = "consumingSegment";
+    addIdealStateResource(tableNameWithType, Map.of(
+        onlineSegment, Map.of("Server_1", SegmentStateModel.ONLINE),
+        consumingSegment, Map.of("Server_1", SegmentStateModel.ONLINE, "Server_2", SegmentStateModel.CONSUMING)));
+    assertTrue(ZKMetadataProvider.setSegmentZKMetadata(_propertyStore, tableNameWithType,
+        new SegmentZKMetadata(onlineSegment)));
+    assertTrue(ZKMetadataProvider.setSegmentZKMetadata(_propertyStore, tableNameWithType,
+        new SegmentZKMetadata(consumingSegment)));
+
+    SegmentDeletionManager mockDeletionManager = mock(SegmentDeletionManager.class);
+    SegmentDeletionManager originalDeletionManager = replaceSegmentDeletionManager(mockDeletionManager);
+    try {
+      ConsumingSegmentDeletionException exception = expectThrows(ConsumingSegmentDeletionException.class,
+          () -> _helixResourceManager.deleteSegments(tableNameWithType,
+              Arrays.asList(onlineSegment, consumingSegment)));
+      assertEquals(exception.getBlockingSegments(), List.of(consumingSegment));
+      assertTrue(exception.getMessage().contains("showing 1 of 1"), exception.getMessage());
+      assertTrue(exception.getMessage().contains("/tables/{tableName}/pauseStatus"), exception.getMessage());
+      assertTrue(exception.getMessage().contains("consumingSegments is empty"), exception.getMessage());
+
+      IdealState unchangedIdealState = _helixResourceManager.getTableIdealState(tableNameWithType);
+      assertNotNull(unchangedIdealState);
+      assertTrue(unchangedIdealState.getPartitionSet().containsAll(List.of(onlineSegment, consumingSegment)));
+      assertNotNull(ZKMetadataProvider.getSegmentZKMetadata(_propertyStore, tableNameWithType, onlineSegment));
+      assertNotNull(ZKMetadataProvider.getSegmentZKMetadata(_propertyStore, tableNameWithType, consumingSegment));
+      verify(mockDeletionManager, never()).deleteSegments(eq(tableNameWithType), anyCollection(),
+          nullable(TableConfig.class));
+
+      HelixHelper.updateIdealState(_helixManager, tableNameWithType, idealState -> {
+        idealState.setPartitionState(consumingSegment, "Server_2", SegmentStateModel.ONLINE);
+        return idealState;
+      });
+      PinotResourceManagerResponse response = _helixResourceManager.deleteSegments(tableNameWithType,
+          Arrays.asList(onlineSegment, consumingSegment));
+      assertTrue(response.isSuccessful(), response.getMessage());
+      IdealState finalIdealState = _helixResourceManager.getTableIdealState(tableNameWithType);
+      assertNotNull(finalIdealState);
+      assertFalse(finalIdealState.getPartitionSet().contains(onlineSegment));
+      assertFalse(finalIdealState.getPartitionSet().contains(consumingSegment));
+      verify(mockDeletionManager).deleteSegments(eq(tableNameWithType),
+          eq(Arrays.asList(onlineSegment, consumingSegment)), nullable(TableConfig.class));
+    } finally {
+      replaceSegmentDeletionManager(originalDeletionManager);
+      ZKMetadataProvider.removeSegmentZKMetadata(_propertyStore, tableNameWithType, onlineSegment);
+      ZKMetadataProvider.removeSegmentZKMetadata(_propertyStore, tableNameWithType, consumingSegment);
+      dropResourceIfPresent(tableNameWithType);
+    }
+  }
+
+  @Test
+  public void testConsumingSegmentDeleteEdgeCasesAndInternalBypass()
+      throws Exception {
+    String realtimeTable = "consumingDeleteEdges_REALTIME";
+    String offlineTable = "consumingDeleteEdges_OFFLINE";
+    String bypassTable = "consumingDeleteBypass_REALTIME";
+    String onlineSegment = "onlineSegment";
+    String emptyStateSegment = "emptyStateSegment";
+    String offlineConsumingSegment = "offlineConsumingSegment";
+    String bypassConsumingSegment = "bypassConsumingSegment";
+    addIdealStateResource(realtimeTable, Map.of(
+        onlineSegment, Map.of("Server_1", SegmentStateModel.ONLINE), emptyStateSegment, Map.of()));
+    addIdealStateResource(offlineTable,
+        Map.of(offlineConsumingSegment, Map.of("Server_1", SegmentStateModel.CONSUMING)));
+    addIdealStateResource(bypassTable,
+        Map.of(bypassConsumingSegment, Map.of("Server_1", SegmentStateModel.CONSUMING)));
+
+    SegmentDeletionManager mockDeletionManager = mock(SegmentDeletionManager.class);
+    SegmentDeletionManager originalDeletionManager = replaceSegmentDeletionManager(mockDeletionManager);
+    try {
+      PinotResourceManagerResponse absentResponse =
+          _helixResourceManager.deleteSegments(realtimeTable, List.of("absentSegment"));
+      assertTrue(absentResponse.isSuccessful(), absentResponse.getMessage());
+      IdealState realtimeIdealState = _helixResourceManager.getTableIdealState(realtimeTable);
+      assertNotNull(realtimeIdealState);
+      assertTrue(realtimeIdealState.getPartitionSet().containsAll(List.of(onlineSegment, emptyStateSegment)));
+
+      PinotResourceManagerResponse emptyStateResponse =
+          _helixResourceManager.deleteSegments(realtimeTable, List.of(emptyStateSegment));
+      assertTrue(emptyStateResponse.isSuccessful(), emptyStateResponse.getMessage());
+      assertFalse(_helixResourceManager.getTableIdealState(realtimeTable).getPartitionSet()
+          .contains(emptyStateSegment));
+
+      String missingIdealStateTable = "missingConsumingDelete_REALTIME";
+      PinotResourceManagerResponse missingIdealStateResponse =
+          _helixResourceManager.deleteSegments(missingIdealStateTable, List.of("missingSegment"));
+      assertFalse(missingIdealStateResponse.isSuccessful(), missingIdealStateResponse.getMessage());
+      verify(mockDeletionManager, never()).deleteSegments(eq(missingIdealStateTable), anyCollection(),
+          nullable(TableConfig.class));
+
+      PinotResourceManagerResponse offlineResponse =
+          _helixResourceManager.deleteSegments(offlineTable, List.of(offlineConsumingSegment));
+      assertTrue(offlineResponse.isSuccessful(), offlineResponse.getMessage());
+      assertFalse(_helixResourceManager.getTableIdealState(offlineTable).getPartitionSet()
+          .contains(offlineConsumingSegment));
+
+      PinotResourceManagerResponse bypassResponse = _helixResourceManager.deleteSegmentsForLineageCleanup(
+          bypassTable, List.of(bypassConsumingSegment));
+      assertTrue(bypassResponse.isSuccessful(), bypassResponse.getMessage());
+      assertFalse(_helixResourceManager.getTableIdealState(bypassTable).getPartitionSet()
+          .contains(bypassConsumingSegment));
+
+      IdealState nullStateMap = new IdealState("nullStateMap_REALTIME");
+      nullStateMap.getRecord().getMapFields().put("nullStateSegment", null);
+      assertTrue(_helixResourceManager.getConsumingSegmentsForDeletion(nullStateMap,
+          List.of("nullStateSegment")).isEmpty());
+
+      List<String> manySegments = new ArrayList<>();
+      for (int i = 0; i < 12; i++) {
+        manySegments.add("segment_" + i);
+      }
+      ConsumingSegmentDeletionException boundedException =
+          new ConsumingSegmentDeletionException(realtimeTable, manySegments);
+      assertEquals(boundedException.getBlockingSegments().size(), 12);
+      assertTrue(boundedException.getMessage().contains("showing 10 of 12"), boundedException.getMessage());
+      assertFalse(boundedException.getMessage().contains("segment_11"), boundedException.getMessage());
+    } finally {
+      replaceSegmentDeletionManager(originalDeletionManager);
+      dropResourceIfPresent(realtimeTable);
+      dropResourceIfPresent(offlineTable);
+      dropResourceIfPresent(bypassTable);
+    }
+  }
+
+  @Test
+  public void testConcurrentTransitionToConsumingBlocksDelete()
+      throws Exception {
+    String tableNameWithType = "concurrentConsumingDelete_REALTIME";
+    String segmentName = "concurrentSegment";
+    addIdealStateResource(tableNameWithType,
+        Map.of(segmentName, Map.of("Server_1", SegmentStateModel.ONLINE)));
+
+    PinotHelixResourceManager spyResourceManager = spy(_helixResourceManager);
+    CountDownLatch validatorEntered = new CountDownLatch(1);
+    CountDownLatch stateTransitioned = new CountDownLatch(1);
+    AtomicBoolean firstValidation = new AtomicBoolean(true);
+    doAnswer(invocation -> {
+      if (firstValidation.compareAndSet(true, false)) {
+        validatorEntered.countDown();
+        assertTrue(stateTransitioned.await(10, TimeUnit.SECONDS), "Timed out waiting for state transition");
+      }
+      return invocation.callRealMethod();
+    }).when(spyResourceManager).getConsumingSegmentsForDeletion(any(IdealState.class), anyList());
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    Future<PinotResourceManagerResponse> deleteFuture =
+        executor.submit(() -> spyResourceManager.deleteSegments(tableNameWithType, List.of(segmentName)));
+    try {
+      assertTrue(validatorEntered.await(10, TimeUnit.SECONDS), "Delete updater did not reach validation");
+      IdealState transitionedIdealState = _helixAdmin.getResourceIdealState(_clusterName, tableNameWithType);
+      transitionedIdealState.setPartitionState(segmentName, "Server_1", SegmentStateModel.CONSUMING);
+      _helixAdmin.updateIdealState(_clusterName, tableNameWithType, transitionedIdealState);
+      stateTransitioned.countDown();
+
+      ExecutionException executionException = expectThrows(ExecutionException.class,
+          () -> deleteFuture.get(10, TimeUnit.SECONDS));
+      assertTrue(executionException.getCause() instanceof ConsumingSegmentDeletionException,
+          String.valueOf(executionException.getCause()));
+      IdealState finalIdealState = _helixAdmin.getResourceIdealState(_clusterName, tableNameWithType);
+      assertTrue(finalIdealState.getPartitionSet().contains(segmentName));
+      assertEquals(finalIdealState.getInstanceStateMap(segmentName).get("Server_1"), SegmentStateModel.CONSUMING);
+    } finally {
+      stateTransitioned.countDown();
+      executor.shutdownNow();
+      dropResourceIfPresent(tableNameWithType);
+    }
+  }
+
+  private void addIdealStateResource(String tableNameWithType, Map<String, Map<String, String>> segmentStates) {
+    IdealState idealState = new IdealState(tableNameWithType);
+    idealState.setStateModelDefRef("OnlineOffline");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+    idealState.setReplicas("2");
+    idealState.setNumPartitions(segmentStates.size());
+    for (Map.Entry<String, Map<String, String>> entry : segmentStates.entrySet()) {
+      idealState.getRecord().setMapField(entry.getKey(), new HashMap<>(entry.getValue()));
+    }
+    _helixAdmin.addResource(_clusterName, tableNameWithType, idealState);
+  }
+
+  private SegmentDeletionManager replaceSegmentDeletionManager(SegmentDeletionManager replacement)
+      throws ReflectiveOperationException {
+    Field field = PinotHelixResourceManager.class.getDeclaredField("_segmentDeletionManager");
+    field.setAccessible(true);
+    SegmentDeletionManager previous = (SegmentDeletionManager) field.get(_helixResourceManager);
+    field.set(_helixResourceManager, replacement);
+    return previous;
+  }
+
+  private void dropResourceIfPresent(String tableNameWithType) {
+    if (_helixAdmin.getResourceIdealState(_clusterName, tableNameWithType) != null) {
+      _helixAdmin.dropResource(_clusterName, tableNameWithType);
+    }
   }
 
   @AfterClass

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -1900,6 +1900,7 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
       assertTrue(exception.getMessage().contains("showing 1 of 1"), exception.getMessage());
       assertTrue(exception.getMessage().contains("/tables/{tableName}/pauseStatus"), exception.getMessage());
       assertTrue(exception.getMessage().contains("consumingSegments is empty"), exception.getMessage());
+      assertTrue(exception.getMessage().contains("force=true"), exception.getMessage());
 
       IdealState unchangedIdealState = _helixResourceManager.getTableIdealState(tableNameWithType);
       assertNotNull(unchangedIdealState);
@@ -1927,6 +1928,52 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
       ZKMetadataProvider.removeSegmentZKMetadata(_propertyStore, tableNameWithType, onlineSegment);
       ZKMetadataProvider.removeSegmentZKMetadata(_propertyStore, tableNameWithType, consumingSegment);
       dropResourceIfPresent(tableNameWithType);
+    }
+  }
+
+  @Test
+  public void testForceDeleteConsumingSegments()
+      throws Exception {
+    String tableNameWithType = "forceDeleteConsuming_REALTIME";
+    String offlineTable = "forceDeleteConsuming_OFFLINE";
+    String onlineSegment = "onlineSegment";
+    String consumingSegment = "consumingSegment";
+    String offlineSegment = "offlineSegment";
+    addIdealStateResource(tableNameWithType, Map.of(
+        onlineSegment, Map.of("Server_1", SegmentStateModel.ONLINE),
+        consumingSegment, Map.of("Server_1", SegmentStateModel.CONSUMING)));
+    addIdealStateResource(offlineTable, Map.of(offlineSegment, Map.of("Server_1", SegmentStateModel.ONLINE)));
+
+    SegmentDeletionManager mockDeletionManager = mock(SegmentDeletionManager.class);
+    SegmentDeletionManager originalDeletionManager = replaceSegmentDeletionManager(mockDeletionManager);
+    try {
+      ConsumingSegmentDeletionException exception = expectThrows(ConsumingSegmentDeletionException.class,
+          () -> _helixResourceManager.deleteSegments(tableNameWithType,
+              Arrays.asList(onlineSegment, consumingSegment)));
+      assertEquals(exception.getBlockingSegments(), List.of(consumingSegment));
+      assertTrue(_helixResourceManager.getTableIdealState(tableNameWithType).getPartitionSet()
+          .containsAll(List.of(onlineSegment, consumingSegment)));
+      verify(mockDeletionManager, never()).deleteSegments(eq(tableNameWithType), anyCollection(),
+          nullable(TableConfig.class));
+
+      PinotResourceManagerResponse forceResponse = _helixResourceManager.deleteSegments(tableNameWithType,
+          Arrays.asList(onlineSegment, consumingSegment), null, true);
+      assertTrue(forceResponse.isSuccessful(), forceResponse.getMessage());
+      IdealState afterForce = _helixResourceManager.getTableIdealState(tableNameWithType);
+      assertNotNull(afterForce);
+      assertFalse(afterForce.getPartitionSet().contains(onlineSegment));
+      assertFalse(afterForce.getPartitionSet().contains(consumingSegment));
+      verify(mockDeletionManager).deleteSegments(eq(tableNameWithType),
+          eq(Arrays.asList(onlineSegment, consumingSegment)), nullable(TableConfig.class));
+
+      PinotResourceManagerResponse offlineResponse =
+          _helixResourceManager.deleteSegments(offlineTable, List.of(offlineSegment), null, true);
+      assertTrue(offlineResponse.isSuccessful(), offlineResponse.getMessage());
+      assertFalse(_helixResourceManager.getTableIdealState(offlineTable).getPartitionSet().contains(offlineSegment));
+    } finally {
+      replaceSegmentDeletionManager(originalDeletionManager);
+      dropResourceIfPresent(tableNameWithType);
+      dropResourceIfPresent(offlineTable);
     }
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/lineage/LineageDeleteExclusionTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/lineage/LineageDeleteExclusionTest.java
@@ -160,6 +160,17 @@ public class LineageDeleteExclusionTest {
   }
 
   @Test
+  public void testForceDoesNotBypassLineageLock() {
+    addSegments("forceA1", "forceB1");
+    writeLineageEntry("e1", List.of("forceA1"), List.of("forceB1"), LineageEntryState.IN_PROGRESS);
+    PinotResourceManagerResponse response =
+        _resourceManager.deleteSegments(OFFLINE_TABLE_NAME, List.of("forceA1"), null, true);
+    assertFalse(response.isSuccessful());
+    assertTrue(response.getMessage().contains("forceA1"));
+    assertTrue(_resourceManager.getSegmentsFor(OFFLINE_TABLE_NAME, false).contains("forceA1"));
+  }
+
+  @Test
   public void testBypassOverloadAllowsBlockedSegments() {
     addSegments("byA1", "byB1");
     writeLineageEntry("e1", List.of("byA1"), List.of("byB1"),

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
@@ -44,7 +44,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 
 
@@ -116,22 +115,7 @@ public class UpsertTableSegmentPreloadIntegrationTest extends BaseClusterIntegra
   public void tearDown()
       throws IOException {
     String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
-
-    // Test dropping all segments one by one
-    List<String> segments = listSegments(realtimeTableName);
-    assertFalse(segments.isEmpty());
-    for (String segment : segments) {
-      dropSegment(realtimeTableName, segment);
-    }
-    // NOTE: There is a delay to remove the segment from property store
-    TestUtils.waitForCondition((aVoid) -> {
-      try {
-        return listSegments(realtimeTableName).isEmpty();
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    }, 60_000L, "Failed to drop the segments");
-
+    // Public segment delete rejects CONSUMING replicas. Table drop is the supported cleanup.
     dropRealtimeTable(realtimeTableName);
     stopServer();
     stopBroker();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
@@ -115,7 +115,7 @@ public class UpsertTableSegmentPreloadIntegrationTest extends BaseClusterIntegra
   public void tearDown()
       throws IOException {
     String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
-    // Public segment delete rejects CONSUMING replicas. Table drop is the supported cleanup.
+    // Public segment delete rejects CONSUMING replicas unless force=true. Table drop remains the cleanup path.
     dropRealtimeTable(realtimeTableName);
     stopServer();
     stopBroker();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentUploadIntegrationTest.java
@@ -37,7 +37,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 
 
 public class UpsertTableSegmentUploadIntegrationTest extends BaseClusterIntegrationTestSet {
@@ -90,22 +89,7 @@ public class UpsertTableSegmentUploadIntegrationTest extends BaseClusterIntegrat
   public void tearDown()
       throws IOException {
     String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
-
-    // Test dropping all segments one by one
-    List<String> segments = listSegments(realtimeTableName);
-    assertFalse(segments.isEmpty());
-    for (String segment : segments) {
-      dropSegment(realtimeTableName, segment);
-    }
-    // NOTE: There is a delay to remove the segment from property store
-    TestUtils.waitForCondition((aVoid) -> {
-      try {
-        return listSegments(realtimeTableName).isEmpty();
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    }, 60_000L, "Failed to drop the segments");
-
+    // Public segment delete rejects CONSUMING replicas. Table drop is the supported cleanup.
     dropRealtimeTable(realtimeTableName);
     stopServer();
     stopBroker();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentUploadIntegrationTest.java
@@ -89,7 +89,7 @@ public class UpsertTableSegmentUploadIntegrationTest extends BaseClusterIntegrat
   public void tearDown()
       throws IOException {
     String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
-    // Public segment delete rejects CONSUMING replicas. Table drop is the supported cleanup.
+    // Public segment delete rejects CONSUMING replicas unless force=true. Table drop remains the cleanup path.
     dropRealtimeTable(realtimeTableName);
     stopServer();
     stopBroker();


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Realtime segment deletion is rejected when any replica is CONSUMING, unless force=true is used\.

```mermaid
flowchart TD
  N0["REST endpoint receives delete request #40;force#61;false#41; #40;F5#41;"]:::stModified
  N1["Resource manager deleteSegmentsInternal #40;force#61;false#41; #40;F5#44; F4#41;"]:::stModified
  N2["removeSegmentsFromIdealState #40;bypassConsumingCheck#61;false#41; #40;F4#41;"]:::stModified
  N3["HelixHelper#46;validateAndRemoveSegments #40;with consuming check#41; #40;F4#44; F2#41;"]:::stAdded
  N4["Validator#58; check segments for CONSUMING state #40;F4#44; F2#41;"]:::stModified
  N5["Throw ConsumingSegmentDeletionException if consuming segment found #40;F4#44; F3#41;"]:::stModified
  N6["Resource manager rethrows ConsumingSegmentDeletionException #40;F4#41;"]:::stModified
  N7["REST endpoint converts to HTTP 400 response #40;F5#41;"]:::stModified
  N0 -->|"calls"| N1
  N1 -->|"calls"| N2
  N2 -->|"calls"| N3
  N3 -->|"runs validator"| N4
  N4 -->|"if non#45;empty"| N5
  N5 -->|"throws"| N6
  N6 -->|"throws"| N7
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper\.java — [before](https://github.com/apache/pinot/blob/80dbb7d02dfd92ccc20ae2606ac712ea4f73d3cf/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java) · [after](https://github.com/apache/pinot/blob/2bf222b3f0eb5cf8a87d031e605cf24037902d21/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java)
- F3: pinot\-controller/src/main/java/org/apache/pinot/controller/helix/core/ConsumingSegmentDeletionException\.java — [after](https://github.com/apache/pinot/blob/2bf222b3f0eb5cf8a87d031e605cf24037902d21/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/ConsumingSegmentDeletionException.java)
- F4: pinot\-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager\.java — [before](https://github.com/apache/pinot/blob/80dbb7d02dfd92ccc20ae2606ac712ea4f73d3cf/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java) · [after](https://github.com/apache/pinot/blob/2bf222b3f0eb5cf8a87d031e605cf24037902d21/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java)
- F5: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource\.java — [before](https://github.com/apache/pinot/blob/80dbb7d02dfd92ccc20ae2606ac712ea4f73d3cf/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java) · [after](https://github.com/apache/pinot/blob/2bf222b3f0eb5cf8a87d031e605cf24037902d21/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjgwZGJiN2QwMmRmZDkyY2NjMjBhZTI2MDZhYzcxMmVhNGY3M2QzY2YiLCJjb250ZXh0X2hhc2giOiIxYWUyZTg3YTUyN2I1YzI3NmY0ZWFlOTA1NmU5MjU1NDg5YzJiMGUwY2UwYTFlNDkwMjFlMTAzZjU0MDdiMTA4IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MDAzMTc2LCJoZWFkX3NoYSI6IjJiZjIyMmIzZjBlYjVjZjhhODdkMDMxZTYwNWNmMjQwMzc5MDJkMjEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI4MGRiYjdkMDJkZmQ5MmNjYzIwYWUyNjA2YWM3MTJlYTRmNzNkM2NmIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 024d24fd0db3448463d12d28f665b3f583e09bfac8ec98d71a086b7550ae12dc -->
<!-- pinot-pr-flow:end -->

Fixes #10237

## Problem

Deleting a realtime segment while one of its replicas is CONSUMING can leave the table without a valid consuming segment and interrupt ingestion.

## Solution

Reject the full public delete batch with HTTP 400 when any target has a CONSUMING replica, and direct operators to pause the table before retrying.

## Why this approach

Validation and IdealState removal run in one versioned Helix update, so a concurrent state change cannot slip between the check and deletion. Controller-owned lineage cleanup remains unchanged.

## Implementation

- Added guarded IdealState removal and a typed rejection.
- Batched sequence-number deletes across partitions to prevent partial deletion.
- Added REST guidance and race, atomicity, bypass, and HTTP-contract coverage.

## Impact

Realtime public deletes now fail safely and atomically. Offline deletes, table drops, lineage cleanup, and existing retention behavior are unchanged.

Contract decision: this implementation is deny-only. Existing force=true does not bypass CONSUMING protection. Please confirm whether a separate forceDeleteConsumingSegment escape hatch is wanted.

Rolling upgrade: no ZK, wire, or on-disk format change. Brokers and servers are unaffected. During a mixed-controller upgrade, an old controller may still allow a CONSUMING delete and a new controller will reject it. After every controller is upgraded, the reject is cluster-wide. Rollback restores the old allow behavior.

## Test plan

- PinotHelixResourceManagerStatelessTest — 28 passed
- PinotSegmentRestletResourceTest — 9 passed
- Spotless, Checkstyle, license checks, and git diff --check passed for pinot-common and pinot-controller
- Upsert segment upload/preload cleanup paths drop the table instead of deleting CONSUMING segments one by one; both targeted integration tests passed.
- GitHub CI on 9a1b9c330ddc1673c1ab9a8d730a6b25a06fc1c4: 12/12 green, including Integration Test Set 2.

##### Was generative AI tooling used to co-author this PR?

- [x] Yes
