### PR TITLE
Match the Spark ingestion plugin name to the directory it ships in

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommand.java
@@ -327,7 +327,12 @@ public class LaunchSparkDataIngestionJobCommand extends AbstractBaseAdminCommand
   }
 
   enum SparkType {
-    SPARK_3("3.2.1", "pinot-batch-ingestion-spark-3.2", JavaVersion.JAVA_11);
+    // The plugin name must match the directory the plugin ships in, which is what
+    // shouldLoadPlugin() compares it against. It read "pinot-batch-ingestion-spark-3.2" while the
+    // module has always been pinot-batch-ingestion-spark-3, so the comparison never matched and
+    // the ingestion plugin was never selected: because its directory name contains "spark" it is
+    // first excluded, and this is the clause meant to bring it back.
+    SPARK_3("3.2.1", "pinot-batch-ingestion-spark-3", JavaVersion.JAVA_11);
 
     private final String _sparkVersion;
     private final String _pluginName;

--- a/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommandTest.java
+++ b/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommandTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.admin.command;
+
+import java.io.File;
+import org.apache.pinot.tools.admin.command.LaunchSparkDataIngestionJobCommand.SparkType;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class LaunchSparkDataIngestionJobCommandTest {
+
+  /// `shouldLoadPlugin` skips any plugin directory whose name contains "spark", so that only the
+  /// ingestion plugin for the selected Spark version is re-included, by comparing the directory
+  /// name against [SparkType#getPluginName()]. The name must therefore be the directory the plugin
+  /// actually ships in, which is its module name. It read "pinot-batch-ingestion-spark-3.2" while
+  /// the module is pinot-batch-ingestion-spark-3, so nothing ever matched and a Spark ingestion job
+  /// failed in the executor with `ClassNotFoundException: SparkSegmentGenerationJobRunner` unless
+  /// the plugin was named explicitly with `-pluginsToLoad`.
+  @Test
+  public void testSparkPluginNameMatchesAnExistingBatchIngestionModule() {
+    File batchIngestion = findBatchIngestionDir();
+    assertNotNull(batchIngestion, "could not locate pinot-plugins/pinot-batch-ingestion");
+    for (SparkType sparkType : SparkType.values()) {
+      File module = new File(batchIngestion, sparkType.getPluginName());
+      assertTrue(module.isDirectory(),
+          sparkType + " declares plugin name '" + sparkType.getPluginName() + "', which is not a module under "
+              + batchIngestion + ". shouldLoadPlugin() matches this against the plugin's directory name, so it must "
+              + "be the module name.");
+    }
+  }
+
+  /// Walks up from the working directory so the test does not care whether it is run from the
+  /// module or from the repository root.
+  private static File findBatchIngestionDir() {
+    for (File dir = new File("").getAbsoluteFile(); dir != null; dir = dir.getParentFile()) {
+      File candidate = new File(dir, "pinot-plugins/pinot-batch-ingestion");
+      if (candidate.isDirectory()) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

`SparkType.SPARK_3` declares the plugin name `pinot-batch-ingestion-spark-3.2`, but the module has always been `pinot-batch-ingestion-spark-3`.

`shouldLoadPlugin()` skips any plugin directory whose name contains `spark`, so that only the ingestion plugin for the *selected* Spark version is re-included — by comparing the directory name against `SparkType#getPluginName()`:

```java
shouldLoadPlugin = shouldLoadPlugin || _sparkVersion.getPluginName().contentEquals(parentDir);
```

Since the declared name never matches a real directory, that clause is dead and the ingestion plugin is never shipped to the executors. A Spark ingestion job then fails with:

```
Caused by: java.lang.ClassNotFoundException:
  org.apache.pinot.plugin.ingestion.batch.spark3.SparkSegmentGenerationJobRunner
    at org.apache.pinot.spi.plugin.PluginManager.createInstance(PluginManager.java:463)
    at org.apache.pinot.spi.ingestion.batch.IngestionJobLauncher.kickoffIngestionJob(IngestionJobLauncher.java:142)
```

Passing `-pluginsToLoad pinot-batch-ingestion-spark-3` explicitly is currently the only way to run one.

## Reproduction

Built a binary distribution from master and ran, with `SPARK_HOME` pointing at a Spark 3.5.9 `scala2.13` build (Pinot depends on `spark-launcher_2.13`):

```
bin/pinot-admin.sh LaunchSparkDataIngestionJob -jobSpecFile <spec> -pinotBaseDir <dist>
```

The job fails with the `ClassNotFoundException` above and produces no segments. Adding `-pluginsToLoad pinot-batch-ingestion-spark-3` gets past it.

Note that segment generation still cannot complete on a Java 25 build for an unrelated, already-known reason: Hadoop 3.4's `UserGroupInformation` calls `Subject.getSubject`, which throws on JDK 23+, and `-Djava.security.manager=allow` is rejected on JDK 25. This PR fixes the plugin selection, which is as far as the job gets before that.

## Test plan

- [x] `LaunchSparkDataIngestionJobCommandTest` asserts every `SparkType`'s plugin name resolves to a real module under `pinot-plugins/pinot-batch-ingestion`, so a rename on either side is caught instead of silently disabling the plugin again.
- [x] Verified the test fails without the fix: `SPARK_3 declares plugin name 'pinot-batch-ingestion-spark-3.2', which is not a module under .../pinot-batch-ingestion`.