### PR TITLE
Don't use the streaming group-by leaf when the server must return final results

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.streaming;
 
+import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -55,6 +56,10 @@ import org.apache.pinot.spi.query.QueryThreadContext;
 ///
 /// - Hash exchange routes the same group key to the same FINAL worker
 /// - AggregationFunction.merge() is associative
+///
+/// That FINAL stage is a precondition, not an implementation detail: a flushed block carries only a partial
+/// aggregate, and one group key can span several flush windows. Leaves that must return final results are rejected
+/// below; finalizing each flush instead would not make them correct, only silent.
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class StreamingGroupByCombineOperator extends BaseStreamingCombineOperator<GroupByResultsBlock> {
   private static final String EXPLAIN_NAME = "STREAMING_COMBINE_GROUP_BY";
@@ -74,6 +79,9 @@ public class StreamingGroupByCombineOperator extends BaseStreamingCombineOperato
   public StreamingGroupByCombineOperator(List<Operator> operators, QueryContext queryContext,
       ExecutorService executorService, int flushThreshold) {
     super(null, operators, overrideMaxExecutionThreads(queryContext, operators.size()), executorService);
+    Preconditions.checkState(
+        !queryContext.isServerReturnFinalResult() && !queryContext.isServerReturnFinalResultKeyUnpartitioned(),
+        "Streaming group-by combine requires a leaf that emits INTERMEDIATE results");
     _flushThreshold = flushThreshold;
 
     AggregationFunction[] aggregationFunctions = _queryContext.getAggregationFunctions();

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -130,10 +130,12 @@ public class CombinePlanNode implements PlanNode {
         // Use streaming operator only for non-empty selection-only query
         return new StreamingSelectionOnlyCombineOperator(operators, _queryContext, _executorService);
       }
+      // Streaming flushes partial aggregates, so it needs an aggregation above to merge them back together.
+      // Leaves that must return final results are excluded, see StreamingGroupByCombineOperator.
       int flushThreshold = _queryContext.getStreamingGroupByFlushThreshold();
       if (flushThreshold > 0 && QueryContextUtils.isAggregationQuery(_queryContext)
-          && _queryContext.getGroupByExpressions() != null) {
-        // Use streaming group-by operator for MSE leaf stages with flush threshold
+          && _queryContext.getGroupByExpressions() != null && !_queryContext.isServerReturnFinalResult()
+          && !_queryContext.isServerReturnFinalResultKeyUnpartitioned()) {
         return new StreamingGroupByCombineOperator(operators, _queryContext, _executorService, flushThreshold);
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -133,8 +133,10 @@ public class CombinePlanNode implements PlanNode {
       // Streaming flushes partial aggregates, so it needs an aggregation above to merge them back together.
       // Leaves that must return final results are excluded, see StreamingGroupByCombineOperator.
       int flushThreshold = _queryContext.getStreamingGroupByFlushThreshold();
-      if (flushThreshold > 0 && QueryContextUtils.isAggregationQuery(_queryContext)
-          && _queryContext.getGroupByExpressions() != null && !_queryContext.isServerReturnFinalResult()
+      if (flushThreshold > 0
+          && QueryContextUtils.isAggregationQuery(_queryContext)
+          && _queryContext.getGroupByExpressions() != null
+          && !_queryContext.isServerReturnFinalResult()
           && !_queryContext.isServerReturnFinalResultKeyUnpartitioned()) {
         return new StreamingGroupByCombineOperator(operators, _queryContext, _executorService, flushThreshold);
       }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperatorTest.java
@@ -33,6 +33,8 @@ import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.MetadataResultsBlock;
+import org.apache.pinot.core.operator.combine.BaseCombineOperator;
+import org.apache.pinot.core.plan.CombinePlanNode;
 import org.apache.pinot.core.plan.PlanNode;
 import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
 import org.apache.pinot.core.plan.maker.PlanMaker;
@@ -71,6 +73,8 @@ public class StreamingGroupByCombineOperatorTest {
   // Each group key appears twice per segment with intColumn values that sum to a known total
   private static final int NUM_RECORDS_PER_SEGMENT = 100;
   private static final int NUM_DISTINCT_GROUPS = 50;
+
+  private static final String GROUP_BY_SUM = "SELECT groupColumn, SUM(intColumn) FROM testTable GROUP BY groupColumn";
 
   private static final String GROUP_COLUMN = "groupColumn";
   private static final String INT_COLUMN = "intColumn";
@@ -432,6 +436,45 @@ public class StreamingGroupByCombineOperatorTest {
     }
     // Per segment, the total over all rows is sum over g of 2 * (g + 1) = 2550
     assertEquals(groupSums.get(null), NUM_SEGMENTS * 2550.0, 0.001, "Incorrect rollup total");
+  }
+
+  /// A leaf asked to return FINAL results must not stream: a flushed block holds only a partial aggregate, and one
+  /// group key can span several flush windows. `serverReturnFinalResult` comes from an `AggType.DIRECT` leaf
+  /// (`is_partitioned_by_group_by_keys`), which has no aggregation above it to merge the pieces back together.
+  @Test
+  public void testServerReturnFinalResultDoesNotUseStreamingCombine() {
+    assertFallsBackToNonStreamingCombine("SET serverReturnFinalResult=true; " + GROUP_BY_SUM);
+  }
+
+  /// Same for `serverReturnFinalResultKeyUnpartitioned` (`is_leaf_return_final_result`): a FINAL stage does sit
+  /// above, but it merges FINAL results, which double-counts across flushes for functions whose mergeFinalResult
+  /// accumulates (e.g. DISTINCTCOUNT sums its inputs).
+  @Test
+  public void testServerReturnFinalResultKeyUnpartitionedDoesNotUseStreamingCombine() {
+    assertFallsBackToNonStreamingCombine("SET serverReturnFinalResultKeyUnpartitioned=true; " + GROUP_BY_SUM);
+  }
+
+  @Test
+  public void testPlainLeafUsesStreamingCombine() {
+    assertEquals(route(GROUP_BY_SUM, 10).getClass(), StreamingGroupByCombineOperator.class);
+  }
+
+  /// Asserts that a flush threshold picks exactly the operator the same query gets without one.
+  private void assertFallsBackToNonStreamingCombine(String query) {
+    assertEquals(route(query, 10).getClass(), route(query, 0).getClass(),
+        "A leaf asked to return FINAL results must be combined as if no flush threshold were set");
+  }
+
+  /// Runs [CombinePlanNode] with a streamer attached, as an MSE leaf stage does.
+  private BaseCombineOperator<?> route(String query, int flushThreshold) {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+    queryContext.setEndTimeMs(System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
+    queryContext.setStreamingGroupByFlushThreshold(flushThreshold);
+    List<PlanNode> planNodes = new ArrayList<>(NUM_SEGMENTS);
+    for (IndexSegment indexSegment : _indexSegments) {
+      planNodes.add(PLAN_MAKER.makeSegmentPlanNode(new SegmentContext(indexSegment), queryContext));
+    }
+    return new CombinePlanNode(planNodes, queryContext, EXECUTOR, block -> { }).run();
   }
 
   private List<Operator> buildOperators(QueryContext queryContext) {


### PR DESCRIPTION
### Problem

`streamingGroupByFlushThreshold` (added in #18035) routes every MSE group-by leaf to `StreamingGroupByCombineOperator`, with no check on whether that leaf is allowed to emit partial results.

The streaming leaf flushes a partial aggregate whenever its table reaches the threshold, so **one group key can be emitted from several flush windows**. That is sound for the plain LEAF + EXCHANGE + FINAL shape it was written for — the FINAL stage merges the pieces back together. It is not sound when the leaf itself has to produce final values:

- `is_partitioned_by_group_by_keys` makes the leaf aggregate `AggType.DIRECT`, which sets `serverReturnFinalResult` and leaves **no aggregation above it at all**.
- `is_leaf_return_final_result` sets `serverReturnFinalResultKeyUnpartitioned`. A FINAL stage does sit above, but it merges *final* results.

Reproduced end to end against a single server with 3 identical segments, using `SET streamingGroupByFlushThreshold=1`:

| Query | Result |
|---|---|
| `/*+ aggOptions(is_partitioned_by_group_by_keys='true') */ col1, COUNT(*)` | **Silently wrong** — 15 rows of `1` instead of 5 rows of `3` |
| `/*+ aggOptions(is_partitioned_by_group_by_keys='true') */ col1, AVG(col3), COUNT(DISTINCT col3)` | `ClassCastException: IntOpenHashSet cannot be cast to Number` |
| `/*+ aggOptions(is_leaf_return_final_result='true') */ col1, COUNT(DISTINCT col3)` | Same `ClassCastException` |

The `ClassCastException` is the raw intermediate escaping the leaf: the flushed block's schema types stay `OBJECT` where the multi-stage plan expects `LONG`/`DOUBLE`.

### Why not just finalize each flush

`flushTable()` calls `_indexedTable.finish(false)` unconditionally, where `GroupByCombineOperator.mergeResults()` branches to `finish(true, true)` / `finish(false, true)` for the same two flags. Mirroring that branching looks like the fix, and it does make both `ClassCastException`s go away — but it replaces them with silent wrong answers:

- `is_leaf_return_final_result` + `COUNT(DISTINCT)` then returns `3` instead of `1`, because `DistinctCountAggregationFunction.mergeFinalResult` sums its inputs, so each flush window's partial count is double-counted.
- `is_partitioned_by_group_by_keys` still returns duplicate rows, since nothing above merges them.

A final result computed per flush window is not the group's final result. The precondition is structural, so the fix is to not stream at all in these cases.

### Fix

Exclude both flags in `CombinePlanNode`, so these leaves fall back to `GroupByCombineOperator` exactly as they would without a flush threshold. The `serverReturnFinalResult` check also covers single-server SSE queries, where the broker sets the flag automatically and the gRPC path supplies a streamer.

`StreamingGroupByCombineOperator`'s constructor now asserts the precondition it documents, so a future second construction site fails loudly instead of returning wrong results.

### Tests

Three routing tests in `StreamingGroupByCombineOperatorTest`, at the point where the decision is made: both flags fall back to the same operator the query would get with no flush threshold at all, and a plain leaf still streams. The first two fail without the fix.

`QueryRunnerTest`, `CombinePlanNodeTest` and `SortedGroupByCombineOperatorsTest` pass unchanged.

No wire, config, or serialization change. The fix is server-side and plan-time only, so servers still on an older build keep returning wrong answers for these queries during a rolling upgrade.