### PR TITLE
Star-tree offheap build: read dims from sort buffer instead of re-fetching from segment

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/BaseSingleTreeBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/BaseSingleTreeBuilder.java
@@ -48,6 +48,7 @@ import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair
 import org.apache.pinot.segment.spi.index.startree.AggregationSpec;
 import org.apache.pinot.segment.spi.index.startree.StarTreeNode;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2Constants;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -221,6 +222,25 @@ abstract class BaseSingleTreeBuilder implements SingleTreeBuilder {
   /// @return Segment record
   Record getSegmentRecord(int docId) {
     int[] dimensions = getSegmentRecordDimensions(docId);
+    Object[] metrics = new Object[_numMetrics];
+    for (int i = 0; i < _numMetrics; i++) {
+      // Ignore the column for COUNT aggregation function
+      if (_metricReaders[i] != null) {
+        metrics[i] = _metricReaders[i].getValue(docId);
+      }
+    }
+    return new Record(dimensions, metrics);
+  }
+
+  /// Same as {@link #getSegmentRecord(int)} but reads dims from `dimBuffer` (row-major, indexed by
+  /// `docId * _numDimensions * Integer.BYTES`) instead of re-fetching from the segment.
+  Record getSegmentRecordWithBufferDims(int docId, PinotDataBuffer dimBuffer) {
+    int[] dimensions = new int[_numDimensions];
+    long off = (long) docId * _numDimensions * Integer.BYTES;
+    for (int i = 0; i < _numDimensions; i++) {
+      dimensions[i] = dimBuffer.getInt(off);
+      off += Integer.BYTES;
+    }
     Object[] metrics = new Object[_numMetrics];
     for (int i = 0; i < _numMetrics; i++) {
       // Ignore the column for COUNT aggregation function

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
@@ -216,6 +216,7 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
     for (int i = 0; i < numDocs; i++) {
       sortedDocIds[i] = i;
     }
+    boolean bufferOwnershipTransferred = false;
     try {
       long offset = 0;
       for (int i = 0; i < numDocs; i++) {
@@ -225,12 +226,13 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
           offset += Integer.BYTES;
         }
       }
+      final PinotDataBuffer segmentRecordBuffer = dataBuffer;
       it.unimi.dsi.fastutil.Arrays.quickSort(0, numDocs, (i1, i2) -> {
         long offset1 = (long) sortedDocIds[i1] * _numDimensions * Integer.BYTES;
         long offset2 = (long) sortedDocIds[i2] * _numDimensions * Integer.BYTES;
         for (int i = 0; i < _numDimensions; i++) {
-          int dimension1 = dataBuffer.getInt(offset1 + (long) i * Integer.BYTES);
-          int dimension2 = dataBuffer.getInt(offset2 + (long) i * Integer.BYTES);
+          int dimension1 = segmentRecordBuffer.getInt(offset1 + (long) i * Integer.BYTES);
+          int dimension2 = segmentRecordBuffer.getInt(offset2 + (long) i * Integer.BYTES);
           if (dimension1 != dimension2) {
             return dimension1 - dimension2;
           }
@@ -241,40 +243,60 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
         sortedDocIds[i1] = sortedDocIds[i2];
         sortedDocIds[i2] = temp;
       });
+
+      // Reading dims from the buffer (already filled sequentially) instead of re-fetching from the
+      // segment avoids random-order page decodes on the aggregation walk. Ownership transfers to
+      // the iterator, which closes the buffer on completion.
+      bufferOwnershipTransferred = true;
+      return new Iterator<Record>() {
+        boolean _hasNext = true;
+        Record _currentRecord = getSegmentRecordWithBufferDims(sortedDocIds[0], segmentRecordBuffer);
+        int _docId = 1;
+
+        @Override
+        public boolean hasNext() {
+          return _hasNext;
+        }
+
+        @Override
+        public Record next() {
+          Record next = mergeSegmentRecord(null, _currentRecord);
+          while (_docId < numDocs) {
+            Record record = getSegmentRecordWithBufferDims(sortedDocIds[_docId++], segmentRecordBuffer);
+            if (!Arrays.equals(record._dimensions, next._dimensions)) {
+              _currentRecord = record;
+              return next;
+            } else {
+              next = mergeSegmentRecord(next, record);
+            }
+          }
+          _hasNext = false;
+          closeSegmentRecordBuffer(segmentRecordBuffer);
+          return next;
+        }
+      };
     } finally {
-      dataBuffer.close();
-      if (_segmentRecordFile.exists()) {
-        FileUtils.forceDelete(_segmentRecordFile);
+      // Only close here if the iterator did not take ownership (i.e. exception before the return).
+      if (!bufferOwnershipTransferred) {
+        closeSegmentRecordBuffer(dataBuffer);
       }
     }
+  }
 
-    // Create an iterator for aggregated records
-    return new Iterator<Record>() {
-      boolean _hasNext = true;
-      Record _currentRecord = getSegmentRecord(sortedDocIds[0]);
-      int _docId = 1;
-
-      @Override
-      public boolean hasNext() {
-        return _hasNext;
+  // Best-effort close + delete of the segment-record file; matches the previous finally-block behavior.
+  private void closeSegmentRecordBuffer(PinotDataBuffer buffer) {
+    try {
+      buffer.close();
+    } catch (IOException ignored) {
+      // best-effort; buffer would be reclaimed by JVM shutdown at worst
+    }
+    if (_segmentRecordFile.exists()) {
+      try {
+        FileUtils.forceDelete(_segmentRecordFile);
+      } catch (IOException ignored) {
+        // best-effort
       }
-
-      @Override
-      public Record next() {
-        Record next = mergeSegmentRecord(null, _currentRecord);
-        while (_docId < numDocs) {
-          Record record = getSegmentRecord(sortedDocIds[_docId++]);
-          if (!Arrays.equals(record._dimensions, next._dimensions)) {
-            _currentRecord = record;
-            return next;
-          } else {
-            next = mergeSegmentRecord(next, record);
-          }
-        }
-        _hasNext = false;
-        return next;
-      }
-    };
+    }
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
@@ -381,22 +381,12 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
 
   @Override
   public void close() {
-    safeSuperClose();
-    releaseSegmentRecordBuffer();
-    releaseStarTreeRecordBuffer();
-    releaseStarTreeRecordOutputStream();
-    releaseStarTreeRecordFile();
-  }
-
-  private void safeSuperClose() {
     try {
       super.close();
     } catch (Exception e) {
       LOGGER.warn("super.close() failed", e);
     }
-  }
-
-  private void releaseStarTreeRecordBuffer() {
+    releaseSegmentRecordBuffer();
     if (_starTreeRecordBuffer != null) {
       try {
         _starTreeRecordBuffer.close();
@@ -405,17 +395,11 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
       }
       _starTreeRecordBuffer = null;
     }
-  }
-
-  private void releaseStarTreeRecordOutputStream() {
     try {
       _starTreeRecordOutputStream.close();
     } catch (IOException e) {
       LOGGER.warn("Failed to close star-tree record output stream", e);
     }
-  }
-
-  private void releaseStarTreeRecordFile() {
     if (_starTreeRecordFile.exists()) {
       try {
         FileUtils.forceDelete(_starTreeRecordFile);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
@@ -35,10 +35,13 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2Constants;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /// The `OffHeapSingleTreeBuilder` class is the single star-tree builder that uses off-heap memory.
 public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
+  private static final Logger LOGGER = LoggerFactory.getLogger(OffHeapSingleTreeBuilder.class);
   private static final String SEGMENT_RECORD_FILE_NAME = "segment.record";
   private static final String STAR_TREE_RECORD_FILE_NAME = "star-tree.record";
   // If the temporary buffer needed is larger than 500M, use MMAP, otherwise use DIRECT
@@ -49,6 +52,7 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
   private final BufferedOutputStream _starTreeRecordOutputStream;
   private final RecordOffsets _starTreeRecordOffsets;
 
+  private PinotDataBuffer _segmentRecordBuffer;
   private PinotDataBuffer _starTreeRecordBuffer;
   private int _numReadableStarTreeRecords;
 
@@ -203,36 +207,33 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
   Iterator<Record> sortAndAggregateSegmentRecords(int numDocs)
       throws IOException {
     // Write all dimensions for segment records into the buffer, and sort all records using an int array
-    PinotDataBuffer dataBuffer;
     long bufferSize = (long) numDocs * _numDimensions * Integer.BYTES;
     if (bufferSize > MMAP_SIZE_THRESHOLD) {
-      dataBuffer = PinotDataBuffer.mapFile(_segmentRecordFile, false, 0, bufferSize, PinotDataBuffer.NATIVE_ORDER,
-          "OffHeapSingleTreeBuilder: segment record buffer");
+      _segmentRecordBuffer = PinotDataBuffer.mapFile(_segmentRecordFile, false, 0, bufferSize,
+          PinotDataBuffer.NATIVE_ORDER, "OffHeapSingleTreeBuilder: segment record buffer");
     } else {
-      dataBuffer = PinotDataBuffer.allocateDirect(bufferSize, PinotDataBuffer.NATIVE_ORDER,
+      _segmentRecordBuffer = PinotDataBuffer.allocateDirect(bufferSize, PinotDataBuffer.NATIVE_ORDER,
           "OffHeapSingleTreeBuilder: segment record buffer");
     }
     int[] sortedDocIds = new int[numDocs];
     for (int i = 0; i < numDocs; i++) {
       sortedDocIds[i] = i;
     }
-    boolean bufferOwnershipTransferred = false;
     try {
       long offset = 0;
       for (int i = 0; i < numDocs; i++) {
         int[] dimensions = getSegmentRecordDimensions(i);
         for (int j = 0; j < _numDimensions; j++) {
-          dataBuffer.putInt(offset, dimensions[j]);
+          _segmentRecordBuffer.putInt(offset, dimensions[j]);
           offset += Integer.BYTES;
         }
       }
-      final PinotDataBuffer segmentRecordBuffer = dataBuffer;
       it.unimi.dsi.fastutil.Arrays.quickSort(0, numDocs, (i1, i2) -> {
         long offset1 = (long) sortedDocIds[i1] * _numDimensions * Integer.BYTES;
         long offset2 = (long) sortedDocIds[i2] * _numDimensions * Integer.BYTES;
         for (int i = 0; i < _numDimensions; i++) {
-          int dimension1 = segmentRecordBuffer.getInt(offset1 + (long) i * Integer.BYTES);
-          int dimension2 = segmentRecordBuffer.getInt(offset2 + (long) i * Integer.BYTES);
+          int dimension1 = _segmentRecordBuffer.getInt(offset1 + (long) i * Integer.BYTES);
+          int dimension2 = _segmentRecordBuffer.getInt(offset2 + (long) i * Integer.BYTES);
           if (dimension1 != dimension2) {
             return dimension1 - dimension2;
           }
@@ -244,13 +245,14 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
         sortedDocIds[i2] = temp;
       });
 
-      // Reading dims from the buffer (already filled sequentially) instead of re-fetching from the
-      // segment avoids random-order page decodes on the aggregation walk. Ownership transfers to
-      // the iterator, which closes the buffer on completion.
-      bufferOwnershipTransferred = true;
+      // Iterator reads dims from `_segmentRecordBuffer` (populated sequentially above) instead of
+      // re-fetching them from the segment forward index in the sorted (random-with-respect-to-layout)
+      // order. The buffer is a field, guaranteed to be released by close() via the try-with-resources
+      // on the builder in MultipleTreesBuilder — the terminal next() below is an early-release
+      // optimization; releaseSegmentRecordBuffer() is idempotent, so double-release is safe.
       return new Iterator<Record>() {
         boolean _hasNext = true;
-        Record _currentRecord = getSegmentRecordWithBufferDims(sortedDocIds[0], segmentRecordBuffer);
+        Record _currentRecord = getSegmentRecordWithBufferDims(sortedDocIds[0], _segmentRecordBuffer);
         int _docId = 1;
 
         @Override
@@ -262,7 +264,7 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
         public Record next() {
           Record next = mergeSegmentRecord(null, _currentRecord);
           while (_docId < numDocs) {
-            Record record = getSegmentRecordWithBufferDims(sortedDocIds[_docId++], segmentRecordBuffer);
+            Record record = getSegmentRecordWithBufferDims(sortedDocIds[_docId++], _segmentRecordBuffer);
             if (!Arrays.equals(record._dimensions, next._dimensions)) {
               _currentRecord = record;
               return next;
@@ -271,30 +273,36 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
             }
           }
           _hasNext = false;
-          closeSegmentRecordBuffer(segmentRecordBuffer);
+          releaseSegmentRecordBuffer();
           return next;
         }
       };
-    } finally {
-      // Only close here if the iterator did not take ownership (i.e. exception before the return).
-      if (!bufferOwnershipTransferred) {
-        closeSegmentRecordBuffer(dataBuffer);
-      }
+    } catch (Throwable t) {
+      // Fill / sort / iterator construction failed: nobody will drain the iterator, so release
+      // the buffer here. close() will find `_segmentRecordBuffer == null` and skip re-releasing.
+      releaseSegmentRecordBuffer();
+      throw t;
     }
   }
 
-  // Best-effort close + delete of the segment-record file; matches the previous finally-block behavior.
-  private void closeSegmentRecordBuffer(PinotDataBuffer buffer) {
-    try {
-      buffer.close();
-    } catch (IOException ignored) {
-      // best-effort; buffer would be reclaimed by JVM shutdown at worst
+  // Idempotent: safe to call multiple times from any exit path (iterator drain, exception during
+  // sortAndAggregate, or close() via try-with-resources). Null-checks the field and sets it to null
+  // after release, so a second call is a no-op. Best-effort — close() failures are logged, not
+  // thrown, so a successful build isn't masked by a cleanup error on the return path.
+  private void releaseSegmentRecordBuffer() {
+    if (_segmentRecordBuffer != null) {
+      try {
+        _segmentRecordBuffer.close();
+      } catch (IOException e) {
+        LOGGER.warn("Failed to close segment record buffer", e);
+      }
+      _segmentRecordBuffer = null;
     }
     if (_segmentRecordFile.exists()) {
       try {
         FileUtils.forceDelete(_segmentRecordFile);
-      } catch (IOException ignored) {
-        // best-effort
+      } catch (IOException e) {
+        LOGGER.warn("Failed to delete segment record file: {}", _segmentRecordFile, e);
       }
     }
   }
@@ -375,6 +383,7 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
   public void close()
       throws IOException {
     super.close();
+    releaseSegmentRecordBuffer();
     if (_starTreeRecordBuffer != null) {
       _starTreeRecordBuffer.close();
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
@@ -381,6 +381,7 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
 
   @Override
   public void close() {
+    // Order matters: release the mmap view before closing the writer and deleting the backing file.
     try {
       super.close();
     } catch (Exception e) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
@@ -380,34 +380,56 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
   }
 
   @Override
-  public void close() {
+  public void close()
+      throws IOException {
     // Order matters: release the mmap view before closing the writer and deleting the backing file.
+    // Each step runs regardless of prior failures; the first exception is thrown, subsequent ones
+    // attached as suppressed. Mirrors BaseSingleTreeBuilder#createForwardIndexes.
+    Throwable primary = null;
     try {
       super.close();
-    } catch (Exception e) {
-      LOGGER.warn("super.close() failed", e);
+    } catch (Throwable t) {
+      primary = t;
     }
-    releaseSegmentRecordBuffer();
-    if (_starTreeRecordBuffer != null) {
-      try {
+    try {
+      releaseSegmentRecordBuffer();
+    } catch (Throwable t) {
+      primary = addSuppressed(primary, t);
+    }
+    try {
+      if (_starTreeRecordBuffer != null) {
         _starTreeRecordBuffer.close();
-      } catch (IOException e) {
-        LOGGER.warn("Failed to close star-tree record buffer", e);
+        _starTreeRecordBuffer = null;
       }
-      _starTreeRecordBuffer = null;
+    } catch (Throwable t) {
+      primary = addSuppressed(primary, t);
     }
     try {
       _starTreeRecordOutputStream.close();
-    } catch (IOException e) {
-      LOGGER.warn("Failed to close star-tree record output stream", e);
+    } catch (Throwable t) {
+      primary = addSuppressed(primary, t);
     }
-    if (_starTreeRecordFile.exists()) {
-      try {
+    try {
+      if (_starTreeRecordFile.exists()) {
         FileUtils.forceDelete(_starTreeRecordFile);
-      } catch (IOException e) {
-        LOGGER.warn("Failed to delete star-tree record file: {}", _starTreeRecordFile, e);
       }
+    } catch (Throwable t) {
+      primary = addSuppressed(primary, t);
     }
+    if (primary instanceof IOException) {
+      throw (IOException) primary;
+    }
+    if (primary != null) {
+      throw new IOException(primary);
+    }
+  }
+
+  private static Throwable addSuppressed(Throwable primary, Throwable next) {
+    if (primary == null) {
+      return next;
+    }
+    primary.addSuppressed(next);
+    return primary;
   }
 
   /// Per-record offsets within the star-tree record file. [#addRecord] is invoked once per appended record with the

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
@@ -382,54 +382,16 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
   @Override
   public void close()
       throws IOException {
-    // Order matters: release the mmap view before closing the writer and deleting the backing file.
-    // Each step runs regardless of prior failures; the first exception is thrown, subsequent ones
-    // attached as suppressed. Mirrors BaseSingleTreeBuilder#createForwardIndexes.
-    Throwable primary = null;
     try {
       super.close();
-    } catch (Throwable t) {
-      primary = t;
-    }
-    try {
+    } finally {
       releaseSegmentRecordBuffer();
-    } catch (Throwable t) {
-      primary = addSuppressed(primary, t);
     }
-    try {
-      if (_starTreeRecordBuffer != null) {
-        _starTreeRecordBuffer.close();
-        _starTreeRecordBuffer = null;
-      }
-    } catch (Throwable t) {
-      primary = addSuppressed(primary, t);
+    if (_starTreeRecordBuffer != null) {
+      _starTreeRecordBuffer.close();
     }
-    try {
-      _starTreeRecordOutputStream.close();
-    } catch (Throwable t) {
-      primary = addSuppressed(primary, t);
-    }
-    try {
-      if (_starTreeRecordFile.exists()) {
-        FileUtils.forceDelete(_starTreeRecordFile);
-      }
-    } catch (Throwable t) {
-      primary = addSuppressed(primary, t);
-    }
-    if (primary instanceof IOException) {
-      throw (IOException) primary;
-    }
-    if (primary != null) {
-      throw new IOException(primary);
-    }
-  }
-
-  private static Throwable addSuppressed(Throwable primary, Throwable next) {
-    if (primary == null) {
-      return next;
-    }
-    primary.addSuppressed(next);
-    return primary;
+    _starTreeRecordOutputStream.close();
+    FileUtils.forceDelete(_starTreeRecordFile);
   }
 
   /// Per-record offsets within the star-tree record file. [#addRecord] is invoked once per appended record with the

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
@@ -380,15 +380,49 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
   }
 
   @Override
-  public void close()
-      throws IOException {
-    super.close();
+  public void close() {
+    safeSuperClose();
     releaseSegmentRecordBuffer();
-    if (_starTreeRecordBuffer != null) {
-      _starTreeRecordBuffer.close();
+    releaseStarTreeRecordBuffer();
+    releaseStarTreeRecordOutputStream();
+    releaseStarTreeRecordFile();
+  }
+
+  private void safeSuperClose() {
+    try {
+      super.close();
+    } catch (Exception e) {
+      LOGGER.warn("super.close() failed", e);
     }
-    _starTreeRecordOutputStream.close();
-    FileUtils.forceDelete(_starTreeRecordFile);
+  }
+
+  private void releaseStarTreeRecordBuffer() {
+    if (_starTreeRecordBuffer != null) {
+      try {
+        _starTreeRecordBuffer.close();
+      } catch (IOException e) {
+        LOGGER.warn("Failed to close star-tree record buffer", e);
+      }
+      _starTreeRecordBuffer = null;
+    }
+  }
+
+  private void releaseStarTreeRecordOutputStream() {
+    try {
+      _starTreeRecordOutputStream.close();
+    } catch (IOException e) {
+      LOGGER.warn("Failed to close star-tree record output stream", e);
+    }
+  }
+
+  private void releaseStarTreeRecordFile() {
+    if (_starTreeRecordFile.exists()) {
+      try {
+        FileUtils.forceDelete(_starTreeRecordFile);
+      } catch (IOException e) {
+        LOGGER.warn("Failed to delete star-tree record file: {}", _starTreeRecordFile, e);
+      }
+    }
   }
 
   /// Per-record offsets within the star-tree record file. [#addRecord] is invoked once per appended record with the

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilderTest.java
@@ -21,6 +21,8 @@ package org.apache.pinot.segment.local.startree.v2.builder;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
@@ -31,6 +33,10 @@ import org.apache.pinot.segment.local.startree.v2.builder.OffHeapSingleTreeBuild
 import org.apache.pinot.segment.local.startree.v2.builder.OffHeapSingleTreeBuilder.VariableSizeRecordOffsets;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -133,6 +139,76 @@ public class OffHeapSingleTreeBuilderTest {
     File segmentRecordFile = findSegmentRecordFile(segmentDir);
     assertFalse(segmentRecordFile != null && segmentRecordFile.exists(),
         "segment.record file should not exist when build() was never called: " + segmentRecordFile);
+  }
+
+  /// Builds the same segment twice — once with OFF_HEAP and once with ON_HEAP — then compares the
+  /// resulting star-trees by grouping star-tree records by dim tuple and summing the aggregate
+  /// column. Directly regressions-tests dim-read parity: if the buffer read returned wrong bytes,
+  /// OFF_HEAP would aggregate metrics under the wrong dim tuples and the maps would diverge.
+  @Test
+  public void testOffHeapProducesSameStarTreeAsOnHeap()
+      throws Exception {
+    buildTestSegment();
+    File sourceSegmentDir = INDEX_DIR.listFiles()[0];
+    List<StarTreeV2BuilderConfig> builderConfigs = createBuilderConfigs();
+
+    File offHeapDir = new File(TEMP_DIR, "offHeapCopy");
+    File onHeapDir = new File(TEMP_DIR, "onHeapCopy");
+    FileUtils.copyDirectory(sourceSegmentDir, offHeapDir);
+    FileUtils.copyDirectory(sourceSegmentDir, onHeapDir);
+
+    try (MultipleTreesBuilder builder = new MultipleTreesBuilder(builderConfigs, offHeapDir,
+        MultipleTreesBuilder.BuildMode.OFF_HEAP)) {
+      builder.build();
+    }
+    try (MultipleTreesBuilder builder = new MultipleTreesBuilder(builderConfigs, onHeapDir,
+        MultipleTreesBuilder.BuildMode.ON_HEAP)) {
+      builder.build();
+    }
+
+    Map<String, Long> offHeapByDim = readStarTreeAggregatedByDim(offHeapDir);
+    Map<String, Long> onHeapByDim = readStarTreeAggregatedByDim(onHeapDir);
+    assertEquals(offHeapByDim, onHeapByDim,
+        "OFF_HEAP and ON_HEAP star-trees disagree on aggregate-by-dim: "
+            + "off=" + offHeapByDim + ", on=" + onHeapByDim);
+  }
+
+  /// Iterates every star-tree record, resolves dim dict-ids to values, and returns a
+  /// `(stringCol|intCol) -> sum(longCol)` map. Star nodes (dim value = STAR) fold into their own
+  /// bucket, so the map is a canonical view of the tree independent of internal doc order.
+  private Map<String, Long> readStarTreeAggregatedByDim(File segmentDir)
+      throws Exception {
+    ImmutableSegment segment = ImmutableSegmentLoader.load(segmentDir, ReadMode.mmap);
+    try {
+      StarTreeV2 tree = segment.getStarTrees().get(0);
+      int numDocs = tree.getMetadata().getNumDocs();
+
+      ForwardIndexReader<ForwardIndexReaderContext> stringReader =
+          (ForwardIndexReader<ForwardIndexReaderContext>) tree.getDataSource("stringCol").getForwardIndex();
+      Dictionary stringDict = tree.getDataSource("stringCol").getDictionary();
+      ForwardIndexReader<ForwardIndexReaderContext> intReader =
+          (ForwardIndexReader<ForwardIndexReaderContext>) tree.getDataSource("intCol").getForwardIndex();
+      Dictionary intDict = tree.getDataSource("intCol").getDictionary();
+      // Aggregate columns are keyed by AggregationFunctionColumnPair.toColumnName() ("sum__longCol").
+      ForwardIndexReader<ForwardIndexReaderContext> aggReader =
+          (ForwardIndexReader<ForwardIndexReaderContext>) tree.getDataSource("sum__longCol").getForwardIndex();
+
+      Map<String, Long> byDim = new TreeMap<>();
+      try (ForwardIndexReaderContext stringCtx = stringReader.createContext();
+          ForwardIndexReaderContext intCtx = intReader.createContext();
+          ForwardIndexReaderContext aggCtx = aggReader.createContext()) {
+        for (int docId = 0; docId < numDocs; docId++) {
+          int stringDictId = stringReader.getDictId(docId, stringCtx);
+          int intDictId = intReader.getDictId(docId, intCtx);
+          String stringVal = stringDictId == -1 ? "*" : stringDict.getStringValue(stringDictId);
+          String intVal = intDictId == -1 ? "*" : String.valueOf(intDict.getIntValue(intDictId));
+          byDim.merge(stringVal + "|" + intVal, aggReader.getLong(docId, aggCtx), Long::sum);
+        }
+      }
+      return byDim;
+    } finally {
+      segment.destroy();
+    }
   }
 
   private void buildTestSegment()

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilderTest.java
@@ -18,15 +18,52 @@
  */
 package org.apache.pinot.segment.local.startree.v2.builder;
 
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.local.startree.StarTreeBuilderUtils;
 import org.apache.pinot.segment.local.startree.v2.builder.OffHeapSingleTreeBuilder.FixedSizeRecordOffsets;
 import org.apache.pinot.segment.local.startree.v2.builder.OffHeapSingleTreeBuilder.RecordOffsets;
 import org.apache.pinot.segment.local.startree.v2.builder.OffHeapSingleTreeBuilder.VariableSizeRecordOffsets;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 
 
 public class OffHeapSingleTreeBuilderTest {
+
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "OffHeapSingleTreeBuilderTest");
+  private static final File INDEX_DIR = new File(TEMP_DIR, "testSegment");
+  private static final String SEGMENT_RECORD_FILE_NAME = "segment.record";
+
+  @BeforeMethod
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteQuietly(TEMP_DIR);
+    FileUtils.forceMkdir(TEMP_DIR);
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    FileUtils.deleteQuietly(TEMP_DIR);
+  }
 
   @Test
   public void testFixedSizeRecordOffsets() {
@@ -52,5 +89,138 @@ public class OffHeapSingleTreeBuilderTest {
     assertEquals(offsets.getStartOffset(2), Integer.MAX_VALUE);
     assertEquals(offsets.getStartOffset(3), Integer.MAX_VALUE + 456L);
     assertEquals(offsets.getEndOffset(), Integer.MAX_VALUE + 456L + 789L);
+  }
+
+  /// Builds a star-tree with the off-heap builder and asserts the intermediate segment record file
+  /// is cleaned up after build. Exercises the full sortAndAggregateSegmentRecords → iterator → close
+  /// lifecycle, including buffer allocation, sequential fill in Sub-phase A, sort in Sub-phase B,
+  /// and dim-from-buffer reads in Sub-phase C.
+  @Test
+  public void testBuildCleansUpSegmentRecordFile()
+      throws Exception {
+    buildTestSegment();
+
+    List<StarTreeV2BuilderConfig> builderConfigs = createBuilderConfigs();
+    File segmentDir = INDEX_DIR.listFiles()[0];
+
+    try (MultipleTreesBuilder builder = new MultipleTreesBuilder(builderConfigs, segmentDir,
+        MultipleTreesBuilder.BuildMode.OFF_HEAP)) {
+      builder.build();
+    }
+
+    // OffHeapSingleTreeBuilder writes an intermediate segment.record file during Sub-phase A/B/C.
+    // The dim-buffer optimization keeps that file alive through iterator exhaustion; close() must
+    // release the buffer and delete the file.
+    File segmentRecordFile = findSegmentRecordFile(segmentDir);
+    assertFalse(segmentRecordFile != null && segmentRecordFile.exists(),
+        "segment.record file should be deleted after build: " + segmentRecordFile);
+  }
+
+  /// close() before build() must not throw and must leave no leftover segment record file.
+  @Test
+  public void testCloseWithoutBuildDoesNotThrow()
+      throws Exception {
+    buildTestSegment();
+
+    List<StarTreeV2BuilderConfig> builderConfigs = createBuilderConfigs();
+    File segmentDir = INDEX_DIR.listFiles()[0];
+
+    // Construct and immediately close — no build().
+    MultipleTreesBuilder builder = new MultipleTreesBuilder(builderConfigs, segmentDir,
+        MultipleTreesBuilder.BuildMode.OFF_HEAP);
+    builder.close();
+
+    File segmentRecordFile = findSegmentRecordFile(segmentDir);
+    assertFalse(segmentRecordFile != null && segmentRecordFile.exists(),
+        "segment.record file should not exist when build() was never called: " + segmentRecordFile);
+  }
+
+  private void buildTestSegment()
+      throws Exception {
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("stringCol", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("intCol", FieldSpec.DataType.INT)
+        .addMetric("longCol", FieldSpec.DataType.LONG)
+        .build();
+
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("testTable")
+        .build();
+
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(TEMP_DIR.getAbsolutePath());
+    config.setSegmentName("testSegment");
+
+    // Produce a few rows with distinct dim tuples so Sub-phase C's sortedDocIds order genuinely
+    // differs from segment docId order — exercises the "reads dims from buffer under sorted docId
+    // access" path.
+    List<GenericRow> rows = Arrays.asList(
+        createRow("A", 1, 10L),
+        createRow("B", 2, 20L),
+        createRow("A", 2, 30L),
+        createRow("B", 1, 40L),
+        createRow("C", 3, 50L)
+    );
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(config, new GenericRowRecordReader(rows));
+    driver.build();
+  }
+
+  private GenericRow createRow(String stringValue, int intValue, long longValue) {
+    GenericRow row = new GenericRow();
+    row.putValue("stringCol", stringValue);
+    row.putValue("intCol", intValue);
+    row.putValue("longCol", longValue);
+    return row;
+  }
+
+  private List<StarTreeV2BuilderConfig> createBuilderConfigs()
+      throws Exception {
+    StarTreeIndexConfig starTreeConfig = new StarTreeIndexConfig(
+        Arrays.asList("stringCol", "intCol"),
+        null,
+        Arrays.asList("SUM__longCol"),
+        null,
+        1000);
+
+    File segmentDir = INDEX_DIR.listFiles()[0];
+    ImmutableSegment segment = ImmutableSegmentLoader.load(segmentDir, ReadMode.mmap);
+    try {
+      return StarTreeBuilderUtils.generateBuilderConfigs(
+          Arrays.asList(starTreeConfig),
+          false,
+          segment.getSegmentMetadata());
+    } finally {
+      segment.destroy();
+    }
+  }
+
+  private File findSegmentRecordFile(File segmentDir) {
+    // segment.record lives under the star-tree output directory created by MultipleTreesBuilder;
+    // walk the segment dir tree to locate any leftover.
+    return findByName(segmentDir, SEGMENT_RECORD_FILE_NAME);
+  }
+
+  private File findByName(File dir, String name) {
+    if (!dir.isDirectory()) {
+      return null;
+    }
+    File[] children = dir.listFiles();
+    if (children == null) {
+      return null;
+    }
+    for (File child : children) {
+      if (child.getName().equals(name)) {
+        return child;
+      }
+      if (child.isDirectory()) {
+        File found = findByName(child, name);
+        if (found != null) {
+          return found;
+        }
+      }
+    }
+    return null;
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilderTest.java
@@ -20,9 +20,11 @@ package org.apache.pinot.segment.local.startree.v2.builder;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
@@ -37,10 +39,11 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.ReadMode;
@@ -50,14 +53,13 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 
 public class OffHeapSingleTreeBuilderTest {
 
   private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "OffHeapSingleTreeBuilderTest");
   private static final File INDEX_DIR = new File(TEMP_DIR, "testSegment");
-  private static final String SEGMENT_RECORD_FILE_NAME = "segment.record";
 
   @BeforeMethod
   public void setUp()
@@ -97,71 +99,115 @@ public class OffHeapSingleTreeBuilderTest {
     assertEquals(offsets.getEndOffset(), Integer.MAX_VALUE + 456L + 789L);
   }
 
-  /// Builds a star-tree with the off-heap builder and asserts the intermediate segment record file
-  /// is cleaned up after build. Exercises the full sortAndAggregateSegmentRecords → iterator → close
-  /// lifecycle, including buffer allocation, sequential fill in Sub-phase A, sort in Sub-phase B,
-  /// and dim-from-buffer reads in Sub-phase C.
+  /// Drives `sortAndAggregateSegmentRecords` on a real segment and asserts the segment record
+  /// buffer allocated in Sub-phase A is released once the iterator is drained. Direct-buffer
+  /// count/usage must return to the pre-call baseline — proves `releaseSegmentRecordBuffer()`
+  /// runs on the terminal `next()`.
   @Test
-  public void testBuildCleansUpSegmentRecordFile()
+  public void testSegmentRecordBufferReleasedAfterIteratorDrain()
       throws Exception {
     buildTestSegment();
-
-    List<StarTreeV2BuilderConfig> builderConfigs = createBuilderConfigs();
     File segmentDir = INDEX_DIR.listFiles()[0];
+    ImmutableSegment segment = ImmutableSegmentLoader.load(segmentDir, ReadMode.mmap);
+    try {
+      List<StarTreeV2BuilderConfig> builderConfigs = createBuilderConfigs(segment);
+      File outputDir = new File(TEMP_DIR, "starTreeOutputDrain");
+      FileUtils.forceMkdir(outputDir);
 
-    try (MultipleTreesBuilder builder = new MultipleTreesBuilder(builderConfigs, segmentDir,
-        MultipleTreesBuilder.BuildMode.OFF_HEAP)) {
-      builder.build();
+      long baselineCount = PinotDataBuffer.getDirectBufferCount();
+      long baselineUsage = PinotDataBuffer.getDirectBufferUsage();
+
+      try (OffHeapSingleTreeBuilder builder = new OffHeapSingleTreeBuilder(builderConfigs.get(0), outputDir, segment,
+          new PropertiesConfiguration())) {
+        int numDocs = segment.getSegmentMetadata().getTotalDocs();
+        Iterator<?> iterator = builder.sortAndAggregateSegmentRecords(numDocs);
+        assertTrue(PinotDataBuffer.getDirectBufferCount() > baselineCount,
+            "Segment record buffer should be allocated during sortAndAggregateSegmentRecords");
+
+        while (iterator.hasNext()) {
+          iterator.next();
+        }
+
+        assertEquals(PinotDataBuffer.getDirectBufferCount(), baselineCount,
+            "Direct buffer count should return to baseline after iterator drain");
+        assertEquals(PinotDataBuffer.getDirectBufferUsage(), baselineUsage,
+            "Direct buffer usage should return to baseline after iterator drain");
+      }
+    } finally {
+      segment.destroy();
     }
-
-    // OffHeapSingleTreeBuilder writes an intermediate segment.record file during Sub-phase A/B/C.
-    // The dim-buffer optimization keeps that file alive through iterator exhaustion; close() must
-    // release the buffer and delete the file.
-    File segmentRecordFile = findSegmentRecordFile(segmentDir);
-    assertFalse(segmentRecordFile != null && segmentRecordFile.exists(),
-        "segment.record file should be deleted after build: " + segmentRecordFile);
   }
 
-  /// close() before build() must not throw and must leave no leftover segment record file.
+  /// Closes the builder without draining the iterator — `releaseSegmentRecordBuffer()` on the
+  /// close path must still release the buffer. Prior to the fix, `close()` did not release
+  /// `_segmentRecordBuffer`, so an operator abandoning a partial build would leak direct memory
+  /// until the JVM cleaner ran (unbounded).
   @Test
-  public void testCloseWithoutBuildDoesNotThrow()
+  public void testSegmentRecordBufferReleasedOnCloseWithoutDrain()
       throws Exception {
     buildTestSegment();
-
-    List<StarTreeV2BuilderConfig> builderConfigs = createBuilderConfigs();
     File segmentDir = INDEX_DIR.listFiles()[0];
+    ImmutableSegment segment = ImmutableSegmentLoader.load(segmentDir, ReadMode.mmap);
+    try {
+      List<StarTreeV2BuilderConfig> builderConfigs = createBuilderConfigs(segment);
+      File outputDir = new File(TEMP_DIR, "starTreeOutputAbandon");
+      FileUtils.forceMkdir(outputDir);
 
-    // Construct and immediately close — no build().
-    MultipleTreesBuilder builder = new MultipleTreesBuilder(builderConfigs, segmentDir,
-        MultipleTreesBuilder.BuildMode.OFF_HEAP);
-    builder.close();
+      long baselineCount = PinotDataBuffer.getDirectBufferCount();
+      long baselineUsage = PinotDataBuffer.getDirectBufferUsage();
 
-    File segmentRecordFile = findSegmentRecordFile(segmentDir);
-    assertFalse(segmentRecordFile != null && segmentRecordFile.exists(),
-        "segment.record file should not exist when build() was never called: " + segmentRecordFile);
+      OffHeapSingleTreeBuilder builder = new OffHeapSingleTreeBuilder(builderConfigs.get(0), outputDir, segment,
+          new PropertiesConfiguration());
+      try {
+        int numDocs = segment.getSegmentMetadata().getTotalDocs();
+        Iterator<?> iterator = builder.sortAndAggregateSegmentRecords(numDocs);
+        // Pull exactly one element; leave the iterator undrained.
+        iterator.next();
+        assertTrue(PinotDataBuffer.getDirectBufferCount() > baselineCount,
+            "Buffer should be allocated mid-iteration");
+      } finally {
+        builder.close();
+      }
+
+      assertEquals(PinotDataBuffer.getDirectBufferCount(), baselineCount,
+          "Direct buffer count should return to baseline after close() on undrained iterator");
+      assertEquals(PinotDataBuffer.getDirectBufferUsage(), baselineUsage,
+          "Direct buffer usage should return to baseline after close() on undrained iterator");
+    } finally {
+      segment.destroy();
+    }
   }
 
   /// Builds the same segment twice — once with OFF_HEAP and once with ON_HEAP — then compares the
   /// resulting star-trees by grouping star-tree records by dim tuple and summing the aggregate
-  /// column. Directly regressions-tests dim-read parity: if the buffer read returned wrong bytes,
+  /// column. Direct regression test for dim-read parity: if the buffer read returned wrong bytes,
   /// OFF_HEAP would aggregate metrics under the wrong dim tuples and the maps would diverge.
   @Test
   public void testOffHeapProducesSameStarTreeAsOnHeap()
       throws Exception {
     buildTestSegment();
     File sourceSegmentDir = INDEX_DIR.listFiles()[0];
-    List<StarTreeV2BuilderConfig> builderConfigs = createBuilderConfigs();
 
     File offHeapDir = new File(TEMP_DIR, "offHeapCopy");
     File onHeapDir = new File(TEMP_DIR, "onHeapCopy");
     FileUtils.copyDirectory(sourceSegmentDir, offHeapDir);
     FileUtils.copyDirectory(sourceSegmentDir, onHeapDir);
 
-    try (MultipleTreesBuilder builder = new MultipleTreesBuilder(builderConfigs, offHeapDir,
+    List<StarTreeV2BuilderConfig> offHeapBuilderConfigs;
+    List<StarTreeV2BuilderConfig> onHeapBuilderConfigs;
+    ImmutableSegment sourceSegment = ImmutableSegmentLoader.load(sourceSegmentDir, ReadMode.mmap);
+    try {
+      offHeapBuilderConfigs = createBuilderConfigs(sourceSegment);
+      onHeapBuilderConfigs = createBuilderConfigs(sourceSegment);
+    } finally {
+      sourceSegment.destroy();
+    }
+
+    try (MultipleTreesBuilder builder = new MultipleTreesBuilder(offHeapBuilderConfigs, offHeapDir,
         MultipleTreesBuilder.BuildMode.OFF_HEAP)) {
       builder.build();
     }
-    try (MultipleTreesBuilder builder = new MultipleTreesBuilder(builderConfigs, onHeapDir,
+    try (MultipleTreesBuilder builder = new MultipleTreesBuilder(onHeapBuilderConfigs, onHeapDir,
         MultipleTreesBuilder.BuildMode.ON_HEAP)) {
       builder.build();
     }
@@ -214,9 +260,9 @@ public class OffHeapSingleTreeBuilderTest {
   private void buildTestSegment()
       throws Exception {
     Schema schema = new Schema.SchemaBuilder()
-        .addSingleValueDimension("stringCol", FieldSpec.DataType.STRING)
-        .addSingleValueDimension("intCol", FieldSpec.DataType.INT)
-        .addMetric("longCol", FieldSpec.DataType.LONG)
+        .addSingleValueDimension("stringCol", DataType.STRING)
+        .addSingleValueDimension("intCol", DataType.INT)
+        .addMetric("longCol", DataType.LONG)
         .build();
 
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
@@ -251,7 +297,7 @@ public class OffHeapSingleTreeBuilderTest {
     return row;
   }
 
-  private List<StarTreeV2BuilderConfig> createBuilderConfigs()
+  private List<StarTreeV2BuilderConfig> createBuilderConfigs(ImmutableSegment segment)
       throws Exception {
     StarTreeIndexConfig starTreeConfig = new StarTreeIndexConfig(
         Arrays.asList("stringCol", "intCol"),
@@ -259,44 +305,9 @@ public class OffHeapSingleTreeBuilderTest {
         Arrays.asList("SUM__longCol"),
         null,
         1000);
-
-    File segmentDir = INDEX_DIR.listFiles()[0];
-    ImmutableSegment segment = ImmutableSegmentLoader.load(segmentDir, ReadMode.mmap);
-    try {
-      return StarTreeBuilderUtils.generateBuilderConfigs(
-          Arrays.asList(starTreeConfig),
-          false,
-          segment.getSegmentMetadata());
-    } finally {
-      segment.destroy();
-    }
-  }
-
-  private File findSegmentRecordFile(File segmentDir) {
-    // segment.record lives under the star-tree output directory created by MultipleTreesBuilder;
-    // walk the segment dir tree to locate any leftover.
-    return findByName(segmentDir, SEGMENT_RECORD_FILE_NAME);
-  }
-
-  private File findByName(File dir, String name) {
-    if (!dir.isDirectory()) {
-      return null;
-    }
-    File[] children = dir.listFiles();
-    if (children == null) {
-      return null;
-    }
-    for (File child : children) {
-      if (child.getName().equals(name)) {
-        return child;
-      }
-      if (child.isDirectory()) {
-        File found = findByName(child, name);
-        if (found != null) {
-          return found;
-        }
-      }
-    }
-    return null;
+    return StarTreeBuilderUtils.generateBuilderConfigs(
+        Arrays.asList(starTreeConfig),
+        false,
+        segment.getSegmentMetadata());
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilderTest.java
@@ -53,6 +53,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 
@@ -60,6 +61,7 @@ public class OffHeapSingleTreeBuilderTest {
 
   private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "OffHeapSingleTreeBuilderTest");
   private static final File INDEX_DIR = new File(TEMP_DIR, "testSegment");
+  private static final String SEGMENT_RECORD_BUFFER_DESCRIPTION = "OffHeapSingleTreeBuilder: segment record buffer";
 
   @BeforeMethod
   public void setUp()
@@ -100,9 +102,9 @@ public class OffHeapSingleTreeBuilderTest {
   }
 
   /// Drives `sortAndAggregateSegmentRecords` on a real segment and asserts the segment record
-  /// buffer allocated in Sub-phase A is released once the iterator is drained. Direct-buffer
-  /// count/usage must return to the pre-call baseline — proves `releaseSegmentRecordBuffer()`
-  /// runs on the terminal `next()`.
+  /// buffer allocated in Sub-phase A is released once the iterator is drained. Targets our
+  /// specific buffer by description via `PinotDataBuffer.getBufferInfo()` so the assertion is
+  /// invariant under any concurrent JVM-wide buffer traffic.
   @Test
   public void testSegmentRecordBufferReleasedAfterIteratorDrain()
       throws Exception {
@@ -113,26 +115,22 @@ public class OffHeapSingleTreeBuilderTest {
       List<StarTreeV2BuilderConfig> builderConfigs = createBuilderConfigs(segment);
       File outputDir = new File(TEMP_DIR, "starTreeOutputDrain");
       FileUtils.forceMkdir(outputDir);
-
-      long baselineCount = PinotDataBuffer.getDirectBufferCount();
-      long baselineUsage = PinotDataBuffer.getDirectBufferUsage();
+      assertFalse(isSegmentRecordBufferLive(), "No pre-existing segment record buffer");
 
       try (OffHeapSingleTreeBuilder builder = new OffHeapSingleTreeBuilder(builderConfigs.get(0), outputDir, segment,
           new PropertiesConfiguration())) {
         int numDocs = segment.getSegmentMetadata().getTotalDocs();
         Iterator<?> iterator = builder.sortAndAggregateSegmentRecords(numDocs);
-        assertTrue(PinotDataBuffer.getDirectBufferCount() > baselineCount,
-            "Segment record buffer should be allocated during sortAndAggregateSegmentRecords");
+        assertTrue(isSegmentRecordBufferLive(),
+            "Segment record buffer should be live after sortAndAggregateSegmentRecords");
 
         while (iterator.hasNext()) {
           iterator.next();
         }
 
-        assertEquals(PinotDataBuffer.getDirectBufferCount(), baselineCount,
-            "Direct buffer count should return to baseline after iterator drain");
-        assertEquals(PinotDataBuffer.getDirectBufferUsage(), baselineUsage,
-            "Direct buffer usage should return to baseline after iterator drain");
+        assertFalse(isSegmentRecordBufferLive(), "Segment record buffer should be released after iterator drain");
       }
+      assertFalse(isSegmentRecordBufferLive(), "Segment record buffer should remain released after close()");
     } finally {
       segment.destroy();
     }
@@ -152,30 +150,29 @@ public class OffHeapSingleTreeBuilderTest {
       List<StarTreeV2BuilderConfig> builderConfigs = createBuilderConfigs(segment);
       File outputDir = new File(TEMP_DIR, "starTreeOutputAbandon");
       FileUtils.forceMkdir(outputDir);
-
-      long baselineCount = PinotDataBuffer.getDirectBufferCount();
-      long baselineUsage = PinotDataBuffer.getDirectBufferUsage();
+      assertFalse(isSegmentRecordBufferLive(), "No pre-existing segment record buffer");
 
       OffHeapSingleTreeBuilder builder = new OffHeapSingleTreeBuilder(builderConfigs.get(0), outputDir, segment,
           new PropertiesConfiguration());
       try {
         int numDocs = segment.getSegmentMetadata().getTotalDocs();
         Iterator<?> iterator = builder.sortAndAggregateSegmentRecords(numDocs);
-        // Pull exactly one element; leave the iterator undrained.
+        // Pull exactly one element; leave the iterator undrained so close() must release the buffer.
         iterator.next();
-        assertTrue(PinotDataBuffer.getDirectBufferCount() > baselineCount,
-            "Buffer should be allocated mid-iteration");
+        assertTrue(isSegmentRecordBufferLive(), "Segment record buffer should be live mid-iteration");
       } finally {
         builder.close();
       }
 
-      assertEquals(PinotDataBuffer.getDirectBufferCount(), baselineCount,
-          "Direct buffer count should return to baseline after close() on undrained iterator");
-      assertEquals(PinotDataBuffer.getDirectBufferUsage(), baselineUsage,
-          "Direct buffer usage should return to baseline after close() on undrained iterator");
+      assertFalse(isSegmentRecordBufferLive(),
+          "Segment record buffer should be released after close() on undrained iterator");
     } finally {
       segment.destroy();
     }
+  }
+
+  private static boolean isSegmentRecordBufferLive() {
+    return PinotDataBuffer.getBufferInfo().stream().anyMatch(info -> info.contains(SEGMENT_RECORD_BUFFER_DESCRIPTION));
   }
 
   /// Builds the same segment twice — once with OFF_HEAP and once with ON_HEAP — then compares the


### PR DESCRIPTION
## Problem

`OffHeapSingleTreeBuilder.sortAndAggregateSegmentRecords` writes every row's dim dict-ids into an off-heap buffer, sorts docIds by dim tuple, closes the buffer, then returns an iterator that calls `getSegmentRecord(sortedDocIds[i])` — re-fetching the same dim dict-ids from the segment forward index in random (post-sort) order. When forward-index random reads are meaningfully more expensive than sequential ones, this dominates preprocess wall clock: a 3.3M-row segment measured 24 min in this method with 77% of JFR samples in the forward-index read path invoked from `getSegmentRecord → getSegmentRecordDimensions`.

## Fix

Extend the sort buffer's lifetime through iterator exhaustion; read dims back from it via a new `BaseSingleTreeBuilder#getSegmentRecordWithBufferDims(int, PinotDataBuffer)`. Metrics still read from the segment.

For N dims + M non-COUNT metrics, per-row random reads drop from `N + M` to `M` — 67% fewer for the common (4, 2) case.