### PR TITLE
Remove realtime metadata before releasing the consumer semaphore

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1198,7 +1198,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   protected SegmentBuildDescriptor buildSegmentInternal(boolean forCommit)
       throws SegmentBuildFailureException {
     if (_parallelSegmentConsumptionPolicy.isAllowedDuringBuild()) {
-      closeStreamConsumer();
+      closeStreamConsumerAndReleaseSemaphore();
     }
     // Do not allow building segment when table data manager is already shut down
     if (_realtimeTableDataManager.isShutDown()) {
@@ -1445,13 +1445,23 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     }
   }
 
+  /// Closes the stream consumer so that no more data can be consumed into this segment. Does NOT release the consumer
+  /// semaphore, see [#closeStreamConsumerAndReleaseSemaphore()] and [#doOffload()].
   private void closeStreamConsumer() {
     if (_streamConsumerClosed.compareAndSet(false, true)) {
       closePartitionGroupConsumer();
       closePartitionMetadataProvider();
-      releaseConsumerSemaphore();
       _transformPipeline.reportStats();
     }
+  }
+
+  /// Closes the stream consumer and releases the consumer semaphore so that the next consuming segment of the
+  /// partition can start consuming in parallel with the build or download of this segment. Only called when the
+  /// [ParallelSegmentConsumptionPolicy] allows it.
+  @VisibleForTesting
+  void closeStreamConsumerAndReleaseSemaphore() {
+    closeStreamConsumer();
+    releaseConsumerSemaphore();
   }
 
   private void closePartitionGroupConsumer() {
@@ -1722,7 +1732,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   protected void downloadSegmentAndReplace(SegmentZKMetadata segmentZKMetadata)
       throws Exception {
     if (_parallelSegmentConsumptionPolicy.isAllowedDuringDownload()) {
-      closeStreamConsumer();
+      closeStreamConsumerAndReleaseSemaphore();
     }
     _realtimeTableDataManager.downloadAndReplaceConsumingSegment(segmentZKMetadata);
   }
@@ -1764,9 +1774,21 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     } catch (Exception e) {
       _segmentLogger.error("Caught exception while stopping the consumer thread", e);
     }
+    // Close the stream consumer first so that nothing can consume into the segment once it is offloaded.
     closeStreamConsumer();
-    cleanupMetrics();
-    _realtimeSegment.offload();
+    // Remove this segment's upsert/dedup metadata BEFORE releasing the consumer semaphore. For partial upsert in
+    // PROTECTED consistency mode, offload() reverts the primary keys owned by this consuming segment to their previous
+    // record locations. If the semaphore were released first, the next consuming segment of the partition could start
+    // replaying while primary keys still point to this mutable segment, and merge against the un-reverted state.
+    // When the parallel consumption policy allowed the next segment to start during build or download, the semaphore
+    // was already released there and the release below is a no-op.
+    // The semaphore is released in a finally block so that a failure in metadata removal cannot stall the partition.
+    try {
+      _realtimeSegment.offload();
+    } finally {
+      releaseConsumerSemaphore();
+      cleanupMetrics();
+    }
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -29,7 +29,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.function.BooleanSupplier;
@@ -48,6 +50,7 @@ import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConsumerFactory;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamMessageDecoder;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImpl;
 import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentStatsHistory;
 import org.apache.pinot.segment.local.segment.creator.Fixtures;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
@@ -83,8 +86,11 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -649,6 +655,96 @@ public class RealtimeSegmentDataManagerTest {
       segmentDataManager.goOnlineFromConsuming(metadata);
       Assert.assertTrue(segmentDataManager._downloadAndReplaceCalled);
       Assert.assertTrue(segmentDataManager._buildAndReplaceCalled);
+    }
+  }
+
+  @Test
+  public void testOffloadRemovesSegmentMetadataBeforeReleasingConsumerSemaphore()
+      throws Exception {
+    // Use a fresh coordinator. Other tests release the shared semaphore without acquiring it, which inflates permits.
+    _partitionGroupIdToConsumerCoordinatorMap.remove(PARTITION_GROUP_ID);
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
+      Semaphore semaphore = _partitionGroupIdToConsumerCoordinatorMap.get(PARTITION_GROUP_ID).getSemaphore();
+      Assert.assertTrue(semaphore.tryAcquire());
+      segmentDataManager.getConsumerSemaphoreAcquired().set(true);
+
+      // MutableSegmentImpl.offload() removes the segment from the upsert/dedup metadata managers. For partial upsert in
+      // PROTECTED mode that is where the primary keys are reverted to their previous locations, so it has to run
+      // (1) after the stream consumer is closed, so nothing can consume into the offloaded segment, and
+      // (2) while the consumer semaphore is still held, so the next consuming segment cannot replay against
+      //     un-reverted state.
+      AtomicInteger permitsWhenMetadataRemoved = new AtomicInteger(-1);
+      AtomicBoolean streamConsumerClosedWhenMetadataRemoved = new AtomicBoolean(false);
+      MutableSegmentImpl realtimeSegment = spy((MutableSegmentImpl) segmentDataManager.getSegment());
+      doAnswer(invocation -> {
+        permitsWhenMetadataRemoved.set(semaphore.availablePermits());
+        streamConsumerClosedWhenMetadataRemoved.set(segmentDataManager.isStreamConsumerClosed());
+        return null;
+      }).when(realtimeSegment).offload();
+      segmentDataManager.setRealtimeSegment(realtimeSegment);
+
+      segmentDataManager.offload();
+
+      verify(realtimeSegment).offload();
+      Assert.assertTrue(streamConsumerClosedWhenMetadataRemoved.get(),
+          "Stream consumer must be closed before the segment metadata is removed");
+      Assert.assertEquals(permitsWhenMetadataRemoved.get(), 0,
+          "Segment metadata must be removed while the consumer semaphore is still held");
+      Assert.assertEquals(semaphore.availablePermits(), 1, "Consumer semaphore must be released after offload");
+      Assert.assertFalse(segmentDataManager.getConsumerSemaphoreAcquired().get());
+    }
+  }
+
+  @Test
+  public void testOffloadAfterParallelConsumptionReleaseDoesNotReleaseSemaphoreTwice()
+      throws Exception {
+    _partitionGroupIdToConsumerCoordinatorMap.remove(PARTITION_GROUP_ID);
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
+      Semaphore semaphore = _partitionGroupIdToConsumerCoordinatorMap.get(PARTITION_GROUP_ID).getSemaphore();
+      Assert.assertTrue(semaphore.tryAcquire());
+      segmentDataManager.getConsumerSemaphoreAcquired().set(true);
+
+      // With ALLOW_DURING_BUILD_ONLY / ALLOW_ALWAYS, buildSegmentInternal() and downloadSegmentAndReplace() let the
+      // next consuming segment start early by closing the consumer and releasing the semaphore together.
+      segmentDataManager.closeStreamConsumerAndReleaseSemaphore();
+      Assert.assertTrue(segmentDataManager.isStreamConsumerClosed());
+      Assert.assertEquals(semaphore.availablePermits(), 1,
+          "Consumer semaphore must be released for parallel consumption");
+      Assert.assertFalse(segmentDataManager.getConsumerSemaphoreAcquired().get());
+
+      MutableSegmentImpl realtimeSegment = spy((MutableSegmentImpl) segmentDataManager.getSegment());
+      doAnswer(invocation -> null).when(realtimeSegment).offload();
+      segmentDataManager.setRealtimeSegment(realtimeSegment);
+
+      segmentDataManager.offload();
+
+      verify(realtimeSegment).offload();
+      Assert.assertEquals(semaphore.availablePermits(), 1, "Offload must not release the consumer semaphore twice");
+    }
+  }
+
+  @Test
+  public void testOffloadReleasesConsumerSemaphoreWhenMetadataRemovalFails()
+      throws Exception {
+    _partitionGroupIdToConsumerCoordinatorMap.remove(PARTITION_GROUP_ID);
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
+      Semaphore semaphore = _partitionGroupIdToConsumerCoordinatorMap.get(PARTITION_GROUP_ID).getSemaphore();
+      Assert.assertTrue(semaphore.tryAcquire());
+      segmentDataManager.getConsumerSemaphoreAcquired().set(true);
+
+      MutableSegmentImpl realtimeSegment = spy((MutableSegmentImpl) segmentDataManager.getSegment());
+      doThrow(new RuntimeException("metadata removal failed")).when(realtimeSegment).offload();
+      segmentDataManager.setRealtimeSegment(realtimeSegment);
+
+      try {
+        segmentDataManager.offload();
+        Assert.fail("Expected the metadata removal failure to propagate");
+      } catch (RuntimeException e) {
+        Assert.assertEquals(e.getMessage(), "metadata removal failed");
+      }
+      // A failed metadata removal must not leave the semaphore held, or the partition can never consume again.
+      Assert.assertEquals(semaphore.availablePermits(), 1,
+          "Consumer semaphore must be released even when metadata removal fails");
     }
   }
 
@@ -1417,6 +1513,21 @@ public class RealtimeSegmentDataManagerTest {
 
     public RealtimeTableDataManager getTableDataManager() {
       return _tableDataManager;
+    }
+
+    /// Replaces the mutable segment so tests can observe or fail its offload().
+    public void setRealtimeSegment(MutableSegmentImpl realtimeSegment)
+        throws Exception {
+      Field realtimeSegmentField = RealtimeSegmentDataManager.class.getDeclaredField("_realtimeSegment");
+      realtimeSegmentField.setAccessible(true);
+      realtimeSegmentField.set(this, realtimeSegment);
+    }
+
+    public boolean isStreamConsumerClosed()
+        throws Exception {
+      Field streamConsumerClosedField = RealtimeSegmentDataManager.class.getDeclaredField("_streamConsumerClosed");
+      streamConsumerClosedField.setAccessible(true);
+      return ((AtomicBoolean) streamConsumerClosedField.get(this)).get();
     }
 
     public String getStopReason() {


### PR DESCRIPTION
## Summary

Fix the realtime offload handoff so the stream consumer is closed first, upsert/dedup metadata is removed while the partition semaphore is still held, and only then the semaphore is released.

This prevents the next consuming segment from taking its snapshot or replaying against primary-key state that still points to the mutable segment being offloaded. For partial upsert in `PROTECTED` mode, that stale state can merge an update twice.

```mermaid
flowchart LR
  A[stop and close consumer] --> B[remove segment metadata / revert]
  B --> C[release partition semaphore]
  C --> D[next segment snapshots and consumes]
```

It solves the following edgcase in upserts which can lead to data corruption

```mermaid
sequenceDiagram
  autonumber
  participant H as Helix thread
  participant Nm as N' (mutable, offloading)
  participant S as Consumer semaphore
  participant N1 as N+1' (next consumer)
  participant M as Upsert metadata (RocksDB + undo map)
  participant N as N (immutable, K base row)

  Note over M,N: Before: K -> N' at C=c2. row(N') = merge(row(N), u2). undo[K] = (N, c1). N's bit for K is off.
  H->>Nm: doOffload(): stop()
  H->>Nm: closeStreamConsumer()
  Nm->>S: release()
  Note right of S: released before the revert ran
  S-->>N1: acquire() succeeds
  N1->>N1: takeSnapshot(), consume from the cutoff
  alt N+1' reaches K first
    N1->>M: doUpdateRecord(K, C=c2)
    M-->>N1: owner N' still registered, c2 >= c2, merge row(N') with u2
    Note over N1: row(N+1') = merge(merge(row(N), u2), u2)  double count
    N1->>M: doAddRecord(K, C=c2)
    M-->>N1: owner N' is mutable, no undo entry, K -> N+1'
    H->>Nm: _realtimeSegment.offload()
    Nm->>M: removeSegment(N'), revertAndRemoveSegment
    M->>M: K owned by N+1' (mutable): warn and skip, undo[K] left behind
    Note over M,N: After: K -> N+1' with a double-merged row. N's bit for K stays off.
  else revert reaches K first
    H->>Nm: _realtimeSegment.offload()
    Nm->>M: removeSegment(N'), revertAndRemoveSegment
    M->>N: set bit for K's base row
    M->>M: K -> (N, c1), undo[K] removed
    N1->>M: doUpdateRecord(K, C=c2)
    M-->>N1: owner N, merge row(N) with u2
    Note over M,N: After: K -> N+1' with merge(row(N), u2). Same as the committer.
  end
```


## Behavior and scope

- Splits consumer close from semaphore release.
- Keeps early release unchanged for `ALLOW_DURING_BUILD_ONLY` and `ALLOW_ALWAYS` during build/download.
- Releases in `finally` if metadata removal fails, preserving partition liveness and current failure semantics.
- Moves metric cleanup after release so it is outside the protected handoff window.

The only performance impact is on offload handoff: when the semaphore has not already been released, successor startup waits for metadata removal. There is no steady-state ingestion cost.

## Tests

- `./mvnw -pl pinot-core -Dtest=RealtimeSegmentDataManagerTest test`
- Focused offload ordering, early-release idempotency, and failure-path tests
- `./mvnw spotless:apply -pl pinot-core`
- `./mvnw checkstyle:check -pl pinot-core`
- `./mvnw license:format -pl pinot-core`
- `./mvnw license:check -pl pinot-core`
- `./mvnw test-compile -pl pinot-core -Dmaven.compiler.showDeprecation=true -Dmaven.compiler.showWarnings=true`
