### PR TITLE
Remove upsert metadata before releasing the consumer semaphore on segment offload

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1764,9 +1764,20 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     } catch (Exception e) {
       _segmentLogger.error("Caught exception while stopping the consumer thread", e);
     }
-    closeStreamConsumer();
-    cleanupMetrics();
-    _realtimeSegment.offload();
+    // Remove this segment's upsert/dedup metadata BEFORE releasing the consumer semaphore. For partial upsert in
+    // PROTECTED consistency mode, offload() reverts the primary keys owned by this consuming segment to their previous
+    // record locations. If the semaphore is released first, the next consuming segment of the partition can start
+    // replaying while primary keys still point to this mutable segment, and merge against the un-reverted state.
+    // NOTE: This only closes the gap for policies that hold the semaphore until offload, i.e. DISALLOW_ALWAYS (the
+    // default for partial upsert without pauseless). ALLOW_DURING_BUILD_ONLY and ALLOW_ALWAYS release it earlier from
+    // buildSegmentInternal() / downloadSegmentAndReplace() by design, so overlap there needs a separate mechanism.
+    // The semaphore is released in a finally block so a failure in metadata removal cannot stall the partition.
+    try {
+      _realtimeSegment.offload();
+    } finally {
+      closeStreamConsumer();
+      cleanupMetrics();
+    }
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -29,6 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
@@ -48,6 +49,7 @@ import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConsumerFactory;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamMessageDecoder;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImpl;
 import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentStatsHistory;
 import org.apache.pinot.segment.local.segment.creator.Fixtures;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
@@ -83,8 +85,11 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -649,6 +654,62 @@ public class RealtimeSegmentDataManagerTest {
       segmentDataManager.goOnlineFromConsuming(metadata);
       Assert.assertTrue(segmentDataManager._downloadAndReplaceCalled);
       Assert.assertTrue(segmentDataManager._buildAndReplaceCalled);
+    }
+  }
+
+  @Test
+  public void testOffloadRemovesSegmentMetadataBeforeReleasingConsumerSemaphore()
+      throws Exception {
+    // Use a fresh coordinator. Other tests release the shared semaphore without acquiring it, which inflates permits.
+    _partitionGroupIdToConsumerCoordinatorMap.remove(PARTITION_GROUP_ID);
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
+      Semaphore semaphore = _partitionGroupIdToConsumerCoordinatorMap.get(PARTITION_GROUP_ID).getSemaphore();
+      Assert.assertTrue(semaphore.tryAcquire());
+      segmentDataManager.getConsumerSemaphoreAcquired().set(true);
+
+      // MutableSegmentImpl.offload() removes the segment from the upsert/dedup metadata managers. For partial upsert in
+      // PROTECTED mode that is where the primary keys are reverted to their previous locations, so it has to run while
+      // the consumer semaphore is still held. Otherwise the next consuming segment replays against un-reverted state.
+      AtomicInteger permitsWhenMetadataRemoved = new AtomicInteger(-1);
+      MutableSegmentImpl realtimeSegment = spy((MutableSegmentImpl) segmentDataManager.getSegment());
+      doAnswer(invocation -> {
+        permitsWhenMetadataRemoved.set(semaphore.availablePermits());
+        return null;
+      }).when(realtimeSegment).offload();
+      segmentDataManager.setRealtimeSegment(realtimeSegment);
+
+      segmentDataManager.offload();
+
+      verify(realtimeSegment).offload();
+      Assert.assertEquals(permitsWhenMetadataRemoved.get(), 0,
+          "Segment metadata must be removed while the consumer semaphore is still held");
+      Assert.assertEquals(semaphore.availablePermits(), 1, "Consumer semaphore must be released after offload");
+      Assert.assertFalse(segmentDataManager.getConsumerSemaphoreAcquired().get());
+    }
+  }
+
+  @Test
+  public void testOffloadReleasesConsumerSemaphoreWhenMetadataRemovalFails()
+      throws Exception {
+    _partitionGroupIdToConsumerCoordinatorMap.remove(PARTITION_GROUP_ID);
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
+      Semaphore semaphore = _partitionGroupIdToConsumerCoordinatorMap.get(PARTITION_GROUP_ID).getSemaphore();
+      Assert.assertTrue(semaphore.tryAcquire());
+      segmentDataManager.getConsumerSemaphoreAcquired().set(true);
+
+      MutableSegmentImpl realtimeSegment = spy((MutableSegmentImpl) segmentDataManager.getSegment());
+      doThrow(new RuntimeException("metadata removal failed")).when(realtimeSegment).offload();
+      segmentDataManager.setRealtimeSegment(realtimeSegment);
+
+      try {
+        segmentDataManager.offload();
+        Assert.fail("Expected the metadata removal failure to propagate");
+      } catch (RuntimeException e) {
+        Assert.assertEquals(e.getMessage(), "metadata removal failed");
+      }
+      // A failed metadata removal must not leave the semaphore held, or the partition can never consume again.
+      Assert.assertEquals(semaphore.availablePermits(), 1,
+          "Consumer semaphore must be released even when metadata removal fails");
     }
   }
 
@@ -1417,6 +1478,14 @@ public class RealtimeSegmentDataManagerTest {
 
     public RealtimeTableDataManager getTableDataManager() {
       return _tableDataManager;
+    }
+
+    /// Replaces the mutable segment so tests can observe or fail its offload().
+    public void setRealtimeSegment(MutableSegmentImpl realtimeSegment)
+        throws Exception {
+      Field realtimeSegmentField = RealtimeSegmentDataManager.class.getDeclaredField("_realtimeSegment");
+      realtimeSegmentField.setAccessible(true);
+      realtimeSegmentField.set(this, realtimeSegment);
     }
 
     public String getStopReason() {


### PR DESCRIPTION
## TL;DR

`RealtimeSegmentDataManager.doOffload()` released the consumer semaphore two calls before it removed
the segment from the upsert and dedup metadata managers. For partial-upsert tables in `PROTECTED`
consistency mode that removal is where primary keys are reverted to their previous locations, so the
next consuming segment of the partition could start replaying while keys still pointed at the mutable
segment being offloaded. This PR runs the metadata removal first and releases the semaphore in a
`finally` block.

## The problem

On the normal commit path this ordering already holds: `replaceSegment()` reverts the keys before
`offload()` runs, so the semaphore release comes after. The offload-without-replace path
(CONSUMING to OFFLINE, CONSUMING to DROPPED) is the one that was wrong.

```mermaid
flowchart LR
  subgraph Before["❌ Old order"]
    A1[stop consumer] --> A2[release semaphore] --> A3[remove upsert metadata / revert]
    A2 -.-> A4[next segment starts replaying]
    A4 -.-> A5[merges against un-reverted keys]
  end
  subgraph After["✅ New order"]
    B1[stop consumer] --> B2[remove upsert metadata / revert] --> B3[release semaphore]
    B3 --> B4[next segment starts replaying]
    B4 --> B5[merges against reverted keys]
  end
```

What went wrong per key when the successor won the race:

- `doUpdateRecord` found the key still owned by the mutable segment with an equal comparison value,
  passed the out-of-order guard, and merged the already-merged row with the same update again. For
  `INCREMENT`, `APPEND` and `UNION` strategies that is a double count.
- `doAddRecord` wrote no undo entry because the current owner was a mutable segment.
- When the revert reached that key it saw another mutable owner, logged the "consumption is
  occurring concurrently with segment replacement" warning, and skipped it.

This needed a successor consumer already blocked on the semaphore for the same partition on the
same server, so it is rare. It is also cheap to close.

## Scope

This closes the gap only for consumption policies that hold the semaphore until offload, which is
`DISALLOW_ALWAYS`, the default for partial upsert without pauseless. `ALLOW_DURING_BUILD_ONLY` (the
pauseless default) and `ALLOW_ALWAYS` release the semaphore earlier, from `buildSegmentInternal()`
or `downloadSegmentAndReplace()`, by design. Overlap under those policies is a separate problem and
is not addressed here.

## The approach

1. `stop()` the consumer thread, unchanged.
2. Call `_realtimeSegment.offload()`, which calls `PartitionUpsertMetadataManager.removeSegment()`
   and `PartitionDedupMetadataManager.removeSegment()`.
3. In a `finally` block, `closeStreamConsumer()` (this releases the semaphore) and
   `cleanupMetrics()`. The `finally` matters: if the revert throws, the semaphore must still be
   released or the partition can never consume again on this server.

## Flow

```mermaid
sequenceDiagram
  participant H as Helix thread
  participant D as RealtimeSegmentDataManager
  participant M as MutableSegmentImpl
  participant U as PartitionUpsertMetadataManager
  participant C as ConsumerCoordinator
  participant N as Next consuming segment
  H->>D: doOffload()
  D->>D: stop()
  D->>M: offload()
  M->>U: removeSegment(segment)
  U-->>M: keys reverted to previous locations
  D->>C: release() (in finally)
  C-->>N: semaphore acquired
  N->>U: addRecord / updateRecord
  Note over N,U: keys already point at committed segments
```

## Testing

Two unit tests in `RealtimeSegmentDataManagerTest`, using a Mockito spy on the mutable segment:

- `testOffloadRemovesSegmentMetadataBeforeReleasingConsumerSemaphore`: acquires the coordinator's
  semaphore, records `availablePermits()` inside `MutableSegmentImpl.offload()`, and asserts it is 0
  at that point and 1 after `offload()` returns.
- `testOffloadReleasesConsumerSemaphoreWhenMetadataRemovalFails`: makes `offload()` throw and asserts
  the exception propagates and the semaphore is still released.

Both tests use a fresh `ConsumerCoordinator`, because other tests in the class release the shared
semaphore without acquiring it.

## Base

`master`. No config, metric, or wire-format changes.

## Labels

`bugfix`
