### PR TITLE
Fix SSE dropping the FILTER clause of aggregations used only in HAVING or ORDER BY

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -340,7 +340,8 @@ public class QueryContext {
     return _filteredAggregationsIndexMap;
   }
 
-  /// Returns the filtered aggregation expressions for the query.
+  /// Returns whether any aggregation in the query carries a FILTER clause, no matter whether it is referenced in the
+  /// SELECT list, the HAVING clause or the ORDER-BY clause.
   public boolean hasFilteredAggregations() {
     return _hasFilteredAggregations;
   }
@@ -810,9 +811,6 @@ public class QueryContext {
       for (Pair<FunctionContext, FilterContext> pair : filteredAggregations) {
         FunctionContext aggregation = pair.getLeft();
         FilterContext filter = pair.getRight();
-        if (filter != null) {
-          queryContext._hasFilteredAggregations = true;
-        }
         int functionIndex = filteredAggregationFunctions.size();
         AggregationFunction aggregationFunction =
             AggregationFunctionFactory.getAggregationFunction(aggregation, queryContext._nullHandlingEnabled);
@@ -846,7 +844,15 @@ public class QueryContext {
         int numAggregations = filteredAggregationFunctions.size();
         AggregationFunction[] aggregationFunctions = new AggregationFunction[numAggregations];
         for (int i = 0; i < numAggregations; i++) {
-          aggregationFunctions[i] = filteredAggregationFunctions.get(i).getLeft();
+          Pair<AggregationFunction, FilterContext> pair = filteredAggregationFunctions.get(i);
+          aggregationFunctions[i] = pair.getLeft();
+          // NOTE: Compute the flag over all the collected aggregations (SELECT, HAVING and ORDER-BY) instead of only
+          //       the SELECT ones. A FILTER clause on an aggregation that is referenced only in HAVING or ORDER-BY
+          //       must still be honored, else the plan nodes pick the non-filtered operator and silently evaluate the
+          //       aggregation over the main filter alone.
+          if (pair.getRight() != null) {
+            queryContext._hasFilteredAggregations = true;
+          }
         }
         queryContext._aggregationFunctions = aggregationFunctions;
         queryContext._filteredAggregationFunctions = filteredAggregationFunctions;

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
@@ -520,6 +520,15 @@ public class BrokerRequestToQueryContextConverterTest {
 
   @Test
   public void testFilteredAggregations() {
+    // The FILTER clause must be honored no matter which clause references the aggregation.
+    assertTrue(QueryContextConverterUtils.getQueryContext(
+            "SELECT foo, COUNT(*) FROM testTable GROUP BY foo HAVING COUNT(*) FILTER(WHERE bar > 5) > 0")
+        .hasFilteredAggregations());
+    assertTrue(QueryContextConverterUtils.getQueryContext(
+        "SELECT foo FROM testTable GROUP BY foo ORDER BY COUNT(*) FILTER(WHERE bar > 5)").hasFilteredAggregations());
+    assertFalse(QueryContextConverterUtils.getQueryContext(
+        "SELECT foo, COUNT(*) FROM testTable GROUP BY foo HAVING COUNT(*) > 0").hasFilteredAggregations());
+
     {
       String query =
           "SELECT COUNT(*) FILTER(WHERE foo > 5), COUNT(*) FILTER(WHERE foo < 6) FROM testTable WHERE bar > 0";

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
@@ -478,4 +478,79 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
     long nonFilterQueryDocsScanned = getBrokerResponse(nonFilterQuery).getNumDocsScanned();
     assertEquals(filterQueryDocsScanned, nonFilterQueryDocsScanned);
   }
+
+  @Test
+  public void testFilteredAggregationOnlyInHaving() {
+    // An aggregation with a FILTER clause that is referenced only in the HAVING clause (and not in the SELECT list)
+    // must still have its filter applied. With the main filter INT_COL < 8, each group holds a single distinct
+    // INT_COL value, so groups 0-4 hold only rows matching INT_COL < 5 and groups 5-7 only rows matching
+    // INT_COL >= 5. The HAVING clause therefore keeps groups 0-4.
+    String havingQuery =
+        "SELECT NO_INDEX_COL, COUNT(*) testCount FROM MyTable WHERE INT_COL < 8 GROUP BY NO_INDEX_COL "
+            + "HAVING COUNT(*) FILTER(WHERE INT_COL < 5) > 0 AND COUNT(*) FILTER(WHERE INT_COL >= 5) < 1 "
+            + "ORDER BY NO_INDEX_COL";
+    List<Object[]> rows = getBrokerResponse(havingQuery).getResultTable().getRows();
+    assertEquals(rows.size(), 5);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(rows.get(i)[0], i);
+      assertEquals(rows.get(i)[1], 4L);
+    }
+
+    // Projecting the same filtered aggregations in the SELECT list must not change the groups that are kept.
+    String selectQuery =
+        "SELECT NO_INDEX_COL, COUNT(*) testCount, COUNT(*) FILTER(WHERE INT_COL < 5) testLow, "
+            + "COUNT(*) FILTER(WHERE INT_COL >= 5) testHigh FROM MyTable WHERE INT_COL < 8 GROUP BY NO_INDEX_COL "
+            + "HAVING COUNT(*) FILTER(WHERE INT_COL < 5) > 0 AND COUNT(*) FILTER(WHERE INT_COL >= 5) < 1 "
+            + "ORDER BY NO_INDEX_COL";
+    List<Object[]> selectRows = getBrokerResponse(selectQuery).getResultTable().getRows();
+    assertEquals(selectRows.size(), rows.size());
+    for (int i = 0; i < selectRows.size(); i++) {
+      assertEquals(selectRows.get(i)[0], rows.get(i)[0]);
+      assertEquals(selectRows.get(i)[1], rows.get(i)[1]);
+      assertEquals(selectRows.get(i)[2], 4L);
+      assertEquals(selectRows.get(i)[3], 0L);
+    }
+  }
+
+  @Test
+  public void testFilteredAggregationOnlyInOrderBy() {
+    // Same as above for an aggregation that is referenced only in the ORDER-BY clause. Groups 5-7 hold only rows
+    // matching INT_COL >= 5, so they must sort before groups 0-4 on the filtered count.
+    String query = "SELECT NO_INDEX_COL FROM MyTable WHERE INT_COL < 8 GROUP BY NO_INDEX_COL "
+        + "ORDER BY COUNT(*) FILTER(WHERE INT_COL >= 5) DESC, NO_INDEX_COL ASC";
+    List<Object[]> rows = getBrokerResponse(query).getResultTable().getRows();
+    assertEquals(rows.size(), 8);
+    int[] groups = new int[rows.size()];
+    for (int i = 0; i < rows.size(); i++) {
+      groups[i] = (int) rows.get(i)[0];
+    }
+    assertEquals(groups, new int[]{5, 6, 7, 0, 1, 2, 3, 4});
+  }
+
+  @Test
+  public void testFilteredAggregationOnlyInOrderBySkipEmptyGroups() {
+    // The query below has no non-filtered aggregation, so enabling the skip-empty-groups option drops the groups that
+    // match no aggregation filter. Groups 0-4 hold no row matching INT_COL >= 5 and are therefore not returned.
+    String query = "SET " + CommonConstants.Broker.Request.QueryOptionKey.FILTERED_AGGREGATIONS_SKIP_EMPTY_GROUPS
+        + "=true; SELECT NO_INDEX_COL FROM MyTable WHERE INT_COL < 8 GROUP BY NO_INDEX_COL "
+        + "ORDER BY COUNT(*) FILTER(WHERE INT_COL >= 5) DESC, NO_INDEX_COL ASC";
+    List<Object[]> rows = getBrokerResponse(query).getResultTable().getRows();
+    int[] groups = new int[rows.size()];
+    for (int i = 0; i < rows.size(); i++) {
+      groups[i] = (int) rows.get(i)[0];
+    }
+    assertEquals(groups, new int[]{5, 6, 7});
+  }
+
+  @Test
+  public void testFilteredAggregationOnlyInHavingWithoutGroupBy() {
+    // Without a GROUP BY the query is planned by AggregationPlanNode, which switches to the filtered operator here
+    // too. The main filter matches INT_COL 0-7 across the 4 segments, and the HAVING condition holds either way, so
+    // the projected count must stay the same.
+    String query = "SELECT COUNT(*) testCount FROM MyTable WHERE INT_COL < 8 "
+        + "HAVING COUNT(*) FILTER(WHERE INT_COL < 5) > 0";
+    List<Object[]> rows = getBrokerResponse(query).getResultTable().getRows();
+    assertEquals(rows.size(), 1);
+    assertEquals(rows.get(0)[0], 32L);
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -977,6 +977,9 @@ public class CommonConstants {
         // users are okay with skipping empty groups - i.e., only the groups matching at least one aggregation filter
         // will be returned - this query option can be set. This is useful for performance, since indexes can be used
         // for the aggregation filters and a full scan can be avoided.
+        // NOTE: Aggregations are counted here no matter whether they are referenced in the SELECT list, the HAVING
+        //       clause or the ORDER-BY clause, so a query that projects no aggregation but orders by (or filters on)
+        //       a filtered one is also covered.
         public static final String FILTERED_AGGREGATIONS_SKIP_EMPTY_GROUPS = "filteredAggregationsSkipEmptyGroups";
 
         // When set to true, the max initial result holder capacity will be optimized based on the query. Rather than


### PR DESCRIPTION
The single-stage engine silently ignores the `FILTER (WHERE ...)` clause of an aggregation that is
referenced only in `HAVING` or `ORDER BY` and not in the `SELECT` list. The aggregation is evaluated
over the main query filter alone, so the query returns wrong results with no error.

Reproducer (the shape a user hit in production - "groups that had older rows but no recent ones"):

```sql
SELECT cluster, pod, COUNT(*) AS rc
FROM myTable
WHERE metricName = 'someMetric' AND (... time range ...)
GROUP BY cluster, pod
HAVING COUNT(*) FILTER (WHERE ts <  ago('PT1435M')) > 0
   AND COUNT(*) FILTER (WHERE ts >= ago('PT1435M')) < 1
ORDER BY cluster, pod
```

Both filtered counts collapse to the unfiltered `COUNT(*)`, so the predicate becomes
`rc > 0 AND rc < 1`, which no group can satisfy. The query returns zero rows and no exception. The
same query returns the correct rows on the multi-stage engine, which makes it look like an
engine-parity issue rather than a bug.

### Root cause

`QueryContext.Builder.generateAggregationFunctions()` collects filtered aggregations in two passes:
one over the `SELECT` list, then one over `HAVING` and `ORDER BY`. Both passes append to
`filteredAggregationFunctions`, but `_hasFilteredAggregations` was only set in the first pass.

`GroupByPlanNode.run()` and `AggregationPlanNode.run()` branch on `hasFilteredAggregations()` to
choose between `FilteredGroupByOperator` / `FilteredAggregationOperator` and their non-filtered
counterparts. With the flag false, the non-filtered operator runs every aggregation against the main
filter and the per-aggregation filters are dropped.

This has been present since FILTER support was added in #7916.

### Fix

Compute `_hasFilteredAggregations` from the collected `(function, filter)` pairs in the loop that
already walks them, after both passes have run. This removes the second place the flag had to be
maintained, so the two collection passes cannot drift apart again. The stale Javadoc on
`hasFilteredAggregations()` (it described a different method) is corrected to state the contract.

### Tests

Two regression tests in `FilteredAggregationsTest`, both failing before this change and passing
after:

* `testFilteredAggregationOnlyInHaving` - the reproducer shape above, plus an assertion that
  projecting the same filtered aggregations in the `SELECT` list gives the same groups.
* `testFilteredAggregationOnlyInOrderBy` - the same defect reached through `ORDER BY`.

The full `org.apache.pinot.queries` package was run before and after the change with identical
results.

### Release note / upgrade impact

Affected queries are single-stage `GROUP BY` or aggregation queries that reference a
`FILTER (...)` aggregation only from `HAVING` or `ORDER BY`. Two things change for them:

* **Results change**, because they were previously wrong. There is no flag and no opt-out - the
  previous output cannot be reproduced by any correct plan. Dashboards built on such a query will
  move.
* **Execution shape changes.** These queries now plan the filtered operator, which builds one scan
  lane per distinct `FILTER` clause plus a main-filter lane used to materialize the groups. A
  query that previously made a single pass can now make two or more. This is the same cost the
  query already pays when the aggregation is also projected in `SELECT`. The existing
  `filteredAggregationsSkipEmptyGroups` query option now applies to these queries and can be used
  to drop the extra group-materializing lane where empty groups are not wanted.

Queries whose `FILTER` aggregations already appear in the `SELECT` list are unaffected, and the
multi-stage engine is unaffected: it lowers filtered aggregations into the leaf stage projection
and plans `HAVING` as a separate filter node.
