### PR TITLE
Add lifecycle hooks and configs for custom partial-upsert mergers

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -810,6 +810,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       return record;
     }
     try {
+      _partialUpsertHandler.prepare(record);
       return doUpdateRecord(record, recordInfo);
     } finally {
       finishOperation();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
@@ -75,6 +75,11 @@ public class PartialUpsertHandler {
     }
   }
 
+  /// Prepares an incoming record before looking up a previous record for the same primary key.
+  public void prepare(GenericRow newRow) {
+    _partialUpsertMerger.prepare(newRow);
+  }
+
   public void merge(LazyRow previousRow, GenericRow newRow, Map<String, Object> resultHolder) {
     _partialUpsertMerger.merge(previousRow, newRow, resultHolder);
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/merger/PartialUpsertMerger.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/merger/PartialUpsertMerger.java
@@ -27,6 +27,17 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 /// Custom implementation can be plugged by implementing this interface and add the class name to the upsert config.
 public interface PartialUpsertMerger {
 
+  /// Prepares an incoming row before Pinot looks up and merges any previously persisted row.
+  ///
+  /// This method is invoked for every record processed by partial upsert, including the first record for a primary
+  /// key. Implementations can use it to validate or normalize values that must be handled consistently even when
+  /// there is no previous row to merge. Implementations must not modify primary-key or comparison-column values
+  /// because the corresponding [org.apache.pinot.segment.local.upsert.RecordInfo] has already been created.
+  ///
+  /// The default implementation is a no-op so existing custom mergers remain compatible.
+  default void prepare(GenericRow newRow) {
+  }
+
   /// Merges previous row with new incoming row and persists the merged results per column in the provided resultHolder.
   /// Primary key and comparison columns should not be merged because their values are not allowed to be modified.
   void merge(LazyRow previousRow, GenericRow newRow, Map<String, Object> resultHolder);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableConfigValidatorRegistry;
 import org.apache.pinot.spi.data.BuiltInVirtualColumnDefinitions;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
@@ -237,6 +238,7 @@ public class SchemaUtils {
       // existing config so unchanged legacy transforms remain grandfathered while all schema-dependent validation
       // still runs against the proposed schema.
       TableConfigUtils.validate(tableConfig, schema, null, tableConfig);
+      TableConfigValidatorRegistry.validateSchema(tableConfig, schema);
     } catch (Exception e) {
       throw new IllegalStateException(
           "Schema is incompatible with tableConfig with name: " + tableConfig.getTableName() + " and type: "

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -1428,12 +1428,18 @@ public final class TableConfigUtils {
 
     Map<String, UpsertConfig.Strategy> partialUpsertStrategies = upsertConfig.getPartialUpsertStrategies();
     String partialUpsertMergerClass = upsertConfig.getPartialUpsertMergerClass();
+    Map<String, String> partialUpsertMergerConfigs = upsertConfig.getPartialUpsertMergerConfigs();
 
-    // check if partialUpsertMergerClass is provided then partialUpsertStrategies should be empty
+    // A custom row merger owns the complete merge and cannot be combined with built-in column strategies. Custom
+    // merger configs have no consumer when the class is absent, so reject that likely configuration mistake.
     if (StringUtils.isNotBlank(partialUpsertMergerClass)) {
       Preconditions.checkState(MapUtils.isEmpty(partialUpsertStrategies),
           "If partialUpsertMergerClass is provided then partialUpsertStrategies should be empty");
-    } else if (MapUtils.isNotEmpty(partialUpsertStrategies)) {
+    } else {
+      Preconditions.checkState(MapUtils.isEmpty(partialUpsertMergerConfigs),
+          "partialUpsertMergerConfigs can only be provided with partialUpsertMergerClass");
+    }
+    if (StringUtils.isBlank(partialUpsertMergerClass) && MapUtils.isNotEmpty(partialUpsertStrategies)) {
       List<String> primaryKeyColumns = schema.getPrimaryKeyColumns();
       // validate partial upsert column mergers
       for (Map.Entry<String, UpsertConfig.Strategy> entry : partialUpsertStrategies.entrySet()) {
@@ -1486,7 +1492,8 @@ public final class TableConfigUtils {
 
   /// Validates that critical upsert configuration fields are not changed during table config update.
   /// Checks: mode, hashFunction, comparisonColumns, timeColumn (when no comparison columns),
-  /// deleteRecordColumn, dropOutOfOrderRecord, outOfOrderRecordColumn.
+  /// deleteRecordColumn, dropOutOfOrderRecord, outOfOrderRecordColumn, partialUpsertMergerClass, and
+  /// partialUpsertMergerConfigs.
   ///
   /// Partial-upsert strategy maps and the default partial-upsert strategy are intentionally
   /// not validated here — they may be added, removed, or changed on existing tables.
@@ -1503,8 +1510,19 @@ public final class TableConfigUtils {
     if (existingUpsertEnabled != newUpsertEnabled) {
       if (existingUpsertEnabled) {
         LOGGER.info("upsertConfig is removed from existing upsert table: {}", newConfig.getTableName());
+        UpsertConfig existingUpsertConfig = existingConfig.getUpsertConfig();
+        if (existingUpsertConfig != null
+            && StringUtils.isNotBlank(existingUpsertConfig.getPartialUpsertMergerClass())) {
+          violations.add(String.format("upsertConfig.partialUpsertMergerClass (%s -> null)",
+              existingUpsertConfig.getPartialUpsertMergerClass()));
+        }
       } else {
         LOGGER.info("upsertConfig is added to existing non-upsert table: {}", newConfig.getTableName());
+        UpsertConfig newUpsertConfig = newConfig.getUpsertConfig();
+        if (newUpsertConfig != null && StringUtils.isNotBlank(newUpsertConfig.getPartialUpsertMergerClass())) {
+          violations.add(String.format("upsertConfig.partialUpsertMergerClass (null -> %s)",
+              newUpsertConfig.getPartialUpsertMergerClass()));
+        }
       }
     } else if (existingUpsertEnabled) {
       UpsertConfig existingUpsertConfig = existingConfig.getUpsertConfig();
@@ -1550,6 +1568,18 @@ public final class TableConfigUtils {
       if (!Objects.equals(existingUpsertConfig.getDeleteRecordColumn(), newUpsertConfig.getDeleteRecordColumn())) {
         violations.add(String.format("upsertConfig.deleteRecordColumn (%s -> %s)",
             existingUpsertConfig.getDeleteRecordColumn(), newUpsertConfig.getDeleteRecordColumn()));
+      }
+      if (!Objects.equals(existingUpsertConfig.getPartialUpsertMergerClass(),
+          newUpsertConfig.getPartialUpsertMergerClass())) {
+        violations.add(String.format("upsertConfig.partialUpsertMergerClass (%s -> %s)",
+            existingUpsertConfig.getPartialUpsertMergerClass(), newUpsertConfig.getPartialUpsertMergerClass()));
+      }
+      Map<String, String> existingMergerConfigs = existingUpsertConfig.getPartialUpsertMergerConfigs();
+      Map<String, String> newMergerConfigs = newUpsertConfig.getPartialUpsertMergerConfigs();
+      if (!(MapUtils.isEmpty(existingMergerConfigs) && MapUtils.isEmpty(newMergerConfigs))
+          && !Objects.equals(existingMergerConfigs, newMergerConfigs)) {
+        violations.add(String.format("upsertConfig.partialUpsertMergerConfigs (%s -> %s)",
+            existingMergerConfigs, newMergerConfigs));
       }
     }
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
@@ -61,7 +61,10 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
@@ -101,6 +104,48 @@ public class BasePartitionUpsertMetadataManagerTest {
       assertFalse(upsertMetadataManager.isPreloading());
       upsertMetadataManager.stop();
     }
+  }
+
+  @Test
+  public void testPrepareRunsBeforeUpdatingFirstRecord() {
+    PartialUpsertHandler partialUpsertHandler = mock(PartialUpsertHandler.class);
+    UpsertContext upsertContext = mock(UpsertContext.class);
+    GenericRow record = new GenericRow();
+    record.putValue("pk", "pk1");
+    when(upsertContext.getPartialUpsertHandlerSupplier()).thenReturn(() -> partialUpsertHandler);
+    doAnswer(invocation -> {
+      ((GenericRow) invocation.getArgument(0)).putValue("structured", "prepared");
+      return null;
+    }).when(partialUpsertHandler).prepare(record);
+    PreparingPartitionUpsertMetadataManager upsertMetadataManager =
+        new PreparingPartitionUpsertMetadataManager("testTable_REALTIME", 0, upsertContext);
+
+    GenericRow updatedRecord = upsertMetadataManager.updateRecord(record, mock(RecordInfo.class));
+
+    assertSame(updatedRecord, record);
+    assertTrue(upsertMetadataManager.wasUpdateAttempted());
+    assertTrue(upsertMetadataManager.wasPreparedBeforeUpdate());
+    verify(partialUpsertHandler).prepare(record);
+  }
+
+  @Test
+  public void testPrepareFailurePreventsRecordUpdate() {
+    PartialUpsertHandler partialUpsertHandler = mock(PartialUpsertHandler.class);
+    UpsertContext upsertContext = mock(UpsertContext.class);
+    GenericRow record = new GenericRow();
+    record.putValue("pk", "pk1");
+    IllegalArgumentException prepareFailure = new IllegalArgumentException("invalid structured value");
+    when(upsertContext.getPartialUpsertHandlerSupplier()).thenReturn(() -> partialUpsertHandler);
+    doThrow(prepareFailure).when(partialUpsertHandler).prepare(record);
+    PreparingPartitionUpsertMetadataManager upsertMetadataManager =
+        new PreparingPartitionUpsertMetadataManager("testTable_REALTIME", 0, upsertContext);
+
+    IllegalArgumentException thrown = expectThrows(IllegalArgumentException.class,
+        () -> upsertMetadataManager.updateRecord(record, mock(RecordInfo.class)));
+
+    assertSame(thrown, prepareFailure);
+    assertFalse(upsertMetadataManager.wasUpdateAttempted());
+    verify(partialUpsertHandler).prepare(record);
   }
 
   @Test
@@ -1138,6 +1183,30 @@ public class BasePartitionUpsertMetadataManagerTest {
 
     @Override
     protected void clearPrevKeyToRecordLocation() {
+    }
+  }
+
+  private static class PreparingPartitionUpsertMetadataManager extends DummyPartitionUpsertMetadataManager {
+    private boolean _updateAttempted;
+    private boolean _preparedBeforeUpdate;
+
+    private PreparingPartitionUpsertMetadataManager(String tableNameWithType, int partitionId, UpsertContext context) {
+      super(tableNameWithType, partitionId, context);
+    }
+
+    @Override
+    protected GenericRow doUpdateRecord(GenericRow record, RecordInfo recordInfo) {
+      _updateAttempted = true;
+      _preparedBeforeUpdate = "prepared".equals(record.getValue("structured"));
+      return record;
+    }
+
+    private boolean wasUpdateAttempted() {
+      return _updateAttempted;
+    }
+
+    private boolean wasPreparedBeforeUpdate() {
+      return _preparedBeforeUpdate;
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandlerTest.java
@@ -117,6 +117,32 @@ public class PartialUpsertHandlerTest {
   }
 
   @Test
+  public void testPrepareDelegatesToCustomPartialUpsertMerger() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .addSingleValueDimension("pk", FieldSpec.DataType.STRING)
+        .addDateTime("hoursSinceEpoch", FieldSpec.DataType.LONG, "1:HOURS:EPOCH", "1:HOURS")
+        .setPrimaryKeyColumns(List.of("pk")).build();
+    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
+    upsertConfig.setPartialUpsertMergerClass("org.apache.pinot.segment.local.upsert.CustomPartialUpsertRowMerger");
+    PartialUpsertMerger customMerger = mock(PartialUpsertMerger.class);
+
+    try (MockedStatic<PartialUpsertMergerFactory> partialUpsertMergerFactory = mockStatic(
+        PartialUpsertMergerFactory.class)) {
+      when(PartialUpsertMergerFactory.getPartialUpsertMerger(List.of("pk"), List.of("hoursSinceEpoch"),
+          upsertConfig)).thenReturn(customMerger);
+      PartialUpsertHandler handler = new PartialUpsertHandler(createTableConfig(schema, upsertConfig), schema,
+          List.of("hoursSinceEpoch"), upsertConfig);
+      GenericRow newRecord = new GenericRow();
+      newRecord.putValue("pk", "pk1");
+      newRecord.putValue("hoursSinceEpoch", 1L);
+
+      handler.prepare(newRecord);
+
+      verify(customMerger).prepare(newRecord);
+    }
+  }
+
+  @Test
   public void testPostUpsertTransformRunsAfterMerge() {
     Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable").addSingleValueDimension("pk",
             FieldSpec.DataType.STRING)

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SchemaUtilsTableConfigValidatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SchemaUtilsTableConfigValidatorTest.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.utils;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableConfigValidator;
+import org.apache.pinot.spi.config.table.TableConfigValidatorRegistry;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+
+public class SchemaUtilsTableConfigValidatorTest {
+  @AfterMethod(alwaysRun = true)
+  public void resetValidators() {
+    TableConfigValidatorRegistry.reset();
+  }
+
+  @Test
+  public void testSchemaValidationOnlyInvokesOptInTableConfigValidators() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .addSingleValueDimension("id", FieldSpec.DataType.LONG)
+        .setPrimaryKeyColumns(List.of("id"))
+        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    AtomicBoolean ordinaryValidatorInvoked = new AtomicBoolean();
+    AtomicBoolean schemaValidatorInvoked = new AtomicBoolean();
+    TableConfigValidatorRegistry.register((actualTableConfig, actualSchema) -> {
+      ordinaryValidatorInvoked.set(true);
+    });
+    TableConfigValidatorRegistry.register(new TableConfigValidator() {
+      @Override
+      public void validate(TableConfig actualTableConfig, Schema actualSchema) {
+        ordinaryValidatorInvoked.set(true);
+      }
+
+      @Override
+      public void validateSchema(TableConfig actualTableConfig, Schema actualSchema) {
+        assertTrue(actualTableConfig == tableConfig);
+        assertTrue(actualSchema == schema);
+        schemaValidatorInvoked.set(true);
+      }
+    });
+
+    SchemaUtils.validate(schema, List.of(tableConfig));
+
+    assertFalse(ordinaryValidatorInvoked.get());
+    assertTrue(schemaValidatorInvoked.get());
+  }
+
+  @Test
+  public void testSchemaValidationPropagatesRegisteredValidatorFailure() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .addSingleValueDimension("id", FieldSpec.DataType.LONG)
+        .setPrimaryKeyColumns(List.of("id"))
+        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    TableConfigValidatorRegistry.register(new TableConfigValidator() {
+      @Override
+      public void validate(TableConfig actualTableConfig, Schema actualSchema) {
+      }
+
+      @Override
+      public void validateSchema(TableConfig actualTableConfig, Schema actualSchema) {
+        throw new IllegalArgumentException("custom schema rejection");
+      }
+    });
+
+    IllegalStateException e = expectThrows(IllegalStateException.class,
+        () -> SchemaUtils.validate(schema, List.of(tableConfig)));
+
+    assertTrue(e.getMessage().contains("custom schema rejection"));
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -3334,6 +3334,44 @@ public class TableConfigUtilsTest {
     }
   }
 
+  @Test
+  public void testPartialUpsertMergerConfigsRequireCustomMerger() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("pk", DataType.LONG)
+        .addSingleValueDimension("payload", DataType.JSON)
+        .addDateTime("eventTime", DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .setPrimaryKeyColumns(List.of("pk"))
+        .build();
+    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
+    upsertConfig.setComparisonColumn("eventTime");
+    upsertConfig.setPartialUpsertMergerConfigs(Map.of("jsonColumns", "payload"));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName("eventTime")
+        .setUpsertConfig(upsertConfig)
+        .setNullHandlingEnabled(true)
+        .build();
+
+    IllegalStateException e = expectThrows(IllegalStateException.class,
+        () -> TableConfigUtils.validatePartialUpsertStrategies(tableConfig, schema));
+    assertEquals(e.getMessage(), "partialUpsertMergerConfigs can only be provided with partialUpsertMergerClass");
+
+    upsertConfig.setPartialUpsertMergerClass("  ");
+    expectThrows(IllegalStateException.class,
+        () -> TableConfigUtils.validatePartialUpsertStrategies(tableConfig, schema));
+
+    upsertConfig.setPartialUpsertMergerClass("example.StructuredMerger");
+    TableConfigUtils.validatePartialUpsertStrategies(tableConfig, schema);
+
+    upsertConfig.setPartialUpsertStrategies(Map.of("payload", UpsertConfig.Strategy.OVERWRITE));
+    expectThrows(IllegalStateException.class,
+        () -> TableConfigUtils.validatePartialUpsertStrategies(tableConfig, schema));
+
+    upsertConfig.setPartialUpsertMergerClass(null);
+    upsertConfig.setPartialUpsertStrategies(null);
+    upsertConfig.setPartialUpsertMergerConfigs(Map.of());
+    TableConfigUtils.validatePartialUpsertStrategies(tableConfig, schema);
+  }
+
   /// Utility function that can be used to write simple tests that modify the table config and schema.
   ///
   /// This function has been designed to test the nullability of the partial upsert config, but feel free to use it to
@@ -4512,6 +4550,45 @@ public class TableConfigUtilsTest {
     List<String> violations = TableConfigUtils.validateBackwardCompatibility(newConfig, existingConfig);
     assertTrue(violations.isEmpty(),
         "Expected no violations for partial-upsert strategy and default-strategy changes, but got: " + violations);
+  }
+
+  @Test
+  public void testValidateBackwardCompatibilityRejectsCustomMergerChanges() {
+    UpsertConfig existingUpsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
+    UpsertConfig newUpsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
+    TableConfig existingConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN).setUpsertConfig(existingUpsertConfig).build();
+    TableConfig newConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN).setUpsertConfig(newUpsertConfig).build();
+
+    newUpsertConfig.setPartialUpsertMergerClass("example.StructuredMerger");
+    List<String> violations = TableConfigUtils.validateBackwardCompatibility(newConfig, existingConfig);
+    assertEquals(violations.size(), 1);
+    assertTrue(violations.get(0).contains("partialUpsertMergerClass"));
+
+    existingUpsertConfig.setPartialUpsertMergerClass("example.StructuredMerger");
+    existingUpsertConfig.setPartialUpsertMergerConfigs(Map.of("jsonColumns", "old"));
+    newUpsertConfig.setPartialUpsertMergerConfigs(Map.of("jsonColumns", "new"));
+    violations = TableConfigUtils.validateBackwardCompatibility(newConfig, existingConfig);
+    assertEquals(violations.size(), 1);
+    assertTrue(violations.get(0).contains("partialUpsertMergerConfigs"));
+
+    newUpsertConfig.setPartialUpsertMergerConfigs(Map.of("jsonColumns", "old"));
+    assertTrue(TableConfigUtils.validateBackwardCompatibility(newConfig, existingConfig).isEmpty());
+
+    existingUpsertConfig.setPartialUpsertMergerConfigs(null);
+    newUpsertConfig.setPartialUpsertMergerConfigs(Map.of());
+    assertTrue(TableConfigUtils.validateBackwardCompatibility(newConfig, existingConfig).isEmpty());
+
+    TableConfig nonUpsertConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN).build();
+    violations = TableConfigUtils.validateBackwardCompatibility(newConfig, nonUpsertConfig);
+    assertEquals(violations.size(), 1);
+    assertTrue(violations.get(0).contains("partialUpsertMergerClass"));
+
+    violations = TableConfigUtils.validateBackwardCompatibility(nonUpsertConfig, existingConfig);
+    assertEquals(violations.size(), 1);
+    assertTrue(violations.get(0).contains("partialUpsertMergerClass"));
   }
 
   @Test

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfigValidator.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfigValidator.java
@@ -23,9 +23,10 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.exception.ConfigValidationException;
 
 
-/// SPI interface for validating table config mutations (create and update).
-/// Implementations are registered via [TableConfigValidatorRegistry]
-/// and invoked before table config is persisted. Throw [ConfigValidationException] to reject.
+/// SPI interface for extending table-config and schema-mutation validation.
+/// Implementations are registered via [TableConfigValidatorRegistry]. [#validate(TableConfig, Schema)] is invoked
+/// before a table config is persisted; schema validation is a separate opt-in phase described by [#validateSchema].
+/// Throw [ConfigValidationException] to reject a mutation.
 ///
 /// Implementations must be thread-safe — they may be called concurrently from multiple request threads.
 public interface TableConfigValidator {
@@ -37,4 +38,17 @@ public interface TableConfigValidator {
   /// @throws ConfigValidationException if the table config violates validation rules
   void validate(TableConfig tableConfig, @Nullable Schema schema)
       throws ConfigValidationException;
+
+  /// Validates a proposed schema against an existing table config.
+  ///
+  /// This is a separate, opt-in phase from [#validate(TableConfig, Schema)]. Existing validators may depend on
+  /// table-config mutation state and therefore must not run for schema writes unless they explicitly override this
+  /// method. The default implementation is a no-op.
+  ///
+  /// @param tableConfig The existing table config associated with the schema
+  /// @param schema The proposed schema
+  /// @throws ConfigValidationException if the schema violates validation rules
+  default void validateSchema(TableConfig tableConfig, Schema schema)
+      throws ConfigValidationException {
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfigValidatorRegistry.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfigValidatorRegistry.java
@@ -61,6 +61,20 @@ public class TableConfigValidatorRegistry {
     }
   }
 
+  /// Invokes the schema-validation phase of all registered validators in registration order.
+  /// Validators must explicitly opt in by overriding [TableConfigValidator#validateSchema(TableConfig, Schema)];
+  /// the default implementation is a no-op. Short-circuits on the first rejection.
+  ///
+  /// @param tableConfig The existing table config associated with the schema
+  /// @param schema The proposed schema
+  /// @throws ConfigValidationException if any opt-in validator rejects the schema
+  public static void validateSchema(TableConfig tableConfig, Schema schema)
+      throws ConfigValidationException {
+    for (TableConfigValidator validator : VALIDATORS) {
+      validator.validateSchema(tableConfig, schema);
+    }
+  }
+
   /// Removes a previously registered validator. No-op if the validator is not registered. Removes only the
   /// first matching reference if the same validator was registered multiple times.
   ///

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -72,6 +72,10 @@ public class UpsertConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Class name for custom row merger implementation")
   private String _partialUpsertMergerClass;
 
+  @JsonPropertyDescription("Custom configs for the partial upsert row merger")
+  @Nullable
+  private Map<String, String> _partialUpsertMergerConfigs;
+
   /// When two records have the same primary key, the comparison column(s) si used to determine the latest record. If
   /// not configured, the time column is used.
   /// When multiple comparison columns are configured, the latest record is determined by the first non-null value for
@@ -210,6 +214,15 @@ public class UpsertConfig extends BaseJsonConfig {
 
   public void setPartialUpsertMergerClass(@Nullable String partialUpsertMergerClass) {
     _partialUpsertMergerClass = partialUpsertMergerClass;
+  }
+
+  @Nullable
+  public Map<String, String> getPartialUpsertMergerConfigs() {
+    return _partialUpsertMergerConfigs;
+  }
+
+  public void setPartialUpsertMergerConfigs(@Nullable Map<String, String> partialUpsertMergerConfigs) {
+    _partialUpsertMergerConfigs = partialUpsertMergerConfigs;
   }
 
   @Nullable

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/TableConfigValidatorRegistryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/TableConfigValidatorRegistryTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.config.table;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.exception.ConfigValidationException;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.AfterMethod;
@@ -88,5 +89,29 @@ public class TableConfigValidatorRegistryTest {
     });
     TableConfigValidatorRegistry.reset();
     TableConfigValidatorRegistry.validate(DUMMY_TABLE_CONFIG, null);
+  }
+
+  @Test
+  public void testSchemaValidationIsOptIn() {
+    AtomicBoolean tableConfigValidatorCalled = new AtomicBoolean(false);
+    AtomicBoolean schemaValidatorCalled = new AtomicBoolean(false);
+    TableConfigValidatorRegistry.register((tableConfig, schema) -> tableConfigValidatorCalled.set(true));
+    TableConfigValidatorRegistry.register(new TableConfigValidator() {
+      @Override
+      public void validate(TableConfig tableConfig, Schema schema) {
+        tableConfigValidatorCalled.set(true);
+      }
+
+      @Override
+      public void validateSchema(TableConfig tableConfig, Schema schema) {
+        schemaValidatorCalled.set(true);
+      }
+    });
+
+    TableConfigValidatorRegistry.validateSchema(DUMMY_TABLE_CONFIG,
+        new Schema.SchemaBuilder().setSchemaName("testTable").build());
+
+    assertFalse(tableConfigValidatorCalled.get());
+    assertTrue(schemaValidatorCalled.get());
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/UpsertConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/UpsertConfigTest.java
@@ -21,9 +21,11 @@ package org.apache.pinot.spi.config.table;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 
 public class UpsertConfigTest {
@@ -45,6 +47,10 @@ public class UpsertConfigTest {
     upsertConfig2.setPartialUpsertStrategies(partialUpsertStrategies);
     upsertConfig2.setDefaultPartialUpsertStrategy(UpsertConfig.Strategy.OVERWRITE);
     assertEquals(upsertConfig2.getPartialUpsertStrategies(), partialUpsertStrategies);
+
+    Map<String, String> partialUpsertMergerConfigs = Map.of("jsonColumns", "profile,attributes");
+    upsertConfig2.setPartialUpsertMergerConfigs(partialUpsertMergerConfigs);
+    assertEquals(upsertConfig2.getPartialUpsertMergerConfigs(), partialUpsertMergerConfigs);
   }
 
   @Test
@@ -52,5 +58,22 @@ public class UpsertConfigTest {
     UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
     assertEquals(upsertConfig.getHashFunction(), HashFunction.NONE);
     assertEquals(upsertConfig.getDefaultPartialUpsertStrategy(), UpsertConfig.Strategy.OVERWRITE);
+  }
+
+  @Test
+  public void testPartialUpsertMergerConfigsJsonRoundTrip()
+      throws Exception {
+    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
+    upsertConfig.setPartialUpsertMergerClass("example.StructuredMerger");
+    upsertConfig.setPartialUpsertMergerConfigs(Map.of("jsonColumns", "profile", "maxDepth", "32"));
+
+    UpsertConfig deserialized =
+        JsonUtils.stringToObject(JsonUtils.objectToString(upsertConfig), UpsertConfig.class);
+
+    assertEquals(deserialized.getPartialUpsertMergerClass(), "example.StructuredMerger");
+    assertEquals(deserialized.getPartialUpsertMergerConfigs(), Map.of("jsonColumns", "profile", "maxDepth", "32"));
+
+    UpsertConfig oldConfig = JsonUtils.stringToObject("{\"mode\":\"PARTIAL\"}", UpsertConfig.class);
+    assertNull(oldConfig.getPartialUpsertMergerConfigs());
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Prepare hook called before partial upsert record update

```mermaid
flowchart TD
  N0["updateRecord #40;F1#41;"]:::stModified
  N1["handler#46;prepare #40;F2#41;"]:::stModified
  N2["merger#46;prepare #40;F3#41;"]:::stModified
  N0 -->|"calls"| N1
  N1 -->|"calls"| N2
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java) · [after](https://github.com/apache/pinot/blob/4cf279c0f8e1b980583dd53cec73c1f515faeaf3/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java)
- F2: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java) · [after](https://github.com/apache/pinot/blob/4cf279c0f8e1b980583dd53cec73c1f515faeaf3/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java)
- F3: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/upsert/merger/PartialUpsertMerger\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/merger/PartialUpsertMerger.java) · [after](https://github.com/apache/pinot/blob/4cf279c0f8e1b980583dd53cec73c1f515faeaf3/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/merger/PartialUpsertMerger.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImU2Nzg3ZTE3ODY0NWZkM2M1YTg4N2UyYWJhN2UwZGU4MzQzY2Q1MjQiLCJjb250ZXh0X2hhc2giOiJlMzkyMzk5OTViYzlhMzg3ODA2MGE0ZDEzOTEyYWZmNDBhYThhMjZkMWEwY2IzZjczNmZkODhiZGQ1NjhmZGY3IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTI1OTM2LCJoZWFkX3NoYSI6IjRjZjI3OWMwZjhlMWI5ODA1ODNkZDUzY2VjNzNjMWY1MTVmYWVhZjMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJlNjc4N2UxNzg2NDVmZDNjNWE4ODdlMmFiYTdlMGRlODM0M2NkNTI0IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature af29c363fca8f9b3c5412c917fec875b731f3c1daf7f4959cd3381d36ca5c8fc -->
<!-- pinot-pr-flow:end -->

## Motivation

Custom partial-upsert mergers can own row merge behavior, but they currently cannot receive implementation-specific configuration or validate and normalize records that have no previously stored row. Plugins also need an opt-in way to validate schema changes against their table configuration.

## Changes

- Add optional `partialUpsertMergerConfigs` to `UpsertConfig`.
- Add a backward-compatible `PartialUpsertMerger.prepare(GenericRow)` hook.
- Invoke `prepare()` for every partial-upsert record before previous-row lookup and update, including the first record for a primary key.
- Reject merger configs without a custom merger class and continue rejecting combinations of custom mergers with built-in per-column strategies.
- Treat a custom merger class and its configs as immutable on existing tables, preventing replicas from using mixed semantics while handlers remain initialized with old configuration.
- Add an opt-in schema-validation phase to `TableConfigValidator` and invoke registered validators during schema writes.

## Compatibility

Existing custom mergers remain compatible because `prepare()` defaults to a no-op, and existing table configs need not define merger configs.

This intentionally tightens table-update validation: adding, removing, or changing a custom merger class/config on an existing table is rejected. Such handlers are initialized at table startup, so accepting live mutations could give replicas different merge semantics.

Implementations must not change primary-key or comparison-column values from `prepare()` because `RecordInfo` has already been constructed.

## Tests

- 107 focused tests passed across `pinot-spi` and `pinot-segment-local`, including `UpsertConfigTest`, `TableConfigUtilsTest`, `PartialUpsertHandlerTest`, `BasePartitionUpsertMetadataManagerTest`, `TableConfigValidatorRegistryTest`, and `SchemaUtilsTableConfigValidatorTest`.
- Affected-module formatting, Checkstyle, license checks, and `git diff --check` passed.
