### PR TITLE
Don't let RLS filters clobber the leaf's serverReturnFinalResult flag

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -111,7 +111,14 @@ public class ServerPlanRequestUtils {
     pinotQuery.setExplain(explain);
 
     if (MapUtils.isNotEmpty(rowFilters)) {
-      pinotQuery.setQueryOptions(rowFilters);
+      // Merge, never replace: the plan visitor may already have stamped SERVER_RETURN_FINAL_RESULT[_KEY_UNPARTITIONED]
+      // here, and updateQueryOptions() below does not restore them. Copy the map, it belongs to the caller.
+      Map<String, String> queryOptions = pinotQuery.getQueryOptions();
+      if (queryOptions != null) {
+        queryOptions.putAll(rowFilters);
+      } else {
+        pinotQuery.setQueryOptions(new HashMap<>(rowFilters));
+      }
     }
 
     List<InstanceRequest> instanceRequests;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
-import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
@@ -110,15 +109,10 @@ public class ServerPlanRequestUtils {
     PinotQuery pinotQuery = serverContext.getPinotQuery();
     pinotQuery.setExplain(explain);
 
-    if (MapUtils.isNotEmpty(rowFilters)) {
+    if (rowFilters != null) {
       // Merge, never replace: the plan visitor may already have stamped SERVER_RETURN_FINAL_RESULT[_KEY_UNPARTITIONED]
-      // here, and updateQueryOptions() below does not restore them. Copy the map, it belongs to the caller.
-      Map<String, String> queryOptions = pinotQuery.getQueryOptions();
-      if (queryOptions != null) {
-        queryOptions.putAll(rowFilters);
-      } else {
-        pinotQuery.setQueryOptions(new HashMap<>(rowFilters));
-      }
+      // here, and updateQueryOptions() below does not restore them.
+      rowFilters.forEach(pinotQuery::putToQueryOptions);
     }
 
     List<InstanceRequest> instanceRequests;

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
@@ -48,6 +48,7 @@ import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.sql.parsers.rewriter.RlsUtils;
 import org.assertj.core.api.Assertions;
 import org.intellij.lang.annotations.Language;
 import org.testng.Assert;
@@ -370,6 +371,21 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
           .withFailMessage("Exception should contain: " + expectedError + ", but found: " + exceptionMessage)
           .contains(expectedError);
     }
+  }
+
+  /// RLS filters are stamped onto the leaf's query options, which is also the only place the planner records that the
+  /// leaf must finalize its aggregates (`is_partitioned_by_group_by_keys` makes the aggregate `AggType.DIRECT`, so no
+  /// stage above it can finalize anything). Stamping must merge, not replace: dropping the flag makes the leaf emit a
+  /// raw `IntOpenHashSet` into a column typed `INT`. Table b lives on a single server, so one row per group.
+  @Test
+  public void testDirectAggregateWithRowLevelSecurityFilter() {
+    String sql = "SELECT /*+ aggOptions(is_partitioned_by_group_by_keys='true') */ col1, DISTINCTCOUNT(col3) FROM b "
+        + "GROUP BY col1 ORDER BY col1";
+    Map<String, String> rlsFilters = Map.of(RlsUtils.buildRlsFilterKey("b"), "col3 > 1");
+    QueryDispatcher.QueryResult queryResult = queryRunner(sql, false, rlsFilters);
+    Assert.assertNull(queryResult.getProcessingException(), "Query failed: " + queryResult.getProcessingException());
+    // The RLS filter keeps only the two rows with col3 = 42.
+    compareRowEquals(queryResult.getResultTable(), List.of(new Object[]{"bar", 1}, new Object[]{"bob", 1}), true);
   }
 
   @DataProvider(name = "testDataWithSqlToFinalRowCount")

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
@@ -114,6 +114,13 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
   /// Dispatch query to each pinot-server. The logic should mimic QueryDispatcher.submit() but does not actually make
   /// ser/de dispatches.
   protected QueryDispatcher.QueryResult queryRunner(String sql, boolean trace) {
+    return queryRunner(sql, trace, Map.of());
+  }
+
+  /// Same as [#queryRunner(String, boolean)], but adds metadata the broker stamps outside the SQL text, e.g. the
+  /// `rlsFilters-<table>` entries carrying row-level-security filters.
+  protected QueryDispatcher.QueryResult queryRunner(String sql, boolean trace,
+      Map<String, String> extraRequestMetadata) {
     long startTimeMs = System.currentTimeMillis();
     long requestId = REQUEST_ID_GEN.getAndIncrement();
     SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sql);
@@ -141,6 +148,7 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
     requestMetadataMap.put(QueryOptionKey.TIMEOUT_MS, Long.toString(timeoutMs));
     requestMetadataMap.put(QueryOptionKey.EXTRA_PASSIVE_TIMEOUT_MS, Long.toString(extraPassiveTimeoutMs));
     requestMetadataMap.putIfAbsent(QueryOptionKey.ENABLE_NULL_HANDLING, "true");
+    requestMetadataMap.putAll(extraRequestMetadata);
 
     // Putting trace testing here as extra options as it doesn't go along with the rest of the items.
     if (trace) {


### PR DESCRIPTION
When row-level-security filters are present, `ServerPlanRequestUtils.compileLeafStage` replaces the whole query-options
map on the `PinotQuery`:

```java
if (MapUtils.isNotEmpty(rowFilters)) {
  pinotQuery.setQueryOptions(rowFilters);
}
```

By that point `ServerPlanRequestVisitor.visitAggregate` has already written `serverReturnFinalResult` or
`serverReturnFinalResultKeyUnpartitioned` into those options. Those two flags live only on the `PinotQuery` —
`updateQueryOptions` later merges in the op-chain metadata, which restores the broker-supplied options but not these.
So on an RLS-protected table both flags are silently dropped.

Neither hint leaves an aggregate stage above the leaf that could finalize anything, so the leaf emits raw
intermediates into columns typed for final values. A `DISTINCTCOUNT` under `is_partitioned_by_group_by_keys` on an
RLS-filtered table fails with:

```
class it.unimi.dsi.fastutil.ints.IntOpenHashSet cannot be cast to class java.lang.Number
```

`is_leaf_return_final_result` fails the same way. Aggregates whose intermediate and final types coincide (`SUM`,
`COUNT`) are unaffected, which is why this went unnoticed.

## Fix

Merge the row filters into the existing options instead of replacing them. RLS keys are prefixed with
`CommonConstants.RLS_FILTERS`, so they cannot collide with anything already there. The `null` branch copies the map
rather than aliasing it, since `updateQueryOptions` mutates it and it belongs to the caller.

## Testing

New regression test in `QueryRunnerTest`, verified to fail before the fix and pass after. `QueryRunnerTestBase` gains
an overload for passing request metadata the broker stamps outside the SQL text — `SET rlsFilters-b=...` is not a
route, since the key does not parse and is rejected outright in REJECT validation mode.

`pinot-query-runtime` (4593 tests) and `RowLevelSecurityIntegrationTest` both pass.
