### PR TITLE
Sample resource usage while the DISTINCT cross-segment merge grows

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/BigDecimalDistinctTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/BigDecimalDistinctTable.java
@@ -41,6 +41,8 @@ import org.roaringbitmap.RoaringBitmap;
 
 
 public class BigDecimalDistinctTable extends DistinctTable {
+  private static final String MERGE_SCOPE = "BigDecimalDistinctTable#mergeDistinctTable";
+
   private final HashSet<BigDecimal> _valueSet;
   private final OrderByExpressionContext _orderByExpression;
 
@@ -134,13 +136,16 @@ public class BigDecimalDistinctTable extends DistinctTable {
     if (bigDecimalDistinctTable._hasNull) {
       addNull();
     }
+    int numValuesMerged = 0;
     if (hasLimit()) {
       if (hasOrderBy()) {
         for (BigDecimal value : bigDecimalDistinctTable._valueSet) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
           addWithOrderBy(value);
         }
       } else {
         for (BigDecimal value : bigDecimalDistinctTable._valueSet) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
           if (addWithoutOrderBy(value)) {
             return;
           }
@@ -149,6 +154,7 @@ public class BigDecimalDistinctTable extends DistinctTable {
     } else {
       // NOTE: Do not use _valueSet.addAll() to avoid unnecessary resize when most values are common.
       for (BigDecimal value : bigDecimalDistinctTable._valueSet) {
+        QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
         addUnbounded(value);
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/BytesDistinctTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/BytesDistinctTable.java
@@ -43,6 +43,8 @@ import org.roaringbitmap.RoaringBitmap;
 
 
 public class BytesDistinctTable extends DistinctTable {
+  private static final String MERGE_SCOPE = "BytesDistinctTable#mergeDistinctTable";
+
   private final HashSet<ByteArray> _valueSet;
   private final OrderByExpressionContext _orderByExpression;
 
@@ -136,13 +138,16 @@ public class BytesDistinctTable extends DistinctTable {
     if (bytesDistinctTable._hasNull) {
       addNull();
     }
+    int numValuesMerged = 0;
     if (hasLimit()) {
       if (hasOrderBy()) {
         for (ByteArray value : bytesDistinctTable._valueSet) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
           addWithOrderBy(value);
         }
       } else {
         for (ByteArray value : bytesDistinctTable._valueSet) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
           if (addWithoutOrderBy(value)) {
             return;
           }
@@ -151,6 +156,7 @@ public class BytesDistinctTable extends DistinctTable {
     } else {
       // NOTE: Do not use _valueSet.addAll() to avoid unnecessary resize when most values are common.
       for (ByteArray value : bytesDistinctTable._valueSet) {
+        QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
         addUnbounded(value);
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/DoubleDistinctTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/DoubleDistinctTable.java
@@ -40,6 +40,8 @@ import org.roaringbitmap.RoaringBitmap;
 
 
 public class DoubleDistinctTable extends DistinctTable {
+  private static final String MERGE_SCOPE = "DoubleDistinctTable#mergeDistinctTable";
+
   private final DoubleOpenHashSet _valueSet;
   private final OrderByExpressionContext _orderByExpression;
 
@@ -136,14 +138,17 @@ public class DoubleDistinctTable extends DistinctTable {
     if (doubleDistinctTable._hasNull) {
       addNull();
     }
+    int numValuesMerged = 0;
     DoubleIterator doubleIterator = doubleDistinctTable._valueSet.iterator();
     if (hasLimit()) {
       if (hasOrderBy()) {
         while (doubleIterator.hasNext()) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
           addWithOrderBy(doubleIterator.nextDouble());
         }
       } else {
         while (doubleIterator.hasNext()) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
           if (addWithoutOrderBy(doubleIterator.nextDouble())) {
             return;
           }
@@ -152,6 +157,7 @@ public class DoubleDistinctTable extends DistinctTable {
     } else {
       // NOTE: Do not use _valueSet.addAll() to avoid unnecessary resize when most values are common.
       while (doubleIterator.hasNext()) {
+        QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
         addUnbounded(doubleIterator.nextDouble());
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/FloatDistinctTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/FloatDistinctTable.java
@@ -40,6 +40,8 @@ import org.roaringbitmap.RoaringBitmap;
 
 
 public class FloatDistinctTable extends DistinctTable {
+  private static final String MERGE_SCOPE = "FloatDistinctTable#mergeDistinctTable";
+
   private final FloatOpenHashSet _valueSet;
   private final OrderByExpressionContext _orderByExpression;
 
@@ -132,14 +134,17 @@ public class FloatDistinctTable extends DistinctTable {
     if (floatDistinctTable._hasNull) {
       addNull();
     }
+    int numValuesMerged = 0;
     FloatIterator floatIterator = floatDistinctTable._valueSet.iterator();
     if (hasLimit()) {
       if (hasOrderBy()) {
         while (floatIterator.hasNext()) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
           addWithOrderBy(floatIterator.nextFloat());
         }
       } else {
         while (floatIterator.hasNext()) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
           if (addWithoutOrderBy(floatIterator.nextFloat())) {
             return;
           }
@@ -148,6 +153,7 @@ public class FloatDistinctTable extends DistinctTable {
     } else {
       // NOTE: Do not use _valueSet.addAll() to avoid unnecessary resize when most values are common.
       while (floatIterator.hasNext()) {
+        QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
         addUnbounded(floatIterator.nextFloat());
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/IntDistinctTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/IntDistinctTable.java
@@ -41,6 +41,8 @@ import org.roaringbitmap.RoaringBitmap;
 
 
 public class IntDistinctTable extends DistinctTable {
+  private static final String MERGE_SCOPE = "IntDistinctTable#mergeDistinctTable";
+
   protected final IntOpenHashSet _valueSet;
   protected final OrderByExpressionContext _orderByExpression;
 
@@ -136,14 +138,17 @@ public class IntDistinctTable extends DistinctTable {
     if (intDistinctTable._hasNull) {
       addNull();
     }
+    int numValuesMerged = 0;
     IntIterator intIterator = intDistinctTable._valueSet.iterator();
     if (hasLimit()) {
       if (hasOrderBy()) {
         while (intIterator.hasNext()) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
           addWithOrderBy(intIterator.nextInt());
         }
       } else {
         while (intIterator.hasNext()) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
           if (addWithoutOrderBy(intIterator.nextInt())) {
             return;
           }
@@ -152,6 +157,7 @@ public class IntDistinctTable extends DistinctTable {
     } else {
       // NOTE: Do not use _valueSet.addAll() to avoid unnecessary resize when most values are common.
       while (intIterator.hasNext()) {
+        QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
         addUnbounded(intIterator.nextInt());
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/LongDistinctTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/LongDistinctTable.java
@@ -42,6 +42,8 @@ import org.roaringbitmap.RoaringBitmap;
 
 
 public class LongDistinctTable extends DistinctTable {
+  private static final String MERGE_SCOPE = "LongDistinctTable#mergeDistinctTable";
+
   private final LongOpenHashSet _valueSet;
   private final OrderByExpressionContext _orderByExpression;
 
@@ -134,14 +136,17 @@ public class LongDistinctTable extends DistinctTable {
     if (longDistinctTable._hasNull) {
       addNull();
     }
+    int numValuesMerged = 0;
     LongIterator longIterator = longDistinctTable._valueSet.iterator();
     if (hasLimit()) {
       if (hasOrderBy()) {
         while (longIterator.hasNext()) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
           addWithOrderBy(longIterator.nextLong());
         }
       } else {
         while (longIterator.hasNext()) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
           if (addWithoutOrderBy(longIterator.nextLong())) {
             return;
           }
@@ -150,6 +155,7 @@ public class LongDistinctTable extends DistinctTable {
     } else {
       // NOTE: Do not use _valueSet.addAll() to avoid unnecessary resize when most values are common.
       while (longIterator.hasNext()) {
+        QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
         addUnbounded(longIterator.nextLong());
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/MultiColumnDistinctTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/MultiColumnDistinctTable.java
@@ -35,10 +35,13 @@ import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
+import org.apache.pinot.spi.query.QueryThreadContext;
 import org.roaringbitmap.RoaringBitmap;
 
 
 public class MultiColumnDistinctTable extends DistinctTable {
+  private static final String MERGE_SCOPE = "MultiColumnDistinctTable#mergeDistinctTable";
+
   private final HashSet<Record> _recordSet;
   private final List<OrderByExpressionContext> _orderByExpressions;
 
@@ -184,13 +187,16 @@ public class MultiColumnDistinctTable extends DistinctTable {
   @Override
   public void mergeDistinctTable(DistinctTable distinctTable) {
     MultiColumnDistinctTable multiColumnDistinctTable = (MultiColumnDistinctTable) distinctTable;
+    int numRecordsMerged = 0;
     if (hasLimit()) {
       if (hasOrderBy()) {
         for (Record record : multiColumnDistinctTable._recordSet) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numRecordsMerged++, MERGE_SCOPE);
           addWithOrderBy(record);
         }
       } else {
         for (Record record : multiColumnDistinctTable._recordSet) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numRecordsMerged++, MERGE_SCOPE);
           if (addWithoutOrderBy(record)) {
             return;
           }
@@ -199,6 +205,7 @@ public class MultiColumnDistinctTable extends DistinctTable {
     } else {
       // NOTE: Do not use _valueSet.addAll() to avoid unnecessary resize when most values are common.
       for (Record record : multiColumnDistinctTable._recordSet) {
+        QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numRecordsMerged++, MERGE_SCOPE);
         addUnbounded(record);
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/StringDistinctTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/StringDistinctTable.java
@@ -40,6 +40,8 @@ import org.roaringbitmap.RoaringBitmap;
 
 
 public class StringDistinctTable extends DistinctTable {
+  private static final String MERGE_SCOPE = "StringDistinctTable#mergeDistinctTable";
+
   private final HashSet<String> _valueSet;
   private final OrderByExpressionContext _orderByExpression;
 
@@ -133,13 +135,16 @@ public class StringDistinctTable extends DistinctTable {
     if (stringDistinctTable._hasNull) {
       addNull();
     }
+    int numValuesMerged = 0;
     if (hasLimit()) {
       if (hasOrderBy()) {
         for (String value : stringDistinctTable._valueSet) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
           addWithOrderBy(value);
         }
       } else {
         for (String value : stringDistinctTable._valueSet) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
           if (addWithoutOrderBy(value)) {
             return;
           }
@@ -148,6 +153,7 @@ public class StringDistinctTable extends DistinctTable {
     } else {
       // NOTE: Do not use _valueSet.addAll() to avoid unnecessary resize when most values are common.
       for (String value : stringDistinctTable._valueSet) {
+        QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numValuesMerged++, MERGE_SCOPE);
         addUnbounded(value);
       }
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/distinct/table/DistinctTableMergeAccountingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/distinct/table/DistinctTableMergeAccountingTest.java
@@ -1,0 +1,292 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.distinct.table;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.OrderByExpressionContext;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.data.table.Record;
+import org.apache.pinot.spi.accounting.QueryResourceTracker;
+import org.apache.pinot.spi.accounting.ThreadAccountant;
+import org.apache.pinot.spi.accounting.ThreadResourceTracker;
+import org.apache.pinot.spi.accounting.TrackingScope;
+import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.exception.TerminationException;
+import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryThreadContext;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+
+/// Verifies that [DistinctTable#mergeDistinctTable] reports resource usage to the query accountant *while* the
+/// combined distinct set grows, instead of only when the result is serialized in [DistinctTable#toDataTable()].
+///
+/// This is the cross-segment merge performed by `DistinctCombineOperator` on the main query thread. It is unbounded
+/// when the query has no limit, and neither it nor its caller
+/// (`BaseSingleBlockCombineOperator#mergeResults`) used to sample or check for termination, so a runaway
+/// `SELECT DISTINCT` could not be killed by memory footprint for as long as it was growing.
+///
+/// Every concrete [DistinctTable] subclass has three merge branches (unbounded, limited without order-by, limited
+/// with order-by) and each carries its own hand-written sampling call, so all 24 are covered here.
+public class DistinctTableMergeAccountingTest {
+  private static final int SAMPLE_INTERVAL = QueryThreadContext.CHECK_TERMINATION_AND_SAMPLE_USAGE_RECORD_MASK + 1;
+
+  /// Number of values merged per case. Chosen to cross [#SAMPLE_INTERVAL] exactly twice, so the merge loop is expected
+  /// to sample at value `0`, `SAMPLE_INTERVAL` and `2 * SAMPLE_INTERVAL`.
+  private static final int NUM_VALUES = 3 * SAMPLE_INTERVAL;
+  private static final int EXPECTED_SAMPLES = 3;
+
+  /// Limit used by the two limited branches. High enough that the merge never satisfies the limit and returns early.
+  private static final int LIMIT = NUM_VALUES + 1;
+
+  /// Builds a populated merge source plus the (empty) destination it is merged into.
+  @FunctionalInterface
+  private interface TableFactory {
+    MergeCase create(int limit, boolean withOrderBy);
+  }
+
+  @DataProvider(name = "mergeCases")
+  public Object[][] mergeCases() {
+    List<Object[]> cases = new ArrayList<>();
+    addBranches(cases, "INT", DistinctTableMergeAccountingTest::intTables);
+    addBranches(cases, "LONG", DistinctTableMergeAccountingTest::longTables);
+    addBranches(cases, "FLOAT", DistinctTableMergeAccountingTest::floatTables);
+    addBranches(cases, "DOUBLE", DistinctTableMergeAccountingTest::doubleTables);
+    addBranches(cases, "BIG_DECIMAL", DistinctTableMergeAccountingTest::bigDecimalTables);
+    addBranches(cases, "BYTES", DistinctTableMergeAccountingTest::bytesTables);
+    addBranches(cases, "STRING", DistinctTableMergeAccountingTest::stringTables);
+    addBranches(cases, "MULTI_COLUMN", DistinctTableMergeAccountingTest::multiColumnTables);
+    return cases.toArray(new Object[0][]);
+  }
+
+  private static void addBranches(List<Object[]> cases, String type, TableFactory factory) {
+    cases.add(new Object[]{factory.create(Integer.MAX_VALUE, false).named(type + " unbounded")});
+    cases.add(new Object[]{factory.create(LIMIT, false).named(type + " limited")});
+    cases.add(new Object[]{factory.create(LIMIT, true).named(type + " limited with order-by")});
+  }
+
+  @Test(dataProvider = "mergeCases")
+  public void testMergeSamplesUsage(MergeCase mergeCase) {
+    TrackingAccountant accountant = new TrackingAccountant();
+    try (QueryThreadContext ignored = QueryThreadContext.open(QueryExecutionContext.forSseTest(), accountant)) {
+      mergeCase.merge();
+    }
+    assertEquals(mergeCase.destinationSize(), NUM_VALUES);
+    assertEquals(accountant.getSampleUsageCount(), EXPECTED_SAMPLES);
+  }
+
+  @Test(dataProvider = "mergeCases")
+  public void testMergeIsKillable(MergeCase mergeCase) {
+    // Terminate the query on the second sample, mimicking the accountant's watcher thread killing the query with the
+    // largest memory footprint. The merge notices at its next termination check, i.e. after 2 * SAMPLE_INTERVAL values,
+    // instead of running to completion. Asserting the exact size also pins the counter to post-increment semantics.
+    TrackingAccountant accountant = new TrackingAccountant(2);
+    try (QueryThreadContext ignored = QueryThreadContext.open(QueryExecutionContext.forSseTest(), accountant)) {
+      assertThrows(TerminationException.class, mergeCase::merge);
+    }
+    assertEquals(mergeCase.destinationSize(), 2 * SAMPLE_INTERVAL);
+  }
+
+  private static DataSchema singleColumnSchema(ColumnDataType columnDataType) {
+    return new DataSchema(new String[]{"col"}, new ColumnDataType[]{columnDataType});
+  }
+
+  private static OrderByExpressionContext orderBy(String column) {
+    return new OrderByExpressionContext(ExpressionContext.forIdentifier(column), true);
+  }
+
+  private static MergeCase intTables(int limit, boolean withOrderBy) {
+    DataSchema schema = singleColumnSchema(ColumnDataType.INT);
+    IntDistinctTable source = new IntDistinctTable(schema, Integer.MAX_VALUE, false, null);
+    for (int i = 0; i < NUM_VALUES; i++) {
+      source.addUnbounded(i);
+    }
+    return new MergeCase(source,
+        new IntDistinctTable(schema, limit, false, withOrderBy ? orderBy("col") : null));
+  }
+
+  private static MergeCase longTables(int limit, boolean withOrderBy) {
+    DataSchema schema = singleColumnSchema(ColumnDataType.LONG);
+    LongDistinctTable source = new LongDistinctTable(schema, Integer.MAX_VALUE, false, null);
+    for (int i = 0; i < NUM_VALUES; i++) {
+      source.addUnbounded(i);
+    }
+    return new MergeCase(source,
+        new LongDistinctTable(schema, limit, false, withOrderBy ? orderBy("col") : null));
+  }
+
+  private static MergeCase floatTables(int limit, boolean withOrderBy) {
+    DataSchema schema = singleColumnSchema(ColumnDataType.FLOAT);
+    FloatDistinctTable source = new FloatDistinctTable(schema, Integer.MAX_VALUE, false, null);
+    for (int i = 0; i < NUM_VALUES; i++) {
+      source.addUnbounded(i);
+    }
+    return new MergeCase(source,
+        new FloatDistinctTable(schema, limit, false, withOrderBy ? orderBy("col") : null));
+  }
+
+  private static MergeCase doubleTables(int limit, boolean withOrderBy) {
+    DataSchema schema = singleColumnSchema(ColumnDataType.DOUBLE);
+    DoubleDistinctTable source = new DoubleDistinctTable(schema, Integer.MAX_VALUE, false, null);
+    for (int i = 0; i < NUM_VALUES; i++) {
+      source.addUnbounded(i);
+    }
+    return new MergeCase(source,
+        new DoubleDistinctTable(schema, limit, false, withOrderBy ? orderBy("col") : null));
+  }
+
+  private static MergeCase bigDecimalTables(int limit, boolean withOrderBy) {
+    DataSchema schema = singleColumnSchema(ColumnDataType.BIG_DECIMAL);
+    BigDecimalDistinctTable source = new BigDecimalDistinctTable(schema, Integer.MAX_VALUE, false, null);
+    for (int i = 0; i < NUM_VALUES; i++) {
+      source.addUnbounded(BigDecimal.valueOf(i));
+    }
+    return new MergeCase(source,
+        new BigDecimalDistinctTable(schema, limit, false, withOrderBy ? orderBy("col") : null));
+  }
+
+  private static MergeCase bytesTables(int limit, boolean withOrderBy) {
+    DataSchema schema = singleColumnSchema(ColumnDataType.BYTES);
+    BytesDistinctTable source = new BytesDistinctTable(schema, Integer.MAX_VALUE, false, null);
+    for (int i = 0; i < NUM_VALUES; i++) {
+      source.addUnbounded(new ByteArray(Integer.toString(i).getBytes(StandardCharsets.UTF_8)));
+    }
+    return new MergeCase(source,
+        new BytesDistinctTable(schema, limit, false, withOrderBy ? orderBy("col") : null));
+  }
+
+  private static MergeCase stringTables(int limit, boolean withOrderBy) {
+    DataSchema schema = singleColumnSchema(ColumnDataType.STRING);
+    StringDistinctTable source = new StringDistinctTable(schema, Integer.MAX_VALUE, false, null);
+    for (int i = 0; i < NUM_VALUES; i++) {
+      source.addUnbounded(Integer.toString(i));
+    }
+    return new MergeCase(source,
+        new StringDistinctTable(schema, limit, false, withOrderBy ? orderBy("col") : null));
+  }
+
+  private static MergeCase multiColumnTables(int limit, boolean withOrderBy) {
+    DataSchema schema =
+        new DataSchema(new String[]{"col1", "col2"}, new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.INT});
+    MultiColumnDistinctTable source = new MultiColumnDistinctTable(schema, Integer.MAX_VALUE, false, null);
+    for (int i = 0; i < NUM_VALUES; i++) {
+      source.addUnbounded(new Record(new Object[]{i, i}));
+    }
+    return new MergeCase(source,
+        new MultiColumnDistinctTable(schema, limit, false, withOrderBy ? List.of(orderBy("col1")) : null));
+  }
+
+  /// One merge scenario: a populated source table and the destination it is merged into. TestNG renders each
+  /// data-provider parameter with `toString()`, so [#named] supplies a readable label for the test report.
+  private static class MergeCase {
+    private final DistinctTable _source;
+    private final DistinctTable _destination;
+
+    private String _name = "";
+
+    MergeCase(DistinctTable source, DistinctTable destination) {
+      _source = source;
+      _destination = destination;
+    }
+
+    MergeCase named(String name) {
+      _name = name;
+      return this;
+    }
+
+    void merge() {
+      _destination.mergeDistinctTable(_source);
+    }
+
+    int destinationSize() {
+      return _destination.size();
+    }
+
+    @Override
+    public String toString() {
+      return _name;
+    }
+  }
+
+  /// Counts [#sampleUsage()] calls and optionally terminates the query once a given number of samples has been taken,
+  /// standing in for the real accountant's watcher thread. Only ever used from a single thread.
+  private static class TrackingAccountant implements ThreadAccountant {
+    private final AtomicInteger _sampleUsageCount = new AtomicInteger();
+    private final int _terminateAfterSamples;
+
+    private QueryThreadContext _threadContext;
+
+    TrackingAccountant() {
+      this(Integer.MAX_VALUE);
+    }
+
+    TrackingAccountant(int terminateAfterSamples) {
+      _terminateAfterSamples = terminateAfterSamples;
+    }
+
+    int getSampleUsageCount() {
+      return _sampleUsageCount.get();
+    }
+
+    @Override
+    public void setupTask(QueryThreadContext threadContext) {
+      _threadContext = threadContext;
+    }
+
+    @Override
+    public void sampleUsage() {
+      if (_sampleUsageCount.incrementAndGet() == _terminateAfterSamples) {
+        _threadContext.getExecutionContext()
+            .terminate(QueryErrorCode.SERVER_RESOURCE_LIMIT_EXCEEDED, "Terminated by test accountant");
+      }
+    }
+
+    @Override
+    public void clear() {
+      _threadContext = null;
+    }
+
+    @Override
+    public void updateUntrackedResourceUsage(String identifier, long cpuTimeNs, long allocatedBytes,
+        TrackingScope trackingScope) {
+    }
+
+    @Override
+    public Collection<? extends ThreadResourceTracker> getThreadResources() {
+      return List.of();
+    }
+
+    @Override
+    public Map<String, ? extends QueryResourceTracker> getQueryResources() {
+      return Map.of();
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`DistinctTable#mergeDistinctTable` is the cross-segment merge that `DistinctCombineOperator` runs on the main query thread. It never reported resource usage to the query accountant, and neither did its only caller chain — `DistinctResultsBlockMerger#mergeResultsBlocks` → `BaseSingleBlockCombineOperator#mergeResults`. That loop has no sampling and no termination check at all.

The consequence: `QueryThreadContext.sampleUsage()` is what refreshes a thread's memory snapshot (`ResourceUsageAccountantFactory#sampleUsage`). Without it the watcher thread keeps reading a stale footprint, so it cannot pick a runaway `SELECT DISTINCT` as the kill candidate. The first sample on this path only landed in `toDataTable()` — after the table was fully built. The merge is unbounded when the query has no limit, so this is exactly where a runaway grows largest.

Group-by already samples in its equivalent merge loops (`GroupByCombineOperator:143,160`, `SortedGroupByCombineOperator:158,172`), so DISTINCT was the odd one out.

## Fix

Add the standard `QueryThreadContext.checkTerminationAndSampleUsagePeriodically` call to all three merge branches (unbounded, limited, limited with order-by) of the 8 concrete `DistinctTable` subclasses. `DictIdDistinctTable` and `EmptyDistinctTable` throw from `mergeDistinctTable`, so they need nothing.

The counter starts at 0 and the periodic mask fires at 0, so every non-empty merge samples at least once. That is what `mergeResultsBlocks()` needed as well — a second call there would only double-sample per segment, since all of its allocation happens inside `mergeDistinctTable`.

## Behavior change

With accountant-based killing enabled, a DISTINCT query that previously ran to completion can now be killed mid-merge with `SERVER_RESOURCE_LIMIT_EXCEEDED`. That is the intent.

A mid-merge timeout now reports the merge scope (e.g. `Timing out on: IntDistinctTable#mergeDistinctTable`) rather than `Timed out while polling results block`. Both still surface as `EXECUTION_TIMEOUT` via `ExceptionResultsBlock`, so only the message text changes. Exceptions thrown from the merge are already handled by `BaseSingleBlockCombineOperator#mergeResultsAndAttachExecutionStats`, which prefers the terminate exception and preserves `QueryException` error codes.

## What deliberately did *not* change

**The leaf scan path needs no fix.** `ProjectPlanNode` always builds a `DocIdSetOperator`, and `DocIdSetOperator#getNextBlock` already calls `QueryThreadContext.sampleUsage()` once per doc-id block. Since `DistinctOperator` and `InvertedIndexDistinctOperator#executeScanPath` both pull from that chain, `DistinctExecutor#process` is already accounted at ≤10k-doc granularity, and `BaseOperator#nextBlock` already supplies the termination check and OOM-pause hook. Adding a sample to those loops measurably raised the count for a 3-block scan from 4 to 7 and changed nothing else, so it was dropped.

**`mergeDataTable` / the broker reduce path is left alone**, and is a separate follow-up. `DistinctDataTableReducer#mergeToDistinctTable` samples once per server `DataTable` before each `mergeDataTable` call and each broker-side `DistinctTable(…, DataTable)` constructor, so each unaccounted stretch is bounded by one server's payload rather than being unbounded. It is a weaker version of the same gap on a different node, and folding it in would widen this change beyond one concern.

## Testing

New `DistinctTableMergeAccountingTest` — 48 cases covering the full cross-product of 8 table types × 3 merge branches, since each of those 24 call sites is hand-written and a misplaced call or a `++n`/`n++` slip would otherwise ship silently. Two assertions per case:

- sampling happens on the expected cadence (exact count, not a lower bound)
- a `terminate()` raised from the accountant mid-merge actually stops the merge, asserted on the exact number of values merged before the throw

**All 48 fail on the unpatched code and pass with the fix.** 107 distinct/selection tests green. `spotless`, `checkstyle`, and `license` checks pass on `pinot-core`.
