### PR TITLE
Skip block copies for spool stages whose workers are all remote

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
@@ -116,9 +116,12 @@ public class GrpcSendingMailbox implements SendingMailbox {
     return false;
   }
 
-  /// NOTE: [org.apache.pinot.query.runtime.operator.exchange.BlockExchange] implementations rely on this method
-  /// serializing the block synchronously on the calling thread: once it returns, the block's contents may be handed
-  /// by reference to a local receiver that mutates them.
+  @Override
+  public boolean deliversByReference() {
+    // Blocks are serialized within send(MseBlock.Data), so the receiver never reads this instance
+    return false;
+  }
+
   @Override
   public void send(MseBlock.Data data) {
     QueryThreadContext.checkTerminationAndSampleUsage(SEND_SCOPE);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
@@ -63,6 +63,12 @@ public class InMemorySendingMailbox implements SendingMailbox {
   }
 
   @Override
+  public boolean deliversByReference() {
+    // Blocks are offered to the receiving mailbox as they are, so the receiver reads the same instance
+    return true;
+  }
+
+  @Override
   public void send(MseBlock.Data data) {
     QueryThreadContext.checkTerminationAndSampleUsage(SEND_SCOPE);
     sendPrivate(data, List.of());

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/SendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/SendingMailbox.java
@@ -33,14 +33,37 @@ import org.apache.pinot.segment.spi.memory.DataBuffer;
 ///   - One call to [#cancel(Throwable)] if the sender wants to cancel the receiver
 public interface SendingMailbox extends AutoCloseable {
 
-  /// Returns whether the mailbox is sending data to a local receiver, where blocks can be directly passed to the
-  /// receiver.
+  /// Returns whether blocks can be passed to this mailbox whole, instead of being split into smaller blocks that
+  /// respect the maximum content size of a mailbox message.
+  ///
+  /// This says nothing about whether the receiver ends up with a reference to the block: see
+  /// [#deliversByReference()].
   boolean isLocal();
+
+  /// Returns whether a receiver may keep a reference to the blocks sent to this mailbox, instead of reading their
+  /// contents within [#send(MseBlock.Data)]. The answer must not change during the life of the mailbox, so callers
+  /// can read it once.
+  ///
+  /// A caller that sends the same block instance to more than one mailbox, when anything downstream mutates the
+  /// contents of that block, must:
+  ///
+  /// 1. Give a copy of the block to all the mailboxes that return `true` here, except one.
+  /// 2. Give the original block to that remaining mailbox last, once every other mailbox has returned from
+  ///    [#send(MseBlock.Data)].
+  ///
+  /// Step 2 matters as much as step 1. A receiver of the original block can mutate it as soon as `send` gives it the
+  /// block, which would corrupt the block for a mailbox that is still reading it.
+  ///
+  /// See [org.apache.pinot.query.runtime.operator.exchange.BroadcastExchange].
+  boolean deliversByReference();
 
   /// Sends a data block to the receiver. Note that SendingMailbox are required to acquire resources lazily in this
   /// call, and they should **not** acquire any resources when they are created. This method should throw if there was
   /// an error sending the data, since that would allow
   /// [org.apache.pinot.query.runtime.operator.exchange.BlockExchange] to exit early.
+  ///
+  /// Implementations that return `false` from [#deliversByReference()] must finish reading the block before this
+  /// method returns, because the caller may then pass the same block to a receiver that mutates it.
   void send(MseBlock.Data data);
 
   /// Sends an EOS block to the receiver. Note that SendingMailbox are required to acquire resources lazily in this

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -89,7 +89,8 @@ public class MailboxSendOperator extends MultiStageOperator {
   /// 1. One inner exchange is created for each receiver stage, using the method mentioned above and keeping the
   ///    distribution type specified in the [MailboxSendNode].
   /// 2. Then, a single outer broadcast exchange is created to fan out the data to all the inner exchanges. It copies
-  ///    blocks that carry aggregation intermediate results so that no two receiver stages share them.
+  ///    blocks that carry aggregation intermediate results, so that no two receiver stages share them. Stages whose
+  ///    workers all read the block within [SendingMailbox#send(MseBlock.Data)] do not need a copy.
   ///
   /// @see BlockExchange#asSendingMailbox(String)
   private static BlockExchange getBlockExchange(OpChainExecutionContext ctx, MailboxSendNode node,

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchange.java
@@ -43,6 +43,7 @@ public abstract class BlockExchange implements AutoCloseable {
   private final List<SendingMailbox> _sendingMailboxes;
   private final BlockSplitter _splitter;
   private final Function<List<SendingMailbox>, Integer> _statsIndexChooser;
+  private final boolean _deliversByReference;
 
   protected static final Function<List<SendingMailbox>, Integer> RANDOM_INDEX_CHOOSER =
       (mailboxes) -> ThreadLocalRandom.current().nextInt(mailboxes.size());
@@ -86,6 +87,18 @@ public abstract class BlockExchange implements AutoCloseable {
     _sendingMailboxes = sendingMailboxes;
     _splitter = splitter;
     _statsIndexChooser = statsIndexChooser;
+    _deliversByReference = anyDeliversByReference(sendingMailboxes);
+  }
+
+  /// Returns whether any of the given mailboxes delivers blocks by reference. Mailboxes are fixed when the exchange
+  /// is created, and each of them gives a constant answer, so this is computed once.
+  private static boolean anyDeliversByReference(List<SendingMailbox> sendingMailboxes) {
+    for (SendingMailbox sendingMailbox : sendingMailboxes) {
+      if (sendingMailbox.deliversByReference()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /// API to send a block to the destination mailboxes.
@@ -213,7 +226,17 @@ public abstract class BlockExchange implements AutoCloseable {
 
     @Override
     public boolean isLocal() {
+      // Blocks are handed to the decorated exchange whole, and splitting them is left to that exchange.
+      // TODO: the decorated exchange is currently built with BlockSplitter#NO_OP, so blocks sent through a
+      //       multi-send node are never split. See MailboxSendOperator#getBlockExchange.
       return true;
+    }
+
+    @Override
+    public boolean deliversByReference() {
+      // The decorated exchange passes blocks to its own mailboxes, so this mailbox delivers by reference only if
+      // any of those does
+      return _deliversByReference;
     }
 
     @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BroadcastExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BroadcastExchange.java
@@ -28,14 +28,14 @@ import org.apache.pinot.query.runtime.blocks.RowHeapDataBlock;
 
 /// Broadcast blocks to all the destinations.
 ///
-/// This is the only exchange that routes the same block to more than one destination, and local (same-JVM) mailboxes
-/// deliver on-heap blocks by reference. Blocks that
+/// This is the only exchange that routes the same block to more than one destination, and some mailboxes
+/// [deliver blocks by reference][SendingMailbox#deliversByReference()]. Blocks that
 /// [carry aggregation intermediate results][RowHeapDataBlock#containsObjectColumns()] cannot be shared this way:
 /// downstream operators mutate those objects in place when they merge them or extract final results, so two
-/// receivers on the same server would corrupt them. For such blocks, [#route] gives every local destination except
-/// the first its own [copy][RowHeapDataBlock#copyObjectColumns()]. Remote destinations only read the block to
-/// serialize it, before any local receiver can mutate it, so they do not need copies. Blocks without OBJECT columns
-/// are shared by reference with all the destinations.
+/// receivers of the same block would corrupt them. For such blocks, [#route] gives every destination that delivers
+/// by reference, except the first, its own [copy][RowHeapDataBlock#copyObjectColumns()]. The other destinations read
+/// the block within [SendingMailbox#send(MseBlock.Data)], before any receiver can mutate it, so they do not need
+/// copies. Blocks without OBJECT columns are shared by reference with all the destinations.
 ///
 /// This also protects multi-send (spool) nodes, which fan each block out to the exchanges of their receiver stages
 /// through this exchange (see [BlockExchange#asSendingMailbox]).
@@ -60,26 +60,26 @@ class BroadcastExchange extends BlockExchange {
       }
       return;
     }
-    // Send a copy to every active local destination except the first one, which receives the original block without
-    // copying. Remote destinations serialize the original block on this thread, and the copies are also made on this
-    // thread, so all reads of the original block finish before it is handed to a local receiver that can start
-    // mutating it.
+    // Send a copy to every active destination that delivers by reference, except the first one, which receives the
+    // original block without copying. The other destinations read the original block within send, and the copies are
+    // also made on this thread, so all reads of the original block finish before it is handed to a receiver that can
+    // start mutating it.
     RowHeapDataBlock rowHeapBlock = block.asRowHeap();
-    SendingMailbox firstLocalDestination = null;
+    SendingMailbox firstByReferenceDestination = null;
     for (SendingMailbox mailbox : destinations) {
       if (mailbox.isEarlyTerminated()) {
         continue;
       }
-      if (!mailbox.isLocal()) {
+      if (!mailbox.deliversByReference()) {
         sendBlock(mailbox, block);
-      } else if (firstLocalDestination == null) {
-        firstLocalDestination = mailbox;
+      } else if (firstByReferenceDestination == null) {
+        firstByReferenceDestination = mailbox;
       } else {
         sendBlock(mailbox, rowHeapBlock.copyObjectColumns());
       }
     }
-    if (firstLocalDestination != null) {
-      sendBlock(firstLocalDestination, block);
+    if (firstByReferenceDestination != null) {
+      sendBlock(firstByReferenceDestination, block);
     }
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/GrpcSendingMailboxTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/GrpcSendingMailboxTest.java
@@ -80,6 +80,18 @@ public class GrpcSendingMailboxTest {
     }
   }
 
+  @Test
+  public void doesNotDeliverBlocksByReference() {
+    GrpcSendingMailbox mailbox =
+        new GrpcSendingMailbox("test-mailbox", Mockito.mock(ChannelManager.class), "localhost", 0, Long.MAX_VALUE,
+            new StatMap<>(MailboxSendOperator.StatKey.class), 4 * 1024 * 1024, true);
+
+    // Blocks are serialized within send(MseBlock.Data), so senders that share one block between mailboxes do not
+    // need to give this one a copy. See BroadcastExchange.
+    Assert.assertFalse(mailbox.deliversByReference());
+    Assert.assertFalse(mailbox.isLocal());
+  }
+
   /// Regression test for the lazy-initialization data race on `_contentObserver`. Before the fix, both `sendInternal`
   /// and `cancel` had an unsynchronized `if (_contentObserver == null) { _contentObserver = getContentObserver(); }`
   /// pattern. `_contentObserver` is `volatile` so individual reads/writes are atomic, but two threads racing through

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/InMemorySendingMailboxTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/InMemorySendingMailboxTest.java
@@ -49,4 +49,16 @@ public class InMemorySendingMailboxTest {
       Mockito.verifyNoInteractions(mailboxService);
     }
   }
+
+  @Test
+  public void deliversBlocksByReference() {
+    InMemorySendingMailbox mailbox =
+        new InMemorySendingMailbox("test-mailbox", Mockito.mock(MailboxService.class), Long.MAX_VALUE,
+            new StatMap<>(MailboxSendOperator.StatKey.class));
+
+    // Blocks are offered to the receiving mailbox as they are, so senders that share one block between mailboxes
+    // must give this one a copy. See BroadcastExchange.
+    Assert.assertTrue(mailbox.deliversByReference());
+    Assert.assertTrue(mailbox.isLocal());
+  }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchangeTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchangeTest.java
@@ -165,6 +165,28 @@ public class BlockExchangeTest {
     Assert.assertEquals(sentBlocks.get(1).asRowHeap().getRows(), outBlockTwo.getRows());
   }
 
+  @Test
+  public void shouldDeliverByReferenceWhenAnyDestinationDoes() {
+    // Given: an exchange whose destinations are one mailbox that serializes blocks and one that does not
+    when(_mailbox2.deliversByReference()).thenReturn(true);
+    BlockExchange exchange = new TestBlockExchange(List.of(_mailbox1, _mailbox2));
+
+    // Then: the exchange exposed as a mailbox reports that it delivers by reference
+    Assert.assertTrue(exchange.asSendingMailbox("1").deliversByReference());
+  }
+
+  @Test
+  public void shouldNotDeliverByReferenceWhenNoDestinationDoes() {
+    // Given: an exchange whose destinations all serialize the blocks they are sent
+    BlockExchange exchange = new TestBlockExchange(List.of(_mailbox1, _mailbox2));
+
+    // Then: the exchange exposed as a mailbox reports that it does not deliver by reference. It still takes blocks
+    // whole, because splitting them is left to the exchange it decorates
+    SendingMailbox sendingMailbox = exchange.asSendingMailbox("1");
+    Assert.assertFalse(sendingMailbox.deliversByReference());
+    Assert.assertTrue(sendingMailbox.isLocal());
+  }
+
   private static class TestBlockExchange extends BlockExchange {
     protected TestBlockExchange(List<SendingMailbox> destinations) {
       this(destinations, (block, size) -> Iterators.singletonIterator(block));

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/BroadcastExchangeTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/BroadcastExchangeTest.java
@@ -63,8 +63,11 @@ public class BroadcastExchangeTest {
   @BeforeMethod
   public void setUp() {
     _mocks = MockitoAnnotations.openMocks(this);
+    // In-memory mailboxes take blocks whole and hand them to the receiver by reference
     Mockito.when(_mailbox1.isLocal()).thenReturn(true);
     Mockito.when(_mailbox2.isLocal()).thenReturn(true);
+    Mockito.when(_mailbox1.deliversByReference()).thenReturn(true);
+    Mockito.when(_mailbox2.deliversByReference()).thenReturn(true);
     _aggFunction = mockFunnelAggFunction();
   }
 
@@ -89,7 +92,7 @@ public class BroadcastExchangeTest {
   // getAggFunctions() is deprecated, but the copy must preserve it for downstream serialization, so assert on it
   @SuppressWarnings("deprecation")
   @Test
-  public void shouldCopyBlocksWithObjectColumnsForAllLocalDestinationsButOne() {
+  public void shouldCopyBlocksWithObjectColumnsForAllByReferenceDestinationsButOne() {
     // Given:
     PriorityQueue<FunnelStepEvent> stepEvents = stepEvents(new FunnelStepEvent(1000L, 0),
         new FunnelStepEvent(2000L, 1));
@@ -124,16 +127,16 @@ public class BroadcastExchangeTest {
   }
 
   @Test
-  public void shouldSendOriginalBlockToRemoteDestinationsBeforeTheLocalOne() {
-    // Given: a remote destination between two local ones
-    SendingMailbox remoteMailbox = Mockito.mock(SendingMailbox.class);
+  public void shouldSendOriginalBlockToOtherDestinationsBeforeTheByReferenceOne() {
+    // Given: a destination that reads the block within send, between two that deliver it by reference
+    SendingMailbox remoteMailbox = remoteMailbox();
     RowHeapDataBlock block = funnelBlock(stepEvents(new FunnelStepEvent(1000L, 0)));
 
     // When:
     route(block, remoteMailbox, _mailbox1, _mailbox2);
 
-    // Then: the remote destination serializes the original, the first local destination receives the original by
-    // reference after all other reads of it, and the extra local destination receives a copy
+    // Then: the remote destination serializes the original, the first by-reference destination receives the original
+    // after all other reads of it, and the extra by-reference destination receives a copy
     assertSame(capturedBlock(remoteMailbox), block);
     assertSame(capturedBlock(_mailbox1), block);
     assertNotSame(capturedBlock(_mailbox2), block);
@@ -144,11 +147,51 @@ public class BroadcastExchangeTest {
   }
 
   @Test
+  public void shouldNotCopyBlocksForSpoolStagesWithoutByReferenceWorkers() {
+    // Given: two receiver stages of a multi-send (spool) node, each fanning out to workers on other servers
+    SendingMailbox remoteMailbox1 = remoteMailbox();
+    SendingMailbox remoteMailbox2 = remoteMailbox();
+    RowHeapDataBlock block = funnelBlock(stepEvents(new FunnelStepEvent(1000L, 0)));
+
+    // When:
+    route(block, spoolStageMailbox(remoteMailbox1), spoolStageMailbox(remoteMailbox2));
+
+    // Then: no copies are made, because every worker of both stages serializes the block
+    Mockito.verify(_aggFunction, Mockito.never()).serializeIntermediateResult(Mockito.any());
+    assertSame(capturedBlock(remoteMailbox1), block);
+    assertSame(capturedBlock(remoteMailbox2), block);
+  }
+
+  @Test
+  public void shouldCopyBlocksForSpoolStagesWithAByReferenceWorker() {
+    // Given: two receiver stages of a multi-send (spool) node. The second one has a worker on this server, next to
+    // a worker on another server
+    SendingMailbox remoteMailbox = remoteMailbox();
+    RowHeapDataBlock block = funnelBlock(stepEvents(new FunnelStepEvent(1000L, 0)));
+
+    // When:
+    route(block, spoolStageMailbox(_mailbox1), spoolStageMailbox(remoteMailbox, _mailbox2));
+
+    // Then: one copy is made, because a single by-reference worker makes the whole stage share the block
+    Mockito.verify(_aggFunction, Mockito.times(1)).serializeIntermediateResult(Mockito.any());
+    assertSame(capturedBlock(_mailbox1), block);
+    MseBlock.Data copiedBlock = capturedBlock(_mailbox2);
+    assertNotSame(copiedBlock, block);
+    // Within that stage the copy is shared again: only one of its workers keeps a reference to it
+    assertSame(capturedBlock(remoteMailbox), copiedBlock);
+    // The original block reaches its receiver last, after every other destination has read it
+    InOrder inOrder = Mockito.inOrder(remoteMailbox, _mailbox2, _mailbox1);
+    inOrder.verify(remoteMailbox).send(Mockito.any(MseBlock.Data.class));
+    inOrder.verify(_mailbox2).send(Mockito.any(MseBlock.Data.class));
+    inOrder.verify(_mailbox1).send(Mockito.any(MseBlock.Data.class));
+  }
+
+  @Test
   @SuppressWarnings("unchecked")
   public void shouldShareBlocksWithObjectColumnsWithRemoteOnlyDestinations() {
     // Given: only remote destinations, which serialize the block instead of delivering it by reference
-    SendingMailbox remoteMailbox1 = Mockito.mock(SendingMailbox.class);
-    SendingMailbox remoteMailbox2 = Mockito.mock(SendingMailbox.class);
+    SendingMailbox remoteMailbox1 = remoteMailbox();
+    SendingMailbox remoteMailbox2 = remoteMailbox();
     RowHeapDataBlock block = funnelBlock(stepEvents(new FunnelStepEvent(1000L, 0)));
 
     // When:
@@ -253,6 +296,20 @@ public class BroadcastExchangeTest {
   private static void route(MseBlock.Data block, SendingMailbox... destinations) {
     List<SendingMailbox> destinationList = List.of(destinations);
     new BroadcastExchange(destinationList, BlockSplitter.NO_OP).route(destinationList, block);
+  }
+
+  /// Wraps the mailboxes of one receiver stage the way a multi-send (spool) node does: an inner exchange per stage,
+  /// exposed to the outer exchange as a single sending mailbox.
+  private static SendingMailbox spoolStageMailbox(SendingMailbox... innerMailboxes) {
+    return new BroadcastExchange(List.of(innerMailboxes), BlockSplitter.NO_OP).asSendingMailbox("1");
+  }
+
+  /// A mailbox to a worker on another server. It reads the block within send instead of giving it to the receiver.
+  private static SendingMailbox remoteMailbox() {
+    SendingMailbox mailbox = Mockito.mock(SendingMailbox.class);
+    Mockito.when(mailbox.isLocal()).thenReturn(false);
+    Mockito.when(mailbox.deliversByReference()).thenReturn(false);
+    return mailbox;
   }
 
   private static MseBlock.Data capturedBlock(SendingMailbox mailbox) {


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

BroadcastExchange now decides block copying based on whether any destination mailbox delivers blocks by reference, avoiding unnecessary copies for spool stages with all\-remote workers\.

```mermaid
flowchart TD
  N0["BroadcastExchange#35;route #40;F6#41;"]:::stModified
  N1["BlockExchangeSendingMailbox#35;deliversByReference #40;F5#41;"]:::stModified
  N2["BlockExchange#35;#95;deliversByReference #40;F5#41;"]:::stAdded
  N3["SendingMailbox#35;deliversByReference #40;interface#41; #40;F3#41;"]:::stAdded
  N4["GrpcSendingMailbox#35;deliversByReference #40;F1#41;"]:::stAdded
  N5["InMemorySendingMailbox#35;deliversByReference #40;F2#41;"]:::stAdded
  N0 -->|"calls"| N1
  N1 -->|"returns"| N2
  N2 -->|"anyDeliversByReference calls"| N3
  N3 -->|"implemented by"| N4
  N3 -->|"implemented by"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox\.java — [before](https://github.com/apache/pinot/blob/0889d4c4f634eb3011d7574554047797186f2f92/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java) · [after](https://github.com/apache/pinot/blob/6ca1b2fece58b1319f78d565c9c2be363f4e380f/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java)
- F2: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox\.java — [before](https://github.com/apache/pinot/blob/0889d4c4f634eb3011d7574554047797186f2f92/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java) · [after](https://github.com/apache/pinot/blob/6ca1b2fece58b1319f78d565c9c2be363f4e380f/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java)
- F3: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/mailbox/SendingMailbox\.java — [before](https://github.com/apache/pinot/blob/0889d4c4f634eb3011d7574554047797186f2f92/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/SendingMailbox.java) · [after](https://github.com/apache/pinot/blob/6ca1b2fece58b1319f78d565c9c2be363f4e380f/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/SendingMailbox.java)
- F5: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchange\.java — [before](https://github.com/apache/pinot/blob/0889d4c4f634eb3011d7574554047797186f2f92/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchange.java) · [after](https://github.com/apache/pinot/blob/6ca1b2fece58b1319f78d565c9c2be363f4e380f/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchange.java)
- F6: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BroadcastExchange\.java — [before](https://github.com/apache/pinot/blob/0889d4c4f634eb3011d7574554047797186f2f92/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BroadcastExchange.java) · [after](https://github.com/apache/pinot/blob/6ca1b2fece58b1319f78d565c9c2be363f4e380f/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BroadcastExchange.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjA4ODlkNGM0ZjYzNGViMzAxMWQ3NTc0NTU0MDQ3Nzk3MTg2ZjJmOTIiLCJjb250ZXh0X2hhc2giOiI3OWEwMTkzMzcyODRiNTYwMzM4YTI3MGQyMGIxYjRiZDdlZThhN2I5NjVlZGExOGUxMzU3Zjc2ZWI2OGQ2NjZlIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTI1OTkwLCJoZWFkX3NoYSI6IjZjYTFiMmZlY2U1OGIxMzE5Zjc4ZDU2NWM5YzJiZTM2M2Y0ZTM4MGYiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIwODg5ZDRjNGY2MzRlYjMwMTFkNzU3NDU1NDA0Nzc5NzE4NmYyZjkyIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature a9e16efb1fbbea5d3c4b98290c8ca554f4f4676f62637328512352c5d939a91a -->
<!-- pinot-pr-flow:end -->

Fixes #19427. Follow-up to #19353.

## Problem

#19353 made `BroadcastExchange` copy blocks that carry aggregation intermediate results, because a destination can hand an on-heap block to a receiver by reference. It skips the copy for destinations that are not local, because those serialize the block within `send`.

That skip never applied to spools, which are the case #19353 was written for. A multi-send (spool) node wraps each receiver stage's inner exchange as a `BlockExchange.BlockExchangeSendingMailbox`, and `isLocal()` on that wrapper returns `true` unconditionally. Every outer destination of a spool is such a wrapper, so a receiver stage with no worker on the sending server still got a copy. The inner exchange then serialized that copy immediately, on the same thread, and no receiver ever mutated it. Each wasted copy costs one serialization plus one deserialization of every non-null `OBJECT` cell.

The cause is that `isLocal()` answered two different questions:

- `BlockExchange#sendBlock` asks "can I pass the block whole, without splitting it?"
- `BroadcastExchange#route` asks "can a receiver keep a reference to this block?"

The two answers differ for `BlockExchangeSendingMailbox`. Only the conservative direction kept the code correct.

## Fix

Add `SendingMailbox#deliversByReference()`, and use it in `BroadcastExchange#route`:

- `InMemorySendingMailbox` returns `true`.
- `GrpcSendingMailbox` returns `false`.
- `BlockExchangeSendingMailbox` returns `true` if any mailbox of its inner exchange returns `true`.

The answer of a mailbox never changes, so each exchange computes it once, when it is created.

The delegation is an OR over the inner mailboxes. An inner `HashExchange` builds a new block for each destination, but those blocks hold the same cell objects, so one by-reference worker in a receiver stage is enough to require a copy.

`isLocal()` now only means what `sendBlock` needs. This PR also moves the contract that `route` depends on — a mailbox that does not deliver by reference must finish reading the block before `send` returns — from `GrpcSendingMailbox` to `SendingMailbox#send`, where implementers can see it.

## Testing

`BroadcastExchangeTest` gets two spool cases: receiver stages whose workers are all remote (no copies), and a receiver stage with one worker on this server next to one on another server (one copy, shared within that stage). The first fails without this change. `BlockExchangeTest` covers the delegation directly.

The new fast path is covered by unit tests only. It fires when a receiver stage has no worker on the sending server. `WindowFunnelTest` and `SpoolIntegrationTest` run 2 servers, where every stage normally has a worker on both, so their spool wrappers still report `deliversByReference() == true` and still copy. Those suites show that this change causes no regression. They do not show that the fast path fires, and they stay green if it stops firing.

## Out of scope

The same wrapper also reports `isLocal() == true` to `BlockExchange#sendBlock`, while the inner exchanges get `BlockSplitter.NO_OP`, so multi-send blocks to remote receivers are never split against `MAX_MAILBOX_CONTENT_SIZE_BYTES`. That defect is tracked separately in #19427.

