### PR TITLE
Fail a test when a plan node field escapes the spool equivalence check

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/EquivalentStagesFinder.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/EquivalentStagesFinder.java
@@ -111,10 +111,9 @@ public class EquivalentStagesFinder {
           return _equivalentStages.getGroup(stage).contains(visitedStage);
         }
 
+        // Fields of MailboxSendNode that are deliberately not compared here are listed, with the reason, in
+        // NodeEquivalenceFieldCoverageTest.NOT_COMPARED.
         return areBaseNodesEquivalent(stage, visitedStage)
-            // Commented out fields are used in equals() method of MailboxSendNode but not needed for equivalence.
-            // Receiver stage is not important for equivalence
-//            && stage.getReceiverStageId() == visitedStage.getReceiverStageId()
             && stage.getExchangeType() == visitedStage.getExchangeType()
             // TODO: Distribution type not needed for equivalence in the first substituted send nodes. Their different
             //  distribution can be implemented in synthetic stages. But it is important in recursive send nodes
@@ -211,12 +210,9 @@ public class EquivalentStagesFinder {
           return false;
         }
 
+        // Fields of MailboxReceiveNode that are deliberately not compared here are listed, with the reason, in
+        // NodeEquivalenceFieldCoverageTest.NOT_COMPARED.
         return areBaseNodesEquivalent(node1, node2)
-            // Commented out fields are used in equals() method of MailboxReceiveNode but not needed for equivalence.
-            // sender stage id will be different for sure, but we want (and already did) to compare sender equivalence
-            // instead
-//          && node1.getSenderStageId() == that.getSenderStageId()
-
             // TODO: Keys should probably be removed from the equivalence check, but would require to verify both
             //  keys are present in the data schema. We are not doing that for now.
             && Objects.equals(node1.getKeys(), that.getKeys())
@@ -359,9 +355,9 @@ public class EquivalentStagesFinder {
         UnnestNode that = (UnnestNode) node2;
         return areBaseNodesEquivalent(node1, node2)
             && Objects.equals(node1.getArrayExprs(), that.getArrayExprs())
-            && node1.isWithOrdinality() == that.isWithOrdinality()
-            && Objects.equals(node1.getElementIndexes(), that.getElementIndexes())
-            && node1.getOrdinalityIndex() == that.getOrdinalityIndex();
+            // Compare the context as a whole so that this stays in step with the fields it holds. Unrolling a subset
+            // of them here is how passthroughInputIndexes and prunedPassthrough came to be missed.
+            && Objects.equals(node1.getTableFunctionContext(), that.getTableFunctionContext());
       }
     }
   }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/EquivalentStagesFinderTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/EquivalentStagesFinderTest.java
@@ -288,6 +288,44 @@ public class EquivalentStagesFinderTest extends StagesTestBase {
   }
 
   @Test
+  public void sameUnnestKeepEquivalence() {
+    when(
+        join(
+            exchange(1, unnest(tableScan("T1"), passthrough(List.of(0, 1), true))),
+            exchange(2, unnest(tableScan("T1"), passthrough(List.of(0, 1), true)))
+        )
+    );
+    GroupedStages result = EquivalentStagesFinder.findEquivalentStages(stage(0));
+    assertEquals(result.toString(), "[[0], [1, 2]]");
+  }
+
+  /// The passthrough columns decide which input columns reach the output, so two unnests that only differ there do
+  /// not compute the same rows.
+  @Test
+  public void differentPassthroughInputIndexesBreakEquivalence() {
+    when(
+        join(
+            exchange(1, unnest(tableScan("T1"), passthrough(List.of(0, 1), true))),
+            exchange(2, unnest(tableScan("T1"), passthrough(List.of(0), true)))
+        )
+    );
+    GroupedStages result = EquivalentStagesFinder.findEquivalentStages(stage(0));
+    assertEquals(result.toString(), "[[0], [1], [2]]");
+  }
+
+  @Test
+  public void differentPrunedPassthroughBreakEquivalence() {
+    when(
+        join(
+            exchange(1, unnest(tableScan("T1"), passthrough(List.of(0, 1), true))),
+            exchange(2, unnest(tableScan("T1"), passthrough(List.of(0, 1), false)))
+        )
+    );
+    GroupedStages result = EquivalentStagesFinder.findEquivalentStages(stage(0));
+    assertEquals(result.toString(), "[[0], [1], [2]]");
+  }
+
+  @Test
   public void differentDataSchemaBreakEquivalence() {
     when(
         join(

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/NodeEquivalenceFieldCoverageTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/NodeEquivalenceFieldCoverageTest.java
@@ -1,0 +1,168 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.logical;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import org.apache.pinot.query.planner.plannode.AggregateNode;
+import org.apache.pinot.query.planner.plannode.BasePlanNode;
+import org.apache.pinot.query.planner.plannode.EnrichedJoinNode;
+import org.apache.pinot.query.planner.plannode.ExchangeNode;
+import org.apache.pinot.query.planner.plannode.ExplainedNode;
+import org.apache.pinot.query.planner.plannode.FilterNode;
+import org.apache.pinot.query.planner.plannode.JoinNode;
+import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
+import org.apache.pinot.query.planner.plannode.MailboxSendNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.apache.pinot.query.planner.plannode.PlanNodeVisitor;
+import org.apache.pinot.query.planner.plannode.ProjectNode;
+import org.apache.pinot.query.planner.plannode.SetOpNode;
+import org.apache.pinot.query.planner.plannode.SortNode;
+import org.apache.pinot.query.planner.plannode.TableScanNode;
+import org.apache.pinot.query.planner.plannode.UnnestNode;
+import org.apache.pinot.query.planner.plannode.ValueNode;
+import org.apache.pinot.query.planner.plannode.WindowNode;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/// Guards `EquivalentStagesFinder.NodeEquivalence` against field drift.
+///
+/// The spool optimizer decides that two stages are interchangeable by comparing node fields by hand. That list is
+/// maintained separately from `PlanNode.equals`, and a semantically significant field has now reached a plan node
+/// without reaching the equivalence check five times: `ignoreNulls` (#14264), `matchCondition` (#15630),
+/// `exclude` (#18482), `groupingSets` (#18817) and the `TableFunctionContext` passthrough fields (#18782). Every
+/// occurrence gave silent wrong results rather than an error, because a missing comparison only makes the check more
+/// permissive.
+///
+/// This test cannot check that a comparison is *correct*, only that no field is added without a decision: [#FIELDS]
+/// must list every field that the decision reads, so a new field fails this test until someone either makes
+/// `NodeEquivalence` compare it or records it in [#NOT_COMPARED] with a reason. Proving each comparison behaves
+/// correctly needs a value per field and a node built around it, which is what `EquivalentStagesFinderTest` does
+/// case by case.
+public class NodeEquivalenceFieldCoverageTest {
+
+  /// Every declared instance field that the equivalence decision reads.
+  ///
+  /// The scope is every type owned by this module that the decision reaches: the plan nodes themselves, and the value
+  /// types they hold that are compared through `equals`. It stops at the module edge, so `DataSchema` and
+  /// `RelFieldCollation` are out of scope.
+  ///
+  /// When this test fails, make `NodeEquivalence` compare the new field (or record it in [#NOT_COMPARED] with the
+  /// reason it is safe to ignore), then list the field here.
+  private static final Map<Class<?>, List<String>> FIELDS = Map.ofEntries(
+      Map.entry(BasePlanNode.class, List.of("_stageId", "_dataSchema", "_nodeHint", "_inputs")),
+      Map.entry(PlanNode.NodeHint.class, List.of("_hintOptions")),
+      Map.entry(AggregateNode.class, List.of("_aggCalls", "_filterArgs", "_groupKeys", "_aggType",
+          "_leafReturnFinalResult", "_groupingSets", "_collations", "_limit")),
+      Map.entry(FilterNode.class, List.of("_condition")),
+      Map.entry(JoinNode.class, List.of("_joinType", "_leftKeys", "_rightKeys", "_nonEquiConditions", "_joinStrategy",
+          "_matchCondition")),
+      // EnrichedJoinNode is deprecated for removal, but NodeEquivalence still has a visit method for it, so its
+      // fields stay in scope until that method goes away.
+      Map.entry(EnrichedJoinNode.class, List.of("_filterProjectRexes", "_joinResultSchema", "_projectResultSchema",
+          "_fetch", "_offset")),
+      Map.entry(EnrichedJoinNode.FilterProjectRex.class, List.of("_type", "_filter", "_projectAndResultSchema")),
+      Map.entry(EnrichedJoinNode.FilterProjectRex.ProjectAndResultSchema.class, List.of("_project", "_schema")),
+      Map.entry(MailboxReceiveNode.class, List.of("_senderStageId", "_exchangeType", "_distributionType", "_keys",
+          "_collations", "_sort", "_sortedOnSender", "_sender")),
+      Map.entry(MailboxSendNode.class, List.of("_receiverStages", "_exchangeType", "_distributionType", "_keys",
+          "_prePartitioned", "_collations", "_sort", "_hashFunction")),
+      Map.entry(ProjectNode.class, List.of("_projects")),
+      Map.entry(SetOpNode.class, List.of("_setOpType", "_all")),
+      Map.entry(SortNode.class, List.of("_collations", "_fetch", "_offset")),
+      Map.entry(TableScanNode.class, List.of("_tableName", "_columns")),
+      Map.entry(UnnestNode.class, List.of("_arrayExprs", "_tableFunctionContext")),
+      Map.entry(UnnestNode.TableFunctionContext.class, List.of("_withOrdinality", "_elementIndexes",
+          "_ordinalityIndex", "_passthroughInputIndexes", "_prunedPassthrough")),
+      Map.entry(ValueNode.class, List.of("_literalRows")),
+      Map.entry(WindowNode.class, List.of("_keys", "_collations", "_aggCalls", "_windowFrameType", "_lowerBound",
+          "_upperBound", "_exclude", "_constants")),
+      Map.entry(RexExpression.InputRef.class, List.of("_index")),
+      Map.entry(RexExpression.Literal.class, List.of("_dataType", "_value")),
+      Map.entry(RexExpression.FunctionCall.class, List.of("_dataType", "_functionName", "_functionOperands",
+          "_isDistinct", "_ignoreNulls")));
+
+  /// Fields that `NodeEquivalence` deliberately does not compare, and why. Before this test the reasoning lived in
+  /// commented-out code inside the equivalence check, which cannot fail once the reasoning stops holding.
+  ///
+  /// A reason here is a claim about today's planner, not a permanent property. If one of them stops being true, the
+  /// field has to move into the comparison.
+  private static final Map<Class<?>, Map<String, String>> NOT_COMPARED = Map.of(
+      BasePlanNode.class, Map.of(
+          "_stageId", "Equivalence is asked across stages, so the ids always differ"),
+      MailboxReceiveNode.class, Map.of(
+          "_senderStageId", "The senders themselves are compared for equivalence instead"),
+      MailboxSendNode.class, Map.of(
+          "_receiverStages", "Who reads a stage does not change what the stage computes",
+          "_sort", "Sending side sort is not implemented (see the TODO in MailboxSendOperator), and a difference "
+              + "visible to a receiver is already compared in visitMailboxReceive",
+          "_hashFunction", "One hash function is threaded through a whole v1 plan, so two send nodes in the same "
+              + "plan always agree on it"),
+      EnrichedJoinNode.class, Map.of(
+          "_joinResultSchema", "Only PlanNodeDeserializer builds an EnrichedJoinNode, so the broker side planner "
+              + "that runs this check never sees one",
+          "_projectResultSchema", "This is the node's own data schema, which areBaseNodesEquivalent compares"));
+
+  /// Node types that `NodeEquivalence` rejects outright, so none of their fields take part in the decision. Both
+  /// `visitExchange` and `visitExplained` throw `UnsupportedOperationException`: the fragmenter removes exchanges
+  /// before spooling runs, and explained nodes only exist once a plan is rendered.
+  private static final Set<Class<?>> NOT_VISITED = Set.of(ExchangeNode.class, ExplainedNode.class);
+
+  /// A new node type must either be registered in [#FIELDS] or declared out of scope in [#NOT_VISITED].
+  @Test
+  public void everyVisitedNodeTypeIsRegistered() {
+    for (Method method : PlanNodeVisitor.class.getDeclaredMethods()) {
+      if (!method.getName().startsWith("visit")) {
+        continue;
+      }
+      Class<?> nodeType = method.getParameterTypes()[0];
+      assertTrue(FIELDS.containsKey(nodeType) || NOT_VISITED.contains(nodeType),
+          nodeType.getSimpleName() + " is visited by NodeEquivalence but is not registered in FIELDS. Add its declared "
+              + "fields there, or add it to NOT_VISITED if the equivalence check rejects it.");
+    }
+  }
+
+  @Test
+  public void registeredFieldsMatchDeclaredFields() {
+    for (Map.Entry<Class<?>, List<String>> entry : FIELDS.entrySet()) {
+      Class<?> type = entry.getKey();
+      Set<String> declared = new TreeSet<>();
+      for (Field field : type.getDeclaredFields()) {
+        // Skip statics and the synthetic fields that coverage builds add, e.g. $jacocoData.
+        if (!field.isSynthetic() && !Modifier.isStatic(field.getModifiers())) {
+          declared.add(field.getName());
+        }
+      }
+      assertEquals(declared, new TreeSet<>(entry.getValue()),
+          type.getSimpleName() + " declares different fields than this test expects. For every added field, make "
+              + "NodeEquivalence compare it (or record it in NOT_COMPARED with a reason), then update FIELDS.");
+      Set<String> excluded = NOT_COMPARED.getOrDefault(type, Map.of()).keySet();
+      assertTrue(declared.containsAll(excluded),
+          type.getSimpleName() + " has NOT_COMPARED entries for fields it no longer declares: " + excluded);
+    }
+  }
+}

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/StagesTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/StagesTestBase.java
@@ -41,6 +41,7 @@ import org.apache.pinot.query.planner.plannode.MailboxSendNode;
 import org.apache.pinot.query.planner.plannode.PlanNode;
 import org.apache.pinot.query.planner.plannode.PlanNodeVisitor;
 import org.apache.pinot.query.planner.plannode.TableScanNode;
+import org.apache.pinot.query.planner.plannode.UnnestNode;
 import org.apache.pinot.query.planner.plannode.WindowNode;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -200,6 +201,26 @@ public class StagesTestBase {
       return new WindowNode(stageId, schema, myHints, List.of(input), List.of(0), List.of(), List.of(aggCall),
           WindowNode.WindowFrameType.ROWS, Integer.MIN_VALUE, 0, exclude, List.of());
     };
+  }
+
+  /// Creates an unnest node over the given child with the given table function context.
+  ///
+  /// The unnested expression is always the first input column. Tests vary the context, because that is what the
+  /// equivalence check compares.
+  public SimpleChildBuilder<UnnestNode> unnest(SimpleChildBuilder<? extends PlanNode> childBuilder,
+      UnnestNode.TableFunctionContext tableFunctionContext) {
+    return (stageId, mySchema, myHints) -> {
+      PlanNode input = childBuilder.build(stageId);
+      DataSchema schema = mySchema != null ? mySchema : input.getDataSchema();
+      return new UnnestNode(stageId, schema, myHints, List.of(input), List.of(new RexExpression.InputRef(0)),
+          tableFunctionContext);
+    };
+  }
+
+  /// Creates a table function context that unnests one column, varying only the passthrough fields.
+  public static UnnestNode.TableFunctionContext passthrough(List<Integer> passthroughInputIndexes,
+      boolean prunedPassthrough) {
+    return new UnnestNode.TableFunctionContext(false, List.of(0), -1, passthroughInputIndexes, prunedPassthrough);
   }
 
   /// Creates a `LAST_VALUE` window aggregate call over the first input column that respects nulls.


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Updated UnnestNode equivalence check to compare entire TableFunctionContext instead of individual fields\.

```mermaid
flowchart TD
  N0["visitUnnest #40;F1#41;"]:::stRemoved
  N1["areBaseNodesEquivalent #40;F1#41;"]:::stRemoved
  N2["compare arrayExprs #40;F1#41;"]:::stRemoved
  N3["compare tableFunctionContext #40;F1#41;"]:::stAdded
  N0 -->|"calls"| N1
  N1 -->|"then"| N2
  N2 -->|"then"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-query\-planner/src/main/java/org/apache/pinot/query/planner/logical/EquivalentStagesFinder\.java — [before](https://github.com/apache/pinot/blob/ca78b00d4ae49570c662063db6b9332c3715d828/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/EquivalentStagesFinder.java) · [after](https://github.com/apache/pinot/blob/b02a5708d2e73e9218c0a1de3e13c0238e003058/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/EquivalentStagesFinder.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImNhNzhiMDBkNGFlNDk1NzBjNjYyMDYzZGI2YjkzMzJjMzcxNWQ4MjgiLCJjb250ZXh0X2hhc2giOiJlOGZmZWM2OTI3ZTE4MDViOGJjZjQ2YjAyOGY2OTQ4NjBiZDY0Njg2MWRhODg3YjBiNTg3Zjc0ZTA2OGJjYjI3IiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTU4ODU0LCJoZWFkX3NoYSI6ImIwMmE1NzA4ZDJlNzNlOTIxOGMwYTFkZTNlMTNjMDIzOGUwMDMwNTgiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyYWYxYjA5NzA4YWI1YzE2ZGVkYTVlZmU4YTZjYWFlYmFiNDMyYmMwIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature f62452cc6fb650c6745a68e06cff7f59237f658f09b8c0e781cbd91122a60dee -->
<!-- pinot-pr-flow:end -->

Follow-up to #19219, implementing the reflective guard test @gortiz asked for there.

## The problem it guards

`EquivalentStagesFinder.NodeEquivalence` decides whether two stages are interchangeable for `useSpools=true` by comparing node fields **by hand**. That list is maintained separately from `PlanNode.equals`, nothing connects them, and a missing comparison only makes the check *more permissive* — so the failure mode is silent wrong results, never an error.

Five fields have now reached a plan node without reaching the equivalence check:

| Field | Landed in |
|---|---|
| `ignoreNulls` | #14264 |
| `matchCondition` | #15630 |
| `exclude` | #18482 |
| `groupingSets` | #18817 |
| `passthroughInputIndexes` / `prunedPassthrough` | #18782 |

Four were fixed one at a time in #19219. Each fix was correct, but the mechanism guarantees a sixth.

`NodeEquivalenceFieldCoverageTest` walks the declared fields of every type the decision reads and requires each one to be listed. A new field fails the test until someone either makes the check compare it, or records it in `NOT_COMPARED` with a reason. The failure message names the file to edit.

`NOT_COMPARED` also replaces the commented-out fields that used to carry this reasoning inside the check. Those could never fail once the reasoning stopped holding — and one of them had already rotted: it referenced `getReceiverStageId()`, which no longer exists (the field is now a `BitSet _receiverStages`).

## Why A (classification) and not a fully generic B (mutation)

The stronger design is behavioural: for each field, build two nodes differing only in that field and assert the check reports them as not equivalent. That proves the comparison *works*, where this test only proves a decision was *made*. I did not do it generically, for three reasons.

**1. A generic mutation cannot pick a valid value.** The fields are coupled. `groupingSets` holds indexes into `groupKeys`; `elementIndexes`, `ordinalityIndex` and `passthroughInputIndexes` hold indexes into the schema; `DataSchema` must line up with the inputs. Generic values for these produce invalid nodes, so the "value that differs" has to be chosen per field by someone who knows the field — which is a hand-written test.

**2. It would have to construct, not mutate.** Java 25 blocks reflective writes to final fields, and every one of these fields is final. So B needs a per-class builder for each node type — i.e. `StagesTestBase` — at which point the reflective part is only telling you *that* a field exists, which is exactly what this test does.

**3. The false green is a real trap, not a theoretical one.** If the varied field also changes the `DataSchema`, `areBaseNodesEquivalent` rejects the pair first: the test passes without ever reaching the field's own comparison. This bit me in #19219 — my first `Spool.json` case passed *without* the fix, because an extra join condition widened one side's exchange keys and the pair was rejected on `getKeys()` instead of on `exclude`. A generic harness would hit that silently and at scale, and a green suite that proves nothing is worse than no suite.

So the split is: reflection does completeness, which is cheap and has no false failures; `EquivalentStagesFinderTest` keeps doing behaviour case by case, where the value can be chosen correctly and the discriminator verified. Every negative test there has been checked to fail when its comparison is deleted.

**What this test cannot do:** it cannot tell a correct comparison from a missing one. Someone in a hurry can add a field name to `FIELDS` and write no comparison. That is strictly better than today, where adding the field triggers nothing at all — the diff now shows a reviewer that a comparison decision was made — but it is not proof.

## The fields the guard surfaced

@gortiz predicted the guard would flag two things, and it did. Both are resolved here rather than left as known gaps:

- **`visitUnnest` unrolled three of `TableFunctionContext`'s five fields**, missing `passthroughInputIndexes` and `prunedPassthrough`. Now it compares the context as a whole, so it stays in step with the fields it holds. This is the only behavioural change in the PR, and it comes with paired tests (verified to fail when reverted).
- **`MailboxSendNode.isSort()` / `getHashFunction()`** are recorded as opt-outs with verified reasons: sending-side sort is unimplemented (`MailboxSendOperator` still has `// TODO: Support sort on sender`) and a receiver-visible difference is already compared in `visitMailboxReceive`; and one hash function is threaded through an entire v1 plan, so two send nodes in the same plan always agree on it.

The guard also surfaced a third, `EnrichedJoinNode.getJoinResultSchema()`, likewise recorded as an opt-out: only `PlanNodeDeserializer` builds an `EnrichedJoinNode`, so the broker-side planner that runs this check never sees one, and the class is deprecated for removal in 1.6.0.

I originally added comparisons for all three. I reverted them because none can be tested in isolation — the exchange builder threads one `sort` flag into both the send and the receive node, so a test would pass on the receive-side comparison that already exists; and adding an untested comparison to a PR whose thesis is "don't let comparisons drift untested" is self-defeating. A documented opt-out that names the claim it rests on is the honest version, and the guard now fails if any of these fields is renamed or removed.

## Scope of the registry

The boundary is *every type this module owns that the decision reads* — the plan nodes, plus the value types they hold that are compared through `equals` (`RexExpression.InputRef` / `Literal` / `FunctionCall`, `PlanNode.NodeHint`, `UnnestNode.TableFunctionContext`, `EnrichedJoinNode.FilterProjectRex` and its nested schema holder). It deliberately stops at the module edge, so `DataSchema` and `RelFieldCollation` are out.

Drawing the line at "types where we already got burned" would have been too narrow: the motivating regression, `_ignoreNulls` (#14264), was itself a field on a nested value type.

## Verification

- Guard bites, both ways: adding a field to `WindowNode` fails `registeredFieldsMatchDeclaredFields`; dropping a registry entry fails `everyVisitedNodeTypeIsRegistered`. Both with actionable messages.
- The two new `visitUnnest` tests fail when that comparison is reverted.
- Passes under `-Pcodecoverage`. The field walk skips synthetic and static fields on purpose — Jacoco adds `$jacocoData` to instrumented classes, and `RexExpression.Literal` holds `public static final TRUE`/`FALSE`, so without the filter this would fail only in the coverage build.
- `pinot-query-planner` (1544 tests) and `ResourceBasedQueriesTest` (3685) green. spotless / checkstyle / license clean.

## Not in scope

`PlanNodeMerger` has the same three hand-written field lists and the same drift, including the identical `visitUnnest` unrolling. It only affects `EXPLAIN` rendering, not query results, so I left it out to keep this focused — happy to extend the guard to cover both comparators if reviewers prefer.
