### PR TITLE
Report the optimizer's row-count estimates alongside the actual ones in query stats

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -849,8 +849,12 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         }
       }
 
+      // Already empty unless the query asked for estimates: `includeEstimatedRows` is honoured where
+      // the estimates are captured, during planning, so that a query that did not ask for them does
+      // not pay for them either. Nothing to gate a second time here.
       fillOldBrokerResponseStats(brokerResponse, queryResults.getQueryStats(), dispatchableSubPlan,
-          queryResults.getStageCoverage(), queryResults.getStageStatsTrees());
+          queryResults.getStageCoverage(), queryResults.getStageStatsTrees(),
+          dispatchableSubPlan.getEstimatedRowCounts());
 
       if (QueryOptionsUtils.isStreamStats(query.getOptions(), _streamStatsDefault)) {
         _brokerMetrics.addMeteredGlobalValue(BrokerMeter.MSE_STREAM_STATS_QUERIES, 1);
@@ -974,12 +978,12 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   private void fillOldBrokerResponseStats(BrokerResponseNativeV2 brokerResponse,
       List<MultiStageQueryStats.StageStats.Closed> queryStats, DispatchableSubPlan dispatchableSubPlan,
       @Nullable List<QueryDispatcher.QueryResult.StageCoverage> stageCoverage,
-      @Nullable Map<Integer, StageStatsTreeNode> stageStatsTrees) {
+      @Nullable Map<Integer, StageStatsTreeNode> stageStatsTrees, Map<PlanNode, Double> estimatedRowCounts) {
     try {
       Map<Integer, DispatchablePlanFragment> queryStageMap = dispatchableSubPlan.getQueryStageMap();
 
       MultiStageStatsTreeBuilder treeBuilder = new MultiStageStatsTreeBuilder(queryStageMap, queryStats,
-          stageStatsTrees);
+          stageStatsTrees, estimatedRowCounts);
       brokerResponse.setStageStats(treeBuilder.jsonStatsByStage(0));
       for (MultiStageQueryStats.StageStats.Closed stageStats : queryStats) {
         if (stageStats != null) { // for example pipeline breaker may not have stats

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -468,6 +468,12 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.EXPLAIN_PLAN_VERBOSE));
   }
 
+  /// Whether the caller asked for the optimizer's row estimates alongside the actual counts in
+  /// `stageStats`.
+  public static boolean isIncludeEstimatedRows(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.INCLUDE_ESTIMATED_ROWS));
+  }
+
   public static boolean isUseMultistageEngine(Map<String, String> queryOptions) {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.USE_MULTISTAGE_ENGINE));
   }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/QueryOptionsUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/QueryOptionsUtilsTest.java
@@ -377,4 +377,19 @@ public class QueryOptionsUtilsTest {
     queryOptions.put(LITE_MODE_IMPLICIT_LEAF_STAGE_LIMIT, "0");
     assertEquals(QueryOptionsUtils.getLiteModeImplicitLeafStageLimit(queryOptions), Integer.valueOf(0));
   }
+
+  /// The option is a user-facing key, so it has to survive the case-insensitive resolution every
+  /// query option goes through, and it has to default to off when absent. A typo in the constant or
+  /// an inverted read would leave every renderer test green while the option did nothing.
+  @Test
+  public void testIncludeEstimatedRows() {
+    assertTrue(QueryOptionsUtils.isIncludeEstimatedRows(
+        QueryOptionsUtils.resolveCaseInsensitiveOptions(Map.of("INCLUDEESTIMATEDROWS", "true"))));
+    assertTrue(QueryOptionsUtils.isIncludeEstimatedRows(
+        QueryOptionsUtils.resolveCaseInsensitiveOptions(Map.of("includeEstimatedRows", "true"))));
+    assertFalse(QueryOptionsUtils.isIncludeEstimatedRows(
+        QueryOptionsUtils.resolveCaseInsensitiveOptions(Map.of("includeEstimatedRows", "false"))));
+    assertFalse(QueryOptionsUtils.isIncludeEstimatedRows(Map.of()),
+        "estimates must be off unless asked for");
+  }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -81,6 +81,7 @@ import static org.apache.pinot.common.function.scalar.StringFunctions.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -2456,6 +2457,34 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     JsonNode response = postQuery(query);
     assertEquals(response.get("exceptions").get(0), null);
     assertNotNull(response.get("resultTable"), "Should have result table");
+  }
+
+  /// The one hop no unit test can cover: a real query, through the real broker, returning the field
+  /// in its real response. Everything upstream is unit-tested, but a mis-wired argument in the
+  /// broker handler would leave all of those green and the user with nothing.
+  ///
+  /// Deliberately asserts both directions. The absent case is the one that catches a gate that has
+  /// stopped gating -- the failure mode there is extra planning work on every query in the cluster,
+  /// which no assertion on the present case would ever notice.
+  @Test
+  public void testEstimatedRowsInStageStats()
+      throws Exception {
+    String query = "SELECT COUNT(*) FROM mytable";
+
+    JsonNode withOption = postQuery("SET includeEstimatedRows = 'true'; " + query);
+    JsonNode stageStats = withOption.get("stageStats");
+    assertNotNull(stageStats, "Should have stage stats");
+    assertNotNull(stageStats.get("estimatedRows"),
+        "estimatedRows should be reported when the query asks for it, got: " + stageStats);
+    Assertions.assertThat(stageStats.get("estimatedRows").asDouble()).isGreaterThan(0.0);
+    // The actual count sits beside it untouched -- comparing the two is the entire point.
+    assertNotNull(stageStats.get("emittedRows"), "the actual count must still be there");
+
+    JsonNode withoutOption = postQuery(query);
+    JsonNode plainStats = withoutOption.get("stageStats");
+    assertNotNull(plainStats, "Should have stage stats");
+    assertNull(plainStats.get("estimatedRows"),
+        "estimatedRows must be absent unless requested, got: " + plainStats);
   }
 
   @Test

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -96,6 +96,7 @@ import org.apache.pinot.query.validate.BytesCastVisitor;
 import org.apache.pinot.query.validate.RowExpressionValidationVisitor;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.QueryException;
+import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
@@ -518,15 +519,24 @@ public class QueryEnvironment {
   private DispatchableSubPlan toDispatchableSubPlan(RelRoot relRoot, PlannerContext plannerContext,
       @Nullable TransformationTracker.Builder<PlanNode, RelNode> tracker) {
     long requestId = _envConfig.getRequestId();
+    boolean includeEstimatedRows = QueryOptionsUtils.isIncludeEstimatedRows(plannerContext.getOptions());
     if (plannerContext.isUsePhysicalOptimizer()) {
       Pair<SubPlan, PlanFragmentAndMailboxAssignment.Result> plan = PinotLogicalQueryPlanner.makePlanV2(relRoot,
           plannerContext.getPhysicalPlannerContext());
+      if (includeEstimatedRows) {
+        // Tell the user rather than silently returning stats without the field they asked for. Sent
+        // on the response instead of logged: the option is per query, so a log line would say
+        // nothing to whoever ran it while costing a broker under load real write volume.
+        QueryThreadContext.addResponseBrokerMetadata(QueryOptionKey.INCLUDE_ESTIMATED_ROWS,
+            "ignored: row count estimates are not captured on the physical optimizer path ("
+                + QueryOptionKey.USE_PHYSICAL_OPTIMIZER + ")");
+      }
       PinotDispatchPlanner pinotDispatchPlanner = new PinotDispatchPlanner(plannerContext,
           _envConfig.getWorkerManager(), requestId, _envConfig.getTableCache());
       return pinotDispatchPlanner.createDispatchableSubPlanV2(plan.getLeft(), plan.getRight());
     }
     SubPlan plan = PinotLogicalQueryPlanner.makePlan(relRoot, tracker, useSpools(plannerContext.getOptions()),
-        _envConfig.defaultHashFunction(), pruneUnnestColumns(plannerContext.getOptions()));
+        _envConfig.defaultHashFunction(), pruneUnnestColumns(plannerContext.getOptions()), includeEstimatedRows);
     PinotDispatchPlanner pinotDispatchPlanner =
         new PinotDispatchPlanner(plannerContext, _envConfig.getWorkerManager(), _envConfig.getRequestId(),
             _envConfig.getTableCache());

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/SubPlan.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/SubPlan.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.query.planner;
 
 import java.util.List;
+import java.util.Map;
+import org.apache.pinot.query.planner.plannode.PlanNode;
 
 
 /// The `SubPlan` is the logical sub query plan that should be scheduled together from the result of
@@ -30,11 +32,24 @@ public class SubPlan {
   private final SubPlanMetadata _subPlanMetadata;
   /// The list of children sub query plans.
   private final List<SubPlan> _children;
+  /// Row count the optimizer estimated for each plan node, for later comparison against the counts
+  /// the runtime reports. Broker-side only and never serialized; empty when not captured.
+  private final Map<PlanNode, Double> _estimatedRowCounts;
 
   public SubPlan(PlanFragment subPlanRoot, SubPlanMetadata subPlanMetadata, List<SubPlan> children) {
+    this(subPlanRoot, subPlanMetadata, children, Map.of());
+  }
+
+  public SubPlan(PlanFragment subPlanRoot, SubPlanMetadata subPlanMetadata, List<SubPlan> children,
+      Map<PlanNode, Double> estimatedRowCounts) {
     _subPlanRoot = subPlanRoot;
     _subPlanMetadata = subPlanMetadata;
     _children = children;
+    _estimatedRowCounts = estimatedRowCounts;
+  }
+
+  public Map<PlanNode, Double> getEstimatedRowCounts() {
+    return _estimatedRowCounts;
   }
 
   public PlanFragment getSubPlanRoot() {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/PinotLogicalQueryPlanner.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/PinotLogicalQueryPlanner.java
@@ -25,6 +25,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.ints.IntListIterator;
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -58,12 +59,24 @@ public class PinotLogicalQueryPlanner {
   public static SubPlan makePlan(RelRoot relRoot,
       @Nullable TransformationTracker.Builder<PlanNode, RelNode> tracker, boolean useSpools,
       String hashFunction, boolean pruneUnnestColumns) {
-    PlanNode rootNode = new RelToPlanNodeConverter(tracker, hashFunction,
-        !CommonConstants.Helix.DEFAULT_ENABLE_CASE_INSENSITIVE, pruneUnnestColumns).toPlanNode(relRoot.rel);
+    return makePlan(relRoot, tracker, useSpools, hashFunction, pruneUnnestColumns, false);
+  }
 
-    PlanFragment rootFragment = planNodeToPlanFragment(rootNode, tracker, useSpools, hashFunction);
+  /// Converts a Calcite [RelRoot] into a Pinot [SubPlan], optionally capturing the optimizer's row
+  /// count estimate for each node so it can later be compared against what the runtime reports.
+  public static SubPlan makePlan(RelRoot relRoot,
+      @Nullable TransformationTracker.Builder<PlanNode, RelNode> tracker, boolean useSpools,
+      String hashFunction, boolean pruneUnnestColumns, boolean captureEstimatedRowCounts) {
+    RelToPlanNodeConverter converter = new RelToPlanNodeConverter(tracker, hashFunction,
+        !CommonConstants.Helix.DEFAULT_ENABLE_CASE_INSENSITIVE, pruneUnnestColumns, captureEstimatedRowCounts);
+    PlanNode rootNode = converter.toPlanNode(relRoot.rel);
+
+    IdentityHashMap<PlanNode, Double> estimatedRowCounts = converter.getEstimatedRowCounts();
+    PlanFragment rootFragment =
+        planNodeToPlanFragment(rootNode, tracker, useSpools, hashFunction, estimatedRowCounts);
     return new SubPlan(rootFragment,
-        new SubPlanMetadata(RelToPlanNodeConverter.getTableNamesFromRelRoot(relRoot.rel), relRoot.fields), List.of());
+        new SubPlanMetadata(RelToPlanNodeConverter.getTableNamesFromRelRoot(relRoot.rel), relRoot.fields), List.of(),
+        estimatedRowCounts);
 
     // TODO: Currently we don't support multiple sub-plans. Revisit the following logic when we add the support.
     // Fragment the stage tree into multiple SubPlans.
@@ -107,7 +120,7 @@ public class PinotLogicalQueryPlanner {
 
   private static PlanFragment planNodeToPlanFragment(
       PlanNode node, @Nullable TransformationTracker.Builder<PlanNode, RelNode> tracker, boolean useSpools,
-      String hashFunction) {
+      String hashFunction, IdentityHashMap<PlanNode, Double> estimatedRowCounts) {
     PlanFragmenter fragmenter = new PlanFragmenter();
     PlanFragmenter.Context fragmenterContext = fragmenter.createContext();
     node = node.visit(fragmenter, fragmenterContext);
@@ -159,6 +172,43 @@ public class PinotLogicalQueryPlanner {
       }
     }
 
+    if (!estimatedRowCounts.isEmpty()) {
+      copyEstimatesToMailboxNodes(fragmenter, node, subPlanRootSenderNode, rootReceiveNode, estimatedRowCounts);
+    }
+
     return new PlanFragment(0, rootReceiveNode, List.of(planFragment1));
+  }
+
+  /// Carries row-count estimates across the one boundary at which fragmentation does not preserve
+  /// plan node identity.
+  ///
+  /// [PlanFragmenter#process] rewrites ordinary nodes in place, so their estimates survive as they
+  /// are. Exchanges do not: [PlanFragmenter] discards each [ExchangeNode] and builds a fresh
+  /// [MailboxSendNode]/[MailboxReceiveNode] pair in its place. Without this copy, no stage root and
+  /// no mailbox receive leaf would ever carry an estimate — the field would be missing from exactly
+  /// the nodes a reader looks at first. The fragmenter retains the mapping back to the discarded
+  /// exchange for this reason, and the transformation tracker above uses it the same way.
+  ///
+  /// An exchange only moves rows, so its estimate describes both halves of the pair it becomes. The
+  /// outermost pair is built here rather than by the fragmenter and carries the plan root's output,
+  /// so it takes the root's estimate.
+  private static void copyEstimatesToMailboxNodes(PlanFragmenter fragmenter, PlanNode subPlanRoot,
+      MailboxSendNode subPlanRootSenderNode, MailboxReceiveNode rootReceiveNode,
+      IdentityHashMap<PlanNode, Double> estimatedRowCounts) {
+    Iterator<Map.Entry<? extends BasePlanNode, ExchangeNode>> it = Iterators.concat(
+        fragmenter.getMailboxSendToExchangeNodeMap().entrySet().iterator(),
+        fragmenter.getMailboxReceiveToExchangeNodeMap().entrySet().iterator());
+    while (it.hasNext()) {
+      Map.Entry<? extends BasePlanNode, ExchangeNode> entry = it.next();
+      Double estimate = estimatedRowCounts.get(entry.getValue());
+      if (estimate != null) {
+        estimatedRowCounts.put(entry.getKey(), estimate);
+      }
+    }
+    Double rootEstimate = estimatedRowCounts.get(subPlanRoot);
+    if (rootEstimate != null) {
+      estimatedRowCounts.put(subPlanRootSenderNode, rootEstimate);
+      estimatedRowCounts.put(rootReceiveNode, rootEstimate);
+    }
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -106,6 +107,23 @@ public final class RelToPlanNodeConverter {
   private final boolean _caseSensitive;
   // When true, UNNEST output is pruned to drop input (passthrough) columns not referenced downstream. Default off.
   private final boolean _pruneUnnestColumns;
+  /// Whether to capture estimated row counts at all. Off unless the query asked for them: obtaining
+  /// an estimate walks Calcite's metadata handlers, which is real work on a path that otherwise never
+  /// touches them, and the result would be discarded unread for every query that did not request it.
+  private final boolean _captureEstimatedRowCounts;
+  /// Row count the optimizer estimated for each converted node, captured here because it is the last
+  /// point at which both the [RelNode] (which carries the estimate) and the [PlanNode] (which the
+  /// runtime reports stats against) are in hand.
+  ///
+  /// Identity-keyed on purpose: [BasePlanNode] defines structural `equals`/`hashCode`, so a hash map
+  /// would merge distinct nodes that happen to look alike (the branches of a `UNION ALL`, say) and
+  /// attribute one branch's estimate to another.
+  ///
+  /// [PlanFragmenter] keeps these keys valid for every node it rewrites in place, but *not* for
+  /// exchanges: it discards each [org.apache.pinot.query.planner.plannode.ExchangeNode] and builds a
+  /// fresh mailbox pair in its place. [PinotLogicalQueryPlanner] copies the estimates across that
+  /// boundary once fragmentation is done.
+  private final IdentityHashMap<PlanNode, Double> _estimatedRowCounts = new IdentityHashMap<>();
 
   public RelToPlanNodeConverter(@Nullable TransformationTracker.Builder<PlanNode, RelNode> tracker,
       String hashFunction) {
@@ -119,10 +137,17 @@ public final class RelToPlanNodeConverter {
 
   public RelToPlanNodeConverter(@Nullable TransformationTracker.Builder<PlanNode, RelNode> tracker,
       String hashFunction, boolean caseSensitive, boolean pruneUnnestColumns) {
+    this(tracker, hashFunction, caseSensitive, pruneUnnestColumns, false);
+  }
+
+  public RelToPlanNodeConverter(@Nullable TransformationTracker.Builder<PlanNode, RelNode> tracker,
+      String hashFunction, boolean caseSensitive, boolean pruneUnnestColumns,
+      boolean captureEstimatedRowCounts) {
     _tracker = tracker;
     _hashFunction = hashFunction;
     _caseSensitive = caseSensitive;
     _pruneUnnestColumns = pruneUnnestColumns;
+    _captureEstimatedRowCounts = captureEstimatedRowCounts;
   }
 
   /// Converts a [RelNode] into its serializable counterpart.
@@ -176,7 +201,37 @@ public final class RelToPlanNodeConverter {
     if (_tracker != null) {
       _tracker.trackCreation(node, result);
     }
+    if (_captureEstimatedRowCounts) {
+      recordEstimatedRowCount(node, result);
+    }
     return result;
+  }
+
+  /// Records what the optimizer estimated this node would produce.
+  ///
+  /// Nothing is recorded when no estimate can be had. [RelMetadataQuery#getRowCount] is itself
+  /// nullable — `RelMdRowCount` returns null for a `Minus` whose inputs are all unestimated, and for
+  /// a join whose selectivity cannot be guessed — and it can throw if a metadata handler misbehaves.
+  /// Either way a missing entry renders as an absent field, which is the honest answer; storing the
+  /// null would put one behind a `Map<PlanNode, Double>` that callers unbox.
+  ///
+  /// Kept at DEBUG rather than WARN deliberately: this runs per node, and a broken handler on a
+  /// high-QPS broker would otherwise flood the log.
+  private void recordEstimatedRowCount(RelNode relNode, PlanNode planNode) {
+    try {
+      Double estimate = relNode.getCluster().getMetadataQuery().getRowCount(relNode);
+      if (estimate != null) {
+        _estimatedRowCounts.put(planNode, estimate);
+      }
+    } catch (RuntimeException e) {
+      LOGGER.debug("Could not estimate row count for {}", relNode.getRelTypeName(), e);
+    }
+  }
+
+  /// Estimated row counts by plan node, for comparison against the actual counts the runtime
+  /// reports. Identity-keyed; empty when capture was off or nothing could be estimated.
+  public IdentityHashMap<PlanNode, Double> getEstimatedRowCounts() {
+    return _estimatedRowCounts;
   }
 
   private UnnestNode convertLogicalUncollect(Uncollect node) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchableSubPlan.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchableSubPlan.java
@@ -28,6 +28,7 @@ import java.util.TreeSet;
 import java.util.function.ToIntFunction;
 import org.apache.calcite.runtime.PairList;
 import org.apache.pinot.core.util.QueryMultiThreadingUtils;
+import org.apache.pinot.query.planner.plannode.PlanNode;
 
 
 /// The `DispatchableSubPlan` is the dispatchable query execution plan from the result of
@@ -49,6 +50,16 @@ public class DispatchableSubPlan {
   private final Map<String, Set<String>> _tableToUnavailableSegmentsMap;
   private final long _numSegmentsPrunedByBroker;
   private final boolean _allLeafStagesEmpty;
+  /// Row count the optimizer estimated for each plan node, for comparison against the counts the
+  /// runtime reports back. Empty unless the query asked for them.
+  ///
+  /// Must be identity-keyed ([java.util.IdentityHashMap]): [org.apache.pinot.query.planner.plannode.BasePlanNode]
+  /// defines structural `equals`/`hashCode`, so a hash map would merge distinct nodes that happen to
+  /// look alike and misattribute their estimates. Do not replace this with `Map.copyOf`.
+  ///
+  /// Broker-side only — nothing here is serialized to servers, so there is no wire-format or
+  /// mixed-version concern.
+  private final Map<PlanNode, Double> _estimatedRowCounts;
 
   public DispatchableSubPlan(PairList<Integer, String> fields,
       Map<Integer, DispatchablePlanFragment> queryStageMap,
@@ -61,12 +72,27 @@ public class DispatchableSubPlan {
       Map<Integer, DispatchablePlanFragment> queryStageMap,
       Set<String> tableNames, Map<String, Set<String>> tableToUnavailableSegmentsMap,
       long numSegmentsPrunedByBroker, boolean allLeafStagesEmpty) {
+    this(fields, queryStageMap, tableNames, tableToUnavailableSegmentsMap, numSegmentsPrunedByBroker,
+        allLeafStagesEmpty, Map.of());
+  }
+
+  public DispatchableSubPlan(PairList<Integer, String> fields,
+      Map<Integer, DispatchablePlanFragment> queryStageMap,
+      Set<String> tableNames, Map<String, Set<String>> tableToUnavailableSegmentsMap,
+      long numSegmentsPrunedByBroker, boolean allLeafStagesEmpty, Map<PlanNode, Double> estimatedRowCounts) {
     _queryResultFields = fields;
     _queryStageMap = queryStageMap;
     _tableNames = tableNames;
     _tableToUnavailableSegmentsMap = tableToUnavailableSegmentsMap;
     _numSegmentsPrunedByBroker = numSegmentsPrunedByBroker;
     _allLeafStagesEmpty = allLeafStagesEmpty;
+    _estimatedRowCounts = estimatedRowCounts;
+  }
+
+  /// Estimated row counts by plan node; empty when they were not captured. See
+  /// [#_estimatedRowCounts] for why the map is identity-keyed.
+  public Map<PlanNode, Double> getEstimatedRowCounts() {
+    return Collections.unmodifiableMap(_estimatedRowCounts);
   }
 
   /// Get a map from stage id to stage plan.

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/PinotDispatchPlanner.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/PinotDispatchPlanner.java
@@ -79,7 +79,7 @@ public class PinotDispatchPlanner {
     // 5. Run validations
     runValidations(rootFragment, context);
     // 6. convert it into query plan.
-    return finalizeDispatchableSubPlan(rootFragment, context);
+    return finalizeDispatchableSubPlan(rootFragment, context, subPlan.getEstimatedRowCounts());
   }
 
   /// Returns the actual table names taking the case-sensitivity configured within the `TableCache` instance into
@@ -109,7 +109,10 @@ public class PinotDispatchPlanner {
     }
     trackEmptyLeafStages(context);
     runValidations(rootFragment, context);
-    return finalizeDispatchableSubPlan(rootFragment, context);
+    // Always empty on this path: the physical optimizer builds plan fragments from PRelNodes without
+    // going through RelToPlanNodeConverter, so there is nothing to carry. Passed explicitly rather
+    // than defaulted so that adding capture here is a change to this line and not a discovery.
+    return finalizeDispatchableSubPlan(rootFragment, context, subPlan.getEstimatedRowCounts());
   }
 
   /// Records empty leaf stages so that [DispatchablePlanContext#isAllNonReplicatedLeafStagesEmpty()] works for
@@ -164,7 +167,7 @@ public class PinotDispatchPlanner {
   }
 
   private static DispatchableSubPlan finalizeDispatchableSubPlan(PlanFragment subPlanRoot,
-      DispatchablePlanContext dispatchablePlanContext) {
+      DispatchablePlanContext dispatchablePlanContext, Map<PlanNode, Double> estimatedRowCounts) {
     // Empty leaf stages are tracked for both engines: the legacy path in WorkerManager, and the physical optimizer
     // path in #trackEmptyLeafStages.
     boolean allLeafStagesEmpty = dispatchablePlanContext.isAllNonReplicatedLeafStagesEmpty();
@@ -183,7 +186,8 @@ public class PinotDispatchPlanner {
         dispatchablePlanContext.getTableNames(),
         populateTableUnavailableSegments(dispatchablePlanContext.getDispatchablePlanMetadataMap()),
         dispatchablePlanContext.getNumSegmentsPrunedByBroker(),
-        allLeafStagesEmpty);
+        allLeafStagesEmpty,
+        estimatedRowCounts);
   }
 
   static boolean hasNonEmptyReplicatedLeaf(Map<Integer, DispatchablePlanMetadata> metadataMap) {

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -1750,4 +1750,70 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
         "usePlannerRules=JoinToEnrichedJoin must be a no-op, got:\n" + explain);
     assertTrue(explain.contains("LogicalJoin"), "expected an ordinary LogicalJoin, got:\n" + explain);
   }
+
+  /// The estimates must survive the whole planning chain -- converter, SubPlan, dispatch planner --
+  /// and arrive on the DispatchableSubPlan the broker holds. Every hop is a place they could be
+  /// silently dropped, and the unit tests either side of the chain would still pass if they were.
+  @Test
+  public void testEstimatedRowCountsReachTheDispatchableSubPlan() {
+    DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(
+        "SET includeEstimatedRows=true; SELECT a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE a.col3 > 0");
+
+    Map<PlanNode, Double> estimates = dispatchableSubPlan.getEstimatedRowCounts();
+    assertFalse(estimates.isEmpty(), "Estimates were captured during conversion but did not reach "
+        + "the DispatchableSubPlan -- a hop in the planning chain is dropping them");
+
+    // Estimates are row counts: never negative, and a real plan has at least one positive one.
+    boolean anyPositive = false;
+    for (Map.Entry<PlanNode, Double> entry : estimates.entrySet()) {
+      assertTrue(entry.getValue() >= 0,
+          "Negative row estimate for " + entry.getKey().getClass().getSimpleName() + ": " + entry.getValue());
+      anyPositive |= entry.getValue() > 0;
+    }
+    assertTrue(anyPositive, "Every estimate was zero, which no real plan produces");
+  }
+
+  /// Every stage root must carry an estimate, not merely some node somewhere in the plan.
+  ///
+  /// Stage roots are the mailbox nodes, and those are the one kind fragmentation does not preserve:
+  /// it discards each ExchangeNode and builds a fresh pair, so without the copy in
+  /// PinotLogicalQueryPlanner the field would be missing from exactly the nodes a reader looks at
+  /// first -- while an assertion that merely found *an* estimated node somewhere would still pass.
+  @Test
+  public void testEveryStageRootCarriesAnEstimate() {
+    DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(
+        "SET includeEstimatedRows=true; SELECT a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1");
+
+    Map<PlanNode, Double> estimates = dispatchableSubPlan.getEstimatedRowCounts();
+    List<String> uncovered = new ArrayList<>();
+    for (Map.Entry<Integer, DispatchablePlanFragment> entry : dispatchableSubPlan.getQueryStageMap().entrySet()) {
+      PlanNode fragmentRoot = entry.getValue().getPlanFragment().getFragmentRoot();
+      if (!estimates.containsKey(fragmentRoot)) {
+        uncovered.add("stage " + entry.getKey() + " (" + fragmentRoot.getClass().getSimpleName() + ")");
+      }
+    }
+    assertTrue(uncovered.isEmpty(),
+        "These stage roots have no estimate, so identity was lost on the exchange boundary: " + uncovered);
+  }
+
+  /// Nothing is captured unless the query asks. The estimate is obtained by walking Calcite's
+  /// metadata handlers, which the multi-stage planner otherwise barely touches, so a query that did
+  /// not ask for estimates must not pay for them.
+  @Test
+  public void testNoEstimatesCapturedUnlessRequested() {
+    DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(
+        "SELECT a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE a.col3 > 0");
+    assertTrue(dispatchableSubPlan.getEstimatedRowCounts().isEmpty(),
+        "Estimates were captured for a query that did not request them");
+  }
+
+  /// Statistics are not required for this to be useful: without them Calcite still supplies its own
+  /// row-count estimates, so estimate-versus-actual works on a broker with no CBO configured.
+  @Test
+  public void testEstimatesPresentWithoutStatistics() {
+    DispatchableSubPlan dispatchableSubPlan =
+        _queryEnvironment.planQuery("SET includeEstimatedRows=true; SELECT col1 FROM a");
+    assertFalse(dispatchableSubPlan.getEstimatedRowCounts().isEmpty(),
+        "Calcite's default estimates should be captured even with no statistics provider");
+  }
 }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverterTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverterTest.java
@@ -20,7 +20,9 @@ package org.apache.pinot.query.planner.logical;
 
 import com.google.common.collect.ImmutableList;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.hep.HepPlanner;
 import org.apache.calcite.plan.hep.HepProgramBuilder;
@@ -445,5 +447,93 @@ public class RelToPlanNodeConverterTest {
         rexBuilder.makeFieldAccess(rexBuilder.makeCorrel(leftRowType, correlationId), fieldName, true);
     return LogicalProject.create(LogicalValues.createOneRow(cluster), List.of(),
         List.of(fieldAccess), List.of(fieldName));
+  }
+
+  /// Every converted node must carry the estimate the optimizer had for it. This is the only point
+  /// where the RelNode (which holds the estimate) and the PlanNode (which the runtime reports stats
+  /// against) coexist, so a node missed here can never be compared against its actual row count.
+  @Test
+  public void testEveryConvertedNodeRecordsAnEstimatedRowCount() {
+    TypeFactory typeFactory = TypeFactory.INSTANCE;
+    RelOptCluster cluster = createCluster(typeFactory);
+    RelDataType rowType = typeFactory.builder()
+        .add("id", SqlTypeName.INTEGER)
+        .add("arr", typeFactory.createArrayType(typeFactory.createSqlType(SqlTypeName.INTEGER), -1))
+        .build();
+    LogicalValues left = LogicalValues.create(cluster, rowType, ImmutableList.of());
+    CorrelationId correlationId = new CorrelationId(0);
+    LogicalProject project = buildCorrelatedProject(cluster, rowType, correlationId, "arr");
+    Uncollect uncollect = Uncollect.create(project.getTraitSet(), project, false, List.of());
+    LogicalCorrelate correlate =
+        LogicalCorrelate.create(left, uncollect, correlationId, ImmutableBitSet.of(1), JoinRelType.INNER);
+
+    RelToPlanNodeConverter converter = capturingConverter();
+    PlanNode root = converter.toPlanNode(correlate);
+
+    Map<PlanNode, Double> estimates = converter.getEstimatedRowCounts();
+    Assert.assertFalse(estimates.isEmpty(), "No estimates were captured at all");
+
+    List<PlanNode> missing = new ArrayList<>();
+    collectMissingEstimates(root, estimates, missing);
+    Assert.assertTrue(missing.isEmpty(),
+        "Every converted node should have an estimate; missing for: " + missing);
+  }
+
+  /// Nothing may be captured unless asked for -- the capture walks Calcite's metadata handlers, and
+  /// a query that did not request estimates must not pay for them.
+  @Test
+  public void testNothingCapturedWhenNotRequested() {
+    TypeFactory typeFactory = TypeFactory.INSTANCE;
+    RelOptCluster cluster = createCluster(typeFactory);
+    RelDataType rowType = typeFactory.builder().add("id", SqlTypeName.INTEGER).build();
+
+    RelToPlanNodeConverter converter = new RelToPlanNodeConverter(null,
+        CommonConstants.Broker.DEFAULT_BROKER_DEFAULT_HASH_FUNCTION);
+    converter.toPlanNode(LogicalValues.create(cluster, rowType, ImmutableList.of()));
+
+    Assert.assertTrue(converter.getEstimatedRowCounts().isEmpty(),
+        "Estimates were captured even though capture was not requested");
+  }
+
+  /// The estimates must be keyed by node identity, not by value.
+  ///
+  /// [org.apache.pinot.query.planner.plannode.BasePlanNode] defines structural equals/hashCode, so
+  /// an equals-keyed map would merge two nodes that merely look alike -- the branches of a UNION ALL,
+  /// say -- and report one branch's estimate for the other. Asserting the property rather than the
+  /// concrete map class: an unmodifiable wrapper would break an `instanceof IdentityHashMap` check
+  /// without changing behavior, and a wrongly populated IdentityHashMap would satisfy it.
+  @Test
+  public void testEstimatesAreKeyedByIdentityNotByValue() {
+    TypeFactory typeFactory = TypeFactory.INSTANCE;
+    RelOptCluster cluster = createCluster(typeFactory);
+    RelDataType rowType = typeFactory.builder().add("id", SqlTypeName.INTEGER).build();
+
+    RelToPlanNodeConverter converter = capturingConverter();
+    PlanNode first = converter.toPlanNode(LogicalValues.create(cluster, rowType, ImmutableList.of()));
+    PlanNode second = converter.toPlanNode(LogicalValues.create(cluster, rowType, ImmutableList.of()));
+
+    Assert.assertNotSame(first, second, "test needs two distinct instances");
+    Assert.assertEquals(first, second, "test needs two structurally equal nodes to be meaningful");
+
+    Map<PlanNode, Double> estimates = converter.getEstimatedRowCounts();
+    Assert.assertEquals(estimates.size(), 2,
+        "Structurally equal nodes were merged into one entry, so estimates can be misattributed");
+    Assert.assertTrue(estimates.containsKey(first) && estimates.containsKey(second),
+        "Both instances must keep their own entry");
+  }
+
+  private static RelToPlanNodeConverter capturingConverter() {
+    return new RelToPlanNodeConverter(null, CommonConstants.Broker.DEFAULT_BROKER_DEFAULT_HASH_FUNCTION,
+        !CommonConstants.Helix.DEFAULT_ENABLE_CASE_INSENSITIVE, false, true);
+  }
+
+  private static void collectMissingEstimates(PlanNode node, Map<PlanNode, Double> estimates,
+      List<PlanNode> missing) {
+    if (!estimates.containsKey(node)) {
+      missing.add(node);
+    }
+    for (PlanNode input : node.getInputs()) {
+      collectMissingEstimates(input, estimates, missing);
+    }
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/InStageStatsTreeBuilder.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/InStageStatsTreeBuilder.java
@@ -63,11 +63,41 @@ public class InStageStatsTreeBuilder implements PlanNodeVisitor<ObjectNode, InSt
   private int _index;
   private static final String CHILDREN_KEY = "children";
   private final IntFunction<ObjectNode> _jsonStatsByStage;
+  /// Row counts the optimizer estimated, keyed by plan node. Empty unless the caller asked for
+  /// them, which is what keeps the extra field off every query's stats.
+  private final Map<PlanNode, Double> _estimatedRowCounts;
 
-  public InStageStatsTreeBuilder(MultiStageQueryStats.StageStats stageStats, IntFunction<ObjectNode> jsonStatsByStage) {
+  public InStageStatsTreeBuilder(MultiStageQueryStats.StageStats stageStats,
+      IntFunction<ObjectNode> jsonStatsByStage, Map<PlanNode, Double> estimatedRowCounts) {
     _stageStats = stageStats;
     _index = stageStats.getLastOperatorIndex();
     _jsonStatsByStage = jsonStatsByStage;
+    _estimatedRowCounts = estimatedRowCounts;
+  }
+
+  /// Adds the optimizer's estimate for `planNode` to `json`, in place, next to the actual counts
+  /// already there.
+  ///
+  /// Because this builder visits the plan itself, no id lookup is needed to find the estimate — but
+  /// it does not follow that any JSON object reaching this method describes `planNode`. Call it only
+  /// where the object being annotated is the one built for that node; the paths that hand back a
+  /// child's object, or a synthetic container standing for no operator at all, must not. Pairing one
+  /// operator's estimate with another's emitted rows is worse than reporting nothing.
+  ///
+  /// In a leaf stage the engine compiles the whole pushed-down subtree into one operator, so the
+  /// estimate belonging on it is the subtree root's — that is what its emitted-row count represents.
+  ///
+  /// A node with no recorded estimate adds no field, rather than a zero a reader would take for a
+  /// real prediction of no rows.
+  private ObjectNode withEstimatedRows(ObjectNode json, PlanNode planNode) {
+    if (_estimatedRowCounts.isEmpty()) {
+      return json;
+    }
+    Double estimate = _estimatedRowCounts.get(planNode);
+    if (estimate != null) {
+      json.put("estimatedRows", estimate);
+    }
+    return json;
   }
 
   private ObjectNode selfNode(OperatorTypeDescriptor type, Context context) {
@@ -206,6 +236,12 @@ public class InStageStatsTreeBuilder implements PlanNodeVisitor<ObjectNode, InSt
     return joinNode.getJoinType() == JoinRelType.SEMI || joinNode.getJoinType() == JoinRelType.ANTI;
   }
 
+  /// Renders `node` and its children.
+  ///
+  /// Estimates are attached only on the paths that actually render `node` itself. The paths taken
+  /// when the stats and the plan disagree do not: with one input the child's own JSON is returned
+  /// unchanged, and with none or several the result is a synthetic container that stands for no
+  /// operator. Annotating those would pair one operator's estimate with another's emitted rows.
   private ObjectNode recursiveCase(BasePlanNode node, MultiStageOperator.Type expectedType, Context context) {
     OperatorTypeDescriptor type = _stageStats.getOperatorType(_index);
     /*
@@ -220,10 +256,11 @@ public class InStageStatsTreeBuilder implements PlanNodeVisitor<ObjectNode, InSt
         int selfIndex = _index;
         ObjectNode pipelineBreakerResultNode = extractPipelineBreakerResult(node, context);
         if (pipelineBreakerResultNode != null) {
-          return selfNode(
-              MultiStageOperator.Type.LEAF, context, selfIndex, new JsonNode[] {pipelineBreakerResultNode}, false);
+          return withEstimatedRows(selfNode(
+              MultiStageOperator.Type.LEAF, context, selfIndex, new JsonNode[] {pipelineBreakerResultNode}, false),
+              node);
         }
-        return selfNode(MultiStageOperator.Type.LEAF, context, _index, new JsonNode[0]);
+        return withEstimatedRows(selfNode(MultiStageOperator.Type.LEAF, context, _index, new JsonNode[0]), node);
       }
       List<PlanNode> inputs = node.getInputs();
       int childrenSize = inputs.size();
@@ -251,7 +288,7 @@ public class InStageStatsTreeBuilder implements PlanNodeVisitor<ObjectNode, InSt
     JsonNode[] childrenArr = new JsonNode[size];
     if (size > _index) {
       LOGGER.warn("Operator {} has {} inputs but only {} stats are left", type, size, _index);
-      return selfNode(type, context);
+      return withEstimatedRows(selfNode(type, context), node);
     }
     for (int i = size - 1; i >= 0; i--) {
       PlanNode planNode = inputs.get(i);
@@ -261,7 +298,7 @@ public class InStageStatsTreeBuilder implements PlanNodeVisitor<ObjectNode, InSt
       childrenArr[i] = child;
     }
 
-    return selfNode(type, context, selfIndex, childrenArr);
+    return withEstimatedRows(selfNode(type, context, selfIndex, childrenArr), node);
   }
 
   @Override
@@ -292,7 +329,7 @@ public class InStageStatsTreeBuilder implements PlanNodeVisitor<ObjectNode, InSt
 
   @Override
   public ObjectNode visitMailboxReceive(MailboxReceiveNode node, Context context) {
-    ObjectNode json = selfNode(MultiStageOperator.Type.MAILBOX_RECEIVE, context);
+    ObjectNode json = withEstimatedRows(selfNode(MultiStageOperator.Type.MAILBOX_RECEIVE, context), node);
 
     ArrayNode children = JsonUtils.newArrayNode();
     int senderStageId = node.getSenderStageId();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/MultiStageStatsTreeBuilder.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/MultiStageStatsTreeBuilder.java
@@ -51,6 +51,9 @@ public class MultiStageStatsTreeBuilder {
   private final Map<Integer, DispatchablePlanFragment> _planFragments;
   @Nullable
   private final Map<Integer, StageStatsTreeNode> _stageStatsTrees;
+  /// Row counts the optimizer estimated, keyed by plan node. Empty unless the caller asked for
+  /// them, which is what keeps the estimate fields off every query's stats.
+  private final Map<PlanNode, Double> _estimatedRowCounts;
 
   public MultiStageStatsTreeBuilder(Map<Integer, DispatchablePlanFragment> planFragments,
       List<? extends MultiStageQueryStats.StageStats> queryStats) {
@@ -60,6 +63,14 @@ public class MultiStageStatsTreeBuilder {
   public MultiStageStatsTreeBuilder(Map<Integer, DispatchablePlanFragment> planFragments,
       List<? extends MultiStageQueryStats.StageStats> queryStats,
       @Nullable Map<Integer, StageStatsTreeNode> stageStatsTrees) {
+    this(planFragments, queryStats, stageStatsTrees, Map.of());
+  }
+
+  public MultiStageStatsTreeBuilder(Map<Integer, DispatchablePlanFragment> planFragments,
+      List<? extends MultiStageQueryStats.StageStats> queryStats,
+      @Nullable Map<Integer, StageStatsTreeNode> stageStatsTrees,
+      Map<PlanNode, Double> estimatedRowCounts) {
+    _estimatedRowCounts = estimatedRowCounts;
     _planFragments = planFragments;
     _planNodes = Maps.newHashMapWithExpectedSize(planFragments.size());
     for (Map.Entry<Integer, DispatchablePlanFragment> entry : planFragments.entrySet()) {
@@ -90,7 +101,10 @@ public class MultiStageStatsTreeBuilder {
       }
       return jsonNodes;
     }
-    InStageStatsTreeBuilder treeBuilder = new InStageStatsTreeBuilder(stageStats, this::jsonStatsByStage);
+    // Same estimates for the plan-visiting renderer: a query takes one path or the other, so both
+    // must annotate or the field would appear only for some queries.
+    InStageStatsTreeBuilder treeBuilder =
+        new InStageStatsTreeBuilder(stageStats, this::jsonStatsByStage, _estimatedRowCounts);
     return planNode.visit(treeBuilder, new InStageStatsTreeBuilder.Context(1));
   }
 
@@ -113,6 +127,27 @@ public class MultiStageStatsTreeBuilder {
     return jsonFromStatsTreeNode(statsTree, planNodesById, parallelism);
   }
 
+  /// Adds the optimizer's estimate next to the actual counts, so estimate error is readable
+  /// without re-deriving it from EXPLAIN by hand.
+  ///
+  /// A stats node can cover several plan nodes -- operators fuse, and a leaf stage compiles its
+  /// whole pushed-down subtree into ONE operator with a single emitted-row count. There is
+  /// therefore no per-plan-node actual to pair with inside such a group, so the estimate reported
+  /// is the one for the FIRST (topmost) plan node in it: that is the node whose output the group's
+  /// emitted rows actually represent. Attributing to any other member would silently compare
+  /// unrelated numbers.
+  private void addEstimatedRows(ObjectNode json, List<Integer> planNodeIds,
+      Map<Integer, PlanNode> planNodesById) {
+    if (_estimatedRowCounts.isEmpty()) {
+      return;
+    }
+    PlanNode topmost = planNodesById.get(planNodeIds.get(0));
+    Double estimate = topmost == null ? null : _estimatedRowCounts.get(topmost);
+    if (estimate != null) {
+      json.put("estimatedRows", estimate);
+    }
+  }
+
   private ObjectNode jsonFromStatsTreeNode(StageStatsTreeNode node, Map<Integer, PlanNode> planNodesById,
       int parallelism) {
     ObjectNode json = JsonUtils.newObjectNode();
@@ -132,6 +167,7 @@ public class MultiStageStatsTreeBuilder {
       ArrayNode planNodeIds = JsonUtils.newArrayNode();
       node.getPlanNodeIds().forEach(planNodeIds::add);
       json.set("planNodeIds", planNodeIds);
+      addEstimatedRows(json, node.getPlanNodeIds(), planNodesById);
     }
 
     ArrayNode children = JsonUtils.newArrayNode();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/MultiStageStatsTreeBuilderTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/MultiStageStatsTreeBuilderTest.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.query.runtime;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.calcite.rel.RelDistribution;
@@ -203,5 +205,208 @@ public class MultiStageStatsTreeBuilderTest {
   @SuppressWarnings({"unchecked", "rawtypes"})
   private static StatMap<?> statsOf(MultiStageOperator.Type type) {
     return new StatMap(type.getStatKeyClass());
+  }
+
+  /// The estimate must land on the node whose actual count it should be compared against, so that
+  /// reading estimate error off the stats needs no cross-referencing.
+  @Test
+  public void testEstimatedRowsRenderedNextToActualCounts() {
+    OperatorTypeDescriptor sendType = pluginType(300, "TEST_PLUGIN_SEND");
+    OperatorTypeDescriptor receiveType = pluginType(301, "TEST_PLUGIN_RECEIVE");
+    MailboxReceiveNode stage1Receive = receiveNode(1, 2);
+    PlanNode stage1Root = sendNode(1, List.of(stage1Receive), 0);
+    PlanNode stage2Root = sendNode(2,
+        List.of(new ValueNode(2, SCHEMA, PlanNode.NodeHint.EMPTY, List.of(), List.of())), 1);
+
+    StageStatsTreeNode stage1Tree = new StageStatsTreeNode(sendType, List.of(0), pluginStats(10, 7), List.of(
+        new StageStatsTreeNode(receiveType, List.of(1), pluginStats(10, 3), List.of())));
+    StageStatsTreeNode stage2Tree = new StageStatsTreeNode(sendType, List.of(0), pluginStats(5, 1), List.of());
+
+    // Identity-keyed, matching what the planner supplies: structurally equal nodes are distinct
+    // plan nodes with potentially different estimates.
+    Map<PlanNode, Double> estimates = new IdentityHashMap<>();
+    estimates.put(stage1Root, 1234.0);
+    estimates.put(stage1Receive, 99.0);
+
+    MultiStageStatsTreeBuilder builder = new MultiStageStatsTreeBuilder(
+        fragments(Map.of(1, stage1Root, 2, stage2Root)), List.of(), Map.of(1, stage1Tree, 2, stage2Tree),
+        estimates);
+    ObjectNode json = builder.jsonStatsByStage(1);
+
+    // The actual count stays untouched next to the estimate -- the pair is the whole point.
+    Assert.assertEquals(json.get("emittedRows").asLong(), 10);
+    Assert.assertEquals(json.get("estimatedRows").asDouble(), 1234.0, 1e-9);
+
+    ObjectNode receive = (ObjectNode) json.get("children").get(0);
+    Assert.assertEquals(receive.get("emittedRows").asLong(), 10);
+    Assert.assertEquals(receive.get("estimatedRows").asDouble(), 99.0, 1e-9);
+  }
+
+  /// Ordinary queries must not carry the extra fields, so an empty map renders nothing at all --
+  /// not a zero, which a consumer would read as "the optimizer expected no rows".
+  @Test
+  public void testEstimatedRowsAbsentWhenNotRequested() {
+    OperatorTypeDescriptor sendType = pluginType(300, "TEST_PLUGIN_SEND");
+    PlanNode stage1Root = sendNode(1, List.of(receiveNode(1, 2)), 0);
+    PlanNode stage2Root = sendNode(2,
+        List.of(new ValueNode(2, SCHEMA, PlanNode.NodeHint.EMPTY, List.of(), List.of())), 1);
+    StageStatsTreeNode stage1Tree = new StageStatsTreeNode(sendType, List.of(0), pluginStats(10, 7), List.of());
+
+    MultiStageStatsTreeBuilder builder = new MultiStageStatsTreeBuilder(
+        fragments(Map.of(1, stage1Root, 2, stage2Root)), List.of(), Map.of(1, stage1Tree));
+    ObjectNode json = builder.jsonStatsByStage(1);
+
+    Assert.assertEquals(json.get("emittedRows").asLong(), 10);
+    Assert.assertNull(json.get("estimatedRows"), "estimatedRows must be absent unless requested");
+  }
+
+  /// A stats node can cover several plan nodes (operators fuse; a leaf stage compiles its whole
+  /// pushed-down subtree into one operator). There is one actual count for the group, and it
+  /// represents the OUTPUT of the topmost node, so that is the estimate reported. Attributing to
+  /// another member would silently pair unrelated numbers.
+  ///
+  /// This pins the renderer's half of the contract: given a group, it reports the first member's
+  /// estimate and not another member's. The other half -- that the first id really is the group's
+  /// topmost node -- is established by `PlanNodeToOpChain#collectPlanNodeSubTree`, which walks
+  /// pre-order but is private, so it cannot be asserted from here.
+  @Test
+  public void testFusedNodeReportsTheTopmostEstimate() {
+    OperatorTypeDescriptor sendType = pluginType(300, "TEST_PLUGIN_SEND");
+    MailboxReceiveNode stage1Receive = receiveNode(1, 2);
+    PlanNode stage1Root = sendNode(1, List.of(stage1Receive), 0);
+    PlanNode stage2Root = sendNode(2,
+        List.of(new ValueNode(2, SCHEMA, PlanNode.NodeHint.EMPTY, List.of(), List.of())), 1);
+
+    // One stats node covering both plan nodes, topmost first.
+    StageStatsTreeNode fused = new StageStatsTreeNode(sendType, List.of(0, 1), pluginStats(10, 7), List.of());
+
+    Map<PlanNode, Double> estimates = new IdentityHashMap<>();
+    estimates.put(stage1Root, 7777.0);
+    estimates.put(stage1Receive, 11.0);
+
+    MultiStageStatsTreeBuilder builder = new MultiStageStatsTreeBuilder(
+        fragments(Map.of(1, stage1Root, 2, stage2Root)), List.of(), Map.of(1, fused), estimates);
+    ObjectNode json = builder.jsonStatsByStage(1);
+
+    Assert.assertEquals(json.get("estimatedRows").asDouble(), 7777.0, 1e-9);
+  }
+
+  /// A plan node with no recorded estimate renders no field, rather than a sentinel a reader would
+  /// chart as a real value.
+  @Test
+  public void testMissingEstimateRendersNoField() {
+    OperatorTypeDescriptor sendType = pluginType(300, "TEST_PLUGIN_SEND");
+    MailboxReceiveNode stage1Receive = receiveNode(1, 2);
+    PlanNode stage1Root = sendNode(1, List.of(stage1Receive), 0);
+    PlanNode stage2Root = sendNode(2,
+        List.of(new ValueNode(2, SCHEMA, PlanNode.NodeHint.EMPTY, List.of(), List.of())), 1);
+    StageStatsTreeNode stage1Tree = new StageStatsTreeNode(sendType, List.of(0), pluginStats(10, 7), List.of());
+
+    // Non-empty map, but nothing recorded for the node being rendered.
+    Map<PlanNode, Double> estimates = new IdentityHashMap<>();
+    estimates.put(stage1Receive, 11.0);
+
+    MultiStageStatsTreeBuilder builder = new MultiStageStatsTreeBuilder(
+        fragments(Map.of(1, stage1Root, 2, stage2Root)), List.of(), Map.of(1, stage1Tree), estimates);
+    ObjectNode json = builder.jsonStatsByStage(1);
+
+    Assert.assertNull(json.get("estimatedRows"), "A node with no estimate must render no field");
+  }
+
+  /// The plan-visiting renderer must annotate too. A query takes one renderer or the other, so if
+  /// only the streaming one did, the field would appear for some queries and silently not others.
+  /// Built-in operator types on purpose: this renderer pairs stats against the PlanNode tree and
+  /// cannot match plugin types, so a plugin-typed fixture would render nothing and prove nothing.
+  @Test
+  public void testPlanVisitingRendererAlsoReportsEstimatedRows() {
+    MailboxReceiveNode stage1Receive = receiveNode(1, 2);
+    PlanNode stage1Root = sendNode(1, List.of(stage1Receive), 0);
+    PlanNode stage2Root = sendNode(2,
+        List.of(new ValueNode(2, SCHEMA, PlanNode.NodeHint.EMPTY, List.of(), List.of())), 1);
+
+    // Inorder flat list: child (receive) first, then the send root.
+    MultiStageQueryStats.StageStats.Closed flatStats = new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE, MultiStageOperator.Type.MAILBOX_SEND),
+        List.of(statsOf(MultiStageOperator.Type.MAILBOX_RECEIVE), statsOf(MultiStageOperator.Type.MAILBOX_SEND)));
+    List<MultiStageQueryStats.StageStats.Closed> queryStats = new ArrayList<>();
+    queryStats.add(null);
+    queryStats.add(flatStats);
+    queryStats.add(null);
+
+    Map<PlanNode, Double> estimates = new IdentityHashMap<>();
+    estimates.put(stage1Root, 4321.0);
+    estimates.put(stage1Receive, 21.0);
+
+    // Null stageStatsTrees: the older stats-in-blocks path, which walks the plan.
+    MultiStageStatsTreeBuilder builder = new MultiStageStatsTreeBuilder(
+        fragments(Map.of(1, stage1Root, 2, stage2Root)), queryStats, null, estimates);
+    ObjectNode json = builder.jsonStatsByStage(1);
+
+    Assert.assertEquals(json.get("estimatedRows").asDouble(), 4321.0, 1e-9);
+    // The receive node is annotated from its own visit method, not from recursiveCase.
+    ObjectNode receive = (ObjectNode) json.get("children").get(0);
+    Assert.assertEquals(receive.get("estimatedRows").asDouble(), 21.0, 1e-9);
+  }
+
+  /// When the flat stats and the plan disagree, the plan-visiting renderer returns the *child's*
+  /// JSON for the parent's visit. The estimate on it must remain the child's.
+  ///
+  /// This is the ordinary path, not a corner: it is what happens in stage 0, in leaf stages, and
+  /// whenever an operator type is not the one the plan predicted. Annotating the parent's estimate
+  /// onto that object pairs one operator's prediction with another operator's emitted rows -- which
+  /// is what an earlier version of this code did, on the false premise that every return path built
+  /// the JSON for the node being visited.
+  @Test
+  public void testPlanVisitingRendererKeepsTheChildsEstimateOnTypeMismatch() {
+    MailboxReceiveNode stage1Receive = receiveNode(1, 2);
+    PlanNode stage1Root = sendNode(1, List.of(stage1Receive), 0);
+    PlanNode stage2Root = sendNode(2,
+        List.of(new ValueNode(2, SCHEMA, PlanNode.NodeHint.EMPTY, List.of(), List.of())), 1);
+
+    // Stats for the receive operator only -- the send has none, so visiting the send takes the
+    // mismatch path and hands back the receive's JSON.
+    MultiStageQueryStats.StageStats.Closed flatStats = new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE),
+        List.of(statsOf(MultiStageOperator.Type.MAILBOX_RECEIVE)));
+    List<MultiStageQueryStats.StageStats.Closed> queryStats = new ArrayList<>();
+    queryStats.add(null);
+    queryStats.add(flatStats);
+    queryStats.add(null);
+
+    Map<PlanNode, Double> estimates = new IdentityHashMap<>();
+    estimates.put(stage1Root, 4321.0);
+    estimates.put(stage1Receive, 21.0);
+
+    MultiStageStatsTreeBuilder builder = new MultiStageStatsTreeBuilder(
+        fragments(Map.of(1, stage1Root, 2, stage2Root)), queryStats, null, estimates);
+    ObjectNode json = builder.jsonStatsByStage(1);
+
+    Assert.assertEquals(json.get("type").asText(), MultiStageOperator.Type.MAILBOX_RECEIVE.name(),
+        "the mismatch path should have rendered the receive operator");
+    Assert.assertEquals(json.get("estimatedRows").asDouble(), 21.0, 1e-9,
+        "the receive's own estimate must survive; the send's estimate must not overwrite it");
+  }
+
+  /// And it must stay silent when nothing was requested, for the same reason as the streaming path.
+  @Test
+  public void testPlanVisitingRendererOmitsEstimatedRowsWhenNotRequested() {
+    MailboxReceiveNode stage1Receive = receiveNode(1, 2);
+    PlanNode stage1Root = sendNode(1, List.of(stage1Receive), 0);
+    PlanNode stage2Root = sendNode(2,
+        List.of(new ValueNode(2, SCHEMA, PlanNode.NodeHint.EMPTY, List.of(), List.of())), 1);
+
+    MultiStageQueryStats.StageStats.Closed flatStats = new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE, MultiStageOperator.Type.MAILBOX_SEND),
+        List.of(statsOf(MultiStageOperator.Type.MAILBOX_RECEIVE), statsOf(MultiStageOperator.Type.MAILBOX_SEND)));
+    List<MultiStageQueryStats.StageStats.Closed> queryStats = new ArrayList<>();
+    queryStats.add(null);
+    queryStats.add(flatStats);
+    queryStats.add(null);
+
+    MultiStageStatsTreeBuilder builder = new MultiStageStatsTreeBuilder(
+        fragments(Map.of(1, stage1Root, 2, stage2Root)), queryStats);
+    ObjectNode json = builder.jsonStatsByStage(1);
+
+    Assert.assertNull(json.get("estimatedRows"), "estimatedRows must be absent unless requested");
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -833,6 +833,24 @@ public class CommonConstants {
         public static final String ORDERED_PREFERRED_POOLS = "orderedPreferredPools";
         public static final String USE_FIXED_REPLICA = "useFixedReplica";
         public static final String EXPLAIN_PLAN_VERBOSE = "explainPlanVerbose";
+
+        /// When `true`, each node in the response's `stageStats` also reports `estimatedRows` --
+        /// the row count the optimizer expected -- next to the count the runtime actually emitted.
+        ///
+        /// The value is the optimizer's estimate, a double, and it appears only on nodes for which
+        /// an estimate was captured: nothing is reported for a node the optimizer could not estimate,
+        /// and a group of fused operators reports the estimate of its topmost member, since that is
+        /// the node whose output the group's emitted-row count represents.
+        ///
+        /// Off by default, and off in both senses -- a query that does not ask for estimates does not
+        /// pay to compute them either. Not supported together with `usePhysicalOptimizer`, which
+        /// builds its plan fragments without going through the conversion that records estimates; a
+        /// query combining the two gets a notice on the response rather than a silently missing field.
+        ///
+        /// A query option rather than a config because it is a per-query diagnostic: it answers "was
+        /// the estimate for THIS query any good?", which today can only be reconstructed by hand from
+        /// EXPLAIN.
+        public static final String INCLUDE_ESTIMATED_ROWS = "includeEstimatedRows";
         public static final String USE_MULTISTAGE_ENGINE = "useMultistageEngine";
         public static final String INFER_PARTITION_HINT = "inferPartitionHint";
         public static final String ENABLE_NULL_HANDLING = "enableNullHandling";


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

The PR adds estimated row counts to query stats when includeEstimatedRows=true, capturing estimates during RelNode\-to\-PlanNode conversion and passing them through planning to stats builders for output\.

```mermaid
flowchart TD
  N0["Query options parsed #40;F2#41; #40;F2#41;"]:::stAdded
  N1["Option checked in QueryEnvironment #40;F3#41; #40;F3#41;"]:::stModified
  N2["Estimates captured in RelToPlanNodeConverter #40;F6#41; #40;F6#41;"]:::stModified
  N3["Estimates passed via SubPlan #40;F4#41; #40;F4#41;"]:::stModified
  N4["Estimates held in DispatchableSubPlan #40;F7#41; #40;F7#41;"]:::stModified
  N5["Estimates passed to stats builders #40;F1#44; F10#44; F9#41; #40;F1#44; F10#44; F9#41;"]:::stModified
  N0 -->|"options flow"| N1
  N1 -->|"planning path"| N2
  N2 -->|"estimates captured"| N3
  N3 -->|"subplan dispatch"| N4
  N4 -->|"broker stats"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler\.java — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java) · [after](https://github.com/apache/pinot/blob/f6497b584709a6f614ffd227d40e4677729ca2ca/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java)
- F2: pinot\-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils\.java — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java) · [after](https://github.com/apache/pinot/blob/f6497b584709a6f614ffd227d40e4677729ca2ca/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java)
- F3: pinot\-query\-planner/src/main/java/org/apache/pinot/query/QueryEnvironment\.java — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java) · [after](https://github.com/apache/pinot/blob/f6497b584709a6f614ffd227d40e4677729ca2ca/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java)
- F4: pinot\-query\-planner/src/main/java/org/apache/pinot/query/planner/SubPlan\.java — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/SubPlan.java) · [after](https://github.com/apache/pinot/blob/f6497b584709a6f614ffd227d40e4677729ca2ca/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/SubPlan.java)
- F6: pinot\-query\-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter\.java — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java) · [after](https://github.com/apache/pinot/blob/f6497b584709a6f614ffd227d40e4677729ca2ca/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java)
- F7: pinot\-query\-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchableSubPlan\.java — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchableSubPlan.java) · [after](https://github.com/apache/pinot/blob/f6497b584709a6f614ffd227d40e4677729ca2ca/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchableSubPlan.java)
- F9: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/InStageStatsTreeBuilder\.java — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/InStageStatsTreeBuilder.java) · [after](https://github.com/apache/pinot/blob/f6497b584709a6f614ffd227d40e4677729ca2ca/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/InStageStatsTreeBuilder.java)
- F10: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/MultiStageStatsTreeBuilder\.java — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/MultiStageStatsTreeBuilder.java) · [after](https://github.com/apache/pinot/blob/f6497b584709a6f614ffd227d40e4677729ca2ca/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/MultiStageStatsTreeBuilder.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImQwOGFjOTEzNjVmZDJjZWMzZGI1OTViZGI2MzY4NzhjODMzYTlkNWIiLCJjb250ZXh0X2hhc2giOiIwMGRjMTc1MTlhZjAyNWRlY2MxMjg1MDBkY2E3Yjg4MTk4ZjJjOTZmMTFkMGFlNWRhYTY2NjMyNmM4NWU2MDliIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MDIyOTIzLCJoZWFkX3NoYSI6ImY2NDk3YjU4NDcwOWE2ZjYxNGZmZDIyN2Q0MGU0Njc3NzI5Y2EyY2EiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJkMDhhYzkxMzY1ZmQyY2VjM2RiNTk1YmRiNjM2ODc4YzgzM2E5ZDViIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 8ae00830267ffb9805491a6c805d043057b218e8de21f3a8855ec440b1b00e9d -->
<!-- pinot-pr-flow:end -->

## Motivation

The multi-stage engine already reports how many rows each operator emitted, and the planner already
knows how many it expected. The two have never met, so there is no ordinary way to answer "was the
estimate for this query any good?".

Today the only route is `EXPLAIN PLAN INCLUDING ALL ATTRIBUTES` — itself obscure, since the default
explain level hides row counts — followed by working out by hand whether the numbers are plausible.
That does not scale past one query at a time, and it cannot be done at all for a query that has
already run.

Estimate quality is worth being able to see. A plan alone cannot tell you whether the optimizer
chose well from good information or badly from bad information: a join whose true result is a
million rows and one estimated at a hundred billion produce identical-looking plans.

## Change

`SET includeEstimatedRows=true` adds an `estimatedRows` field next to the actual count on each node
of the response's `stageStats`:

```json
{ "type": "HASH_JOIN", "planNodeIds": [4],
  "emittedRows": 6001215, "estimatedRows": 108021870000, ... }
```

Off by default, and off in both senses: a query that does not ask for estimates does not pay to
compute them either. Obtaining one walks Calcite's metadata handlers, which the multi-stage planner
otherwise barely touches, so the option is honoured where the estimates are captured rather than
only where they are rendered.

Not supported alongside `usePhysicalOptimizer`, which builds its fragments without going through
that conversion. Combining the two returns a notice on the response rather than silently omitting
the field the query asked for — the first use, as far as I can tell, of the broker response-metadata
channel added in #19019.

The estimates are captured while converting `RelNode`s to `PlanNode`s — the only
point where both representations exist — carried on `SubPlan`, passed to `DispatchableSubPlan`
through the single funnel both plan paths use, and looked up by the stats renderers against the same
plan nodes the runtime already reports against.

A query option rather than a config, because the question is per query: it has to be answerable for
the query that was actually slow, without a restart or a log-level change.

## This needs no statistics to be useful

With no statistics provider configured, Calcite still supplies its own row-count estimates, so
estimate-versus-actual works on any broker today. When table statistics are available the same
field starts reporting statistics-backed numbers instead. Nothing here depends on cost-based
optimization being enabled.

## What you will see first, and why it is not a bug

On any join query the divergence will be enormous. Only scan row counts are statistics-backed;
every join and filter selectivity is currently Calcite's constant `RelMdUtil.guessSelectivity`,
0.15 per equality conjunct. Measured on TPC-H SF1, matching the plan to every digit:

```
lineitem ⋈ partsupp   6,001,215 × 800,000 × 0.15²  = 1.0802187e11
         ⋈ supplier   1.0802187e11 × 10,000 × 0.15 = 1.62032805e14
         ⋈ nation     1.62032805e14 × 25 × 0.15²   = 9.1143452e13
```

The first join's true cardinality is about 6M, so the estimate is ~18,000× high, and a
`n_name = 'JAPAN'` filter is estimated at 0.15 rather than 1/25.

That is this change working correctly. It surfaces a known gap — join selectivity is not yet
NDV-based — rather than introducing one, and being able to see that gap is the point.

## Design notes

**Nothing is added to `PlanNode`.** `PlanNode` is serialized to servers, so a field there would be
a wire-format and mixed-version concern for what is purely a broker-side diagnostic. The estimates
live in a broker-side map; servers are unaffected and need no upgrade.

**Identity-keyed, not equals-keyed.** `BasePlanNode` defines structural `equals`/`hashCode`, so two
nodes that merely look alike — the branches of a `UNION ALL`, say — would collapse into one entry in
a hash map and report each other's estimates.

**Estimates are copied across the exchange boundary.** Fragmentation preserves node identity for
everything it rewrites in place, but not for exchanges: `PlanFragmenter` discards each `ExchangeNode`
and builds a fresh `MailboxSendNode`/`MailboxReceiveNode` pair. Those pairs are the stage roots, so
leaving it there would mean the field was missing from exactly the nodes a reader looks at first. The
fragmenter already retains the mapping back to the discarded exchange — the transformation tracker
uses it the same way — so the estimates are copied onto the new pair once fragmentation is done. An
exchange only moves rows, so its estimate describes both halves.

**Both renderers annotate.** A query takes either the streaming path (`MultiStageStatsTreeBuilder`)
or the plan-visiting one (`InStageStatsTreeBuilder`). Wiring only the first would make the field
appear for some queries and silently vanish for others, which is worse than not reporting it.

**Attribution for fused nodes is explicit.** A stats node can cover several plan nodes: operators
fuse, and a leaf stage compiles its whole pushed-down subtree into a single operator with one
emitted-row count. The estimate reported for such a group is the topmost node's, because that is
the node whose output those emitted rows represent. Consequently there are no scan-level actuals
inside a leaf stage — a property of the engine, not of this change.

**A missing estimate renders no field**, rather than a zero, which a consumer would read as "the
optimizer predicted no rows". Failure to obtain an estimate is logged at DEBUG and left
unrecorded: a diagnostic must never break planning.

**One gate, not two.** The broker renders whatever was captured rather than re-checking the option,
so "not requested" and "nothing recorded" are the same state and cannot drift apart.

## Testing

- `RelToPlanNodeConverterTest`: every node in a converted tree carries an estimate, and the map is
  identity-keyed.
- `QueryCompilationTest`: the estimates survive the whole planning chain (converter → `SubPlan` →
  dispatch planner → `DispatchableSubPlan`), every hop being somewhere they could be dropped while
  the unit tests either side still passed; that **every stage root** carries an estimate, not merely
  some node somewhere — the weaker assertion passes even when identity is lost at the exchange
  boundary; that nothing at all is captured for a query that did not ask; and that estimates are
  captured with no statistics provider.
- `MultiStageStatsTreeBuilderTest`: the estimate lands on the node whose actual count it should be
  compared against, with the actual untouched beside it; it is absent when not requested; a fused
  node reports its topmost member's estimate rather than another member's; a node with no estimate
  renders no field; and, where the flat stats and the plan disagree — the ordinary case in stage 0
  and in leaf stages — the child's own estimate survives rather than being overwritten by its
  parent's.
- `QueryOptionsUtilsTest`: the option parses through the case-insensitive resolution every query
  option goes through, and defaults to off.
- `MultiStageEngineIntegrationTest`: a real query through a real broker returns the field, and a
  query without the option does not. That absent half is what catches a gate that has stopped
  gating, whose only symptom is extra planning work on every query in the cluster.

## Possible follow-ups

- **Estimates in the `EXPLAIN` text**, which is the more legible format for a human. A small
  `RelWriter` subclass does it. Note for whoever picks this up: the default explain level should
  *not* be moved to `ALL_ATTRIBUTES` to achieve it — that level also emits each node's internal id,
  which is assigned per planning run, so it makes explain output non-deterministic and rewrites
  thousands of pinned plan lines. Appending one attribute at the caller's existing level avoids
  both.
- **`EXPLAIN ANALYZE`**, reporting the same pair of numbers over the plan tree rather than over the
  stats tree. `PhysicalExplainPlanVisitor` already renders from plan nodes, so the annotation is
  small; the real work is that `EXPLAIN` does not execute the query today.

## Release notes

Adds the `includeEstimatedRows` query option (default off). No behavior change when unset.

