### PR TITLE
Remove relocation shading and stop building plugin fat jars

### DIFF
--- a/pinot-clients/pinot-java-client/pom.xml
+++ b/pinot-clients/pinot-java-client/pom.xml
@@ -53,6 +53,30 @@
           <target>11</target>
         </configuration>
       </plugin>
+      <!-- This artifact is consumed by a foreign JVM (an embedding application, or a Spark /
+           Hadoop executor), so the jackson/guava/scala it bundles are relocated to keep them
+           off the host's classpath. Pinot's own services no longer relocate anything; see the
+           note on the shade plugin in the root pom. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>com.fasterxml.jackson</pattern>
+              <shadedPattern>${shade.prefix}.com.fasterxml.jackson</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.common</pattern>
+              <shadedPattern>${shade.prefix}.com.google.common</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.scala-lang</pattern>
+              <shadedPattern>${shade.prefix}.org.scala-lang</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/pinot-clients/pinot-jdbc-client/pom.xml
+++ b/pinot-clients/pinot-jdbc-client/pom.xml
@@ -59,6 +59,30 @@
           <target>11</target>
         </configuration>
       </plugin>
+      <!-- This artifact is consumed by a foreign JVM (an embedding application, or a Spark /
+           Hadoop executor), so the jackson/guava/scala it bundles are relocated to keep them
+           off the host's classpath. Pinot's own services no longer relocate anything; see the
+           note on the shade plugin in the root pom. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>com.fasterxml.jackson</pattern>
+              <shadedPattern>${shade.prefix}.com.fasterxml.jackson</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.common</pattern>
+              <shadedPattern>${shade.prefix}.com.google.common</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.scala-lang</pattern>
+              <shadedPattern>${shade.prefix}.org.scala-lang</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/pinot-distribution/pinot-assembly.xml
+++ b/pinot-distribution/pinot-assembly.xml
@@ -47,32 +47,22 @@
     <!-- Start Include Pinot Plugins-->
     <!-- Start Include Pinot Stream Ingestion Plugins-->
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/target/pinot-kafka-3.0-${project.version}-shaded.jar
-      </source>
-      <destName>
-        plugins/pinot-stream-ingestion/pinot-kafka-3.0/pinot-kafka-3.0-${project.version}-shaded.jar
-      </destName>
+      <source>${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/target/pinot-kafka-3.0-${project.version}.jar</source>
+      <destName>plugins/pinot-stream-ingestion/pinot-kafka-3.0/pinot-kafka-3.0-${project.version}.jar</destName>
     </file>
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/target/pinot-kinesis-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-stream-ingestion/pinot-kinesis/pinot-kinesis-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/target/pinot-kinesis-${project.version}.jar</source>
+      <destName>plugins/pinot-stream-ingestion/pinot-kinesis/pinot-kinesis-${project.version}.jar</destName>
     </file>
     <file>
-      <source>${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/target/pinot-pulsar-${project.version}-shaded.jar</source>
-      <destName>plugins/pinot-stream-ingestion/pinot-pulsar/pinot-pulsar-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/target/pinot-pulsar-${project.version}.jar</source>
+      <destName>plugins/pinot-stream-ingestion/pinot-pulsar/pinot-pulsar-${project.version}.jar</destName>
     </file>
     <!-- End Include Pinot Stream Ingestion Plugins-->
     <!-- Start Include Pinot Batch Ingestion Plugins-->
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/target/pinot-batch-ingestion-standalone-${project.version}-shaded.jar
-      </source>
-      <destName>
-        plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/pinot-batch-ingestion-standalone-${project.version}-shaded.jar
-      </destName>
+      <source>${pinot.root}/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/target/pinot-batch-ingestion-standalone-${project.version}.jar</source>
+      <destName>plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/pinot-batch-ingestion-standalone-${project.version}.jar</destName>
     </file>
     <file>
       <source>
@@ -93,169 +83,323 @@
     <!-- End Include Pinot Batch Ingestion Plugins-->
     <!-- Start Include Pinot File System Plugins-->
     <file>
-      <source>${pinot.root}/pinot-plugins/pinot-file-system/pinot-adls/target/pinot-adls-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-file-system/pinot-adls/pinot-adls-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-file-system/pinot-adls/target/pinot-adls-${project.version}.jar</source>
+      <destName>plugins/pinot-file-system/pinot-adls/pinot-adls-${project.version}.jar</destName>
     </file>
     <file>
-      <source>${pinot.root}/pinot-plugins/pinot-file-system/pinot-gcs/target/pinot-gcs-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-file-system/pinot-gcs/pinot-gcs-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-file-system/pinot-gcs/target/pinot-gcs-${project.version}.jar</source>
+      <destName>plugins/pinot-file-system/pinot-gcs/pinot-gcs-${project.version}.jar</destName>
     </file>
     <file>
-      <source>${pinot.root}/pinot-plugins/pinot-file-system/pinot-hdfs/target/pinot-hdfs-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-file-system/pinot-hdfs/pinot-hdfs-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-file-system/pinot-hdfs/target/pinot-hdfs-${project.version}.jar</source>
+      <destName>plugins/pinot-file-system/pinot-hdfs/pinot-hdfs-${project.version}.jar</destName>
     </file>
     <file>
-      <source>${pinot.root}/pinot-plugins/pinot-file-system/pinot-s3/target/pinot-s3-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-file-system/pinot-s3/pinot-s3-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-file-system/pinot-s3/target/pinot-s3-${project.version}.jar</source>
+      <destName>plugins/pinot-file-system/pinot-s3/pinot-s3-${project.version}.jar</destName>
     </file>
     <!-- End Include Pinot File System Plugins-->
     <!-- Start Include Pinot Environment Plugins-->
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-environment/pinot-azure/target/pinot-azure-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-environment/pinot-azure/pinot-azure-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-environment/pinot-azure/target/pinot-azure-${project.version}.jar</source>
+      <destName>plugins/pinot-environment/pinot-azure/pinot-azure-${project.version}.jar</destName>
     </file>
     <!-- End Include Pinot Environment Plugins-->
     <!-- Start Include Pinot Input Format Plugins-->
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-input-format/pinot-avro/target/pinot-avro-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-input-format/pinot-avro/pinot-avro-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-avro/target/pinot-avro-${project.version}.jar</source>
+      <destName>plugins/pinot-input-format/pinot-avro/pinot-avro-${project.version}.jar</destName>
     </file>
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-input-format/pinot-clp-log/target/pinot-clp-log-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-input-format/pinot-clp-log/pinot-clp-log-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-clp-log/target/pinot-clp-log-${project.version}.jar</source>
+      <destName>plugins/pinot-input-format/pinot-clp-log/pinot-clp-log-${project.version}.jar</destName>
     </file>
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-input-format/pinot-confluent-avro/target/pinot-confluent-avro-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-input-format/pinot-confluent-avro/pinot-confluent-avro-${project.version}-shaded.jar
-      </destName>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-confluent-avro/target/pinot-confluent-avro-${project.version}.jar</source>
+      <destName>plugins/pinot-input-format/pinot-confluent-avro/pinot-confluent-avro-${project.version}.jar</destName>
     </file>
     <file>
-      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-csv/target/pinot-csv-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-input-format/pinot-csv/pinot-csv-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-csv/target/pinot-csv-${project.version}.jar</source>
+      <destName>plugins/pinot-input-format/pinot-csv/pinot-csv-${project.version}.jar</destName>
     </file>
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-input-format/pinot-json/target/pinot-json-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-input-format/pinot-json/pinot-json-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-json/target/pinot-json-${project.version}.jar</source>
+      <destName>plugins/pinot-input-format/pinot-json/pinot-json-${project.version}.jar</destName>
     </file>
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-input-format/pinot-bson/target/pinot-bson-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-input-format/pinot-bson/pinot-bson-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-bson/target/pinot-bson-${project.version}.jar</source>
+      <destName>plugins/pinot-input-format/pinot-bson/pinot-bson-${project.version}.jar</destName>
     </file>
     <file>
-      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-orc/target/pinot-orc-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-input-format/pinot-orc/pinot-orc-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-orc/target/pinot-orc-${project.version}.jar</source>
+      <destName>plugins/pinot-input-format/pinot-orc/pinot-orc-${project.version}.jar</destName>
     </file>
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-input-format/pinot-parquet/target/pinot-parquet-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-input-format/pinot-parquet/pinot-parquet-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-parquet/target/pinot-parquet-${project.version}.jar</source>
+      <destName>plugins/pinot-input-format/pinot-parquet/pinot-parquet-${project.version}.jar</destName>
     </file>
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-input-format/pinot-thrift/target/pinot-thrift-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-input-format/pinot-thrift/pinot-thrift-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-thrift/target/pinot-thrift-${project.version}.jar</source>
+      <destName>plugins/pinot-input-format/pinot-thrift/pinot-thrift-${project.version}.jar</destName>
     </file>
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-input-format/pinot-protobuf/target/pinot-protobuf-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-input-format/pinot-protobuf/pinot-protobuf-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-protobuf/target/pinot-protobuf-${project.version}.jar</source>
+      <destName>plugins/pinot-input-format/pinot-protobuf/pinot-protobuf-${project.version}.jar</destName>
     </file>
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-input-format/pinot-confluent-protobuf/target/pinot-confluent-protobuf-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-input-format/pinot-confluent-protobuf/pinot-confluent-protobuf-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-confluent-protobuf/target/pinot-confluent-protobuf-${project.version}.jar</source>
+      <destName>plugins/pinot-input-format/pinot-confluent-protobuf/pinot-confluent-protobuf-${project.version}.jar</destName>
     </file>
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-input-format/pinot-confluent-json/target/pinot-confluent-json-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-input-format/pinot-confluent-json/pinot-confluent-json-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-confluent-json/target/pinot-confluent-json-${project.version}.jar</source>
+      <destName>plugins/pinot-input-format/pinot-confluent-json/pinot-confluent-json-${project.version}.jar</destName>
     </file>
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-input-format/pinot-arrow/target/pinot-arrow-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-input-format/pinot-arrow/pinot-arrow-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-arrow/target/pinot-arrow-${project.version}.jar</source>
+      <destName>plugins/pinot-input-format/pinot-arrow/pinot-arrow-${project.version}.jar</destName>
     </file>
     <!-- End Include Pinot Input Format Plugins-->
     <!-- Start Include Pinot Minion Tasks Plugins-->
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/target/pinot-minion-builtin-tasks-${project.version}.jar
-      </source>
-      <destName>
-        plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/pinot-minion-builtin-tasks-${project.version}.jar
-      </destName>
+      <source>${pinot.root}/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/target/pinot-minion-builtin-tasks-${project.version}.jar</source>
+      <destName>plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/pinot-minion-builtin-tasks-${project.version}.jar</destName>
     </file>
     <!-- End Include Pinot Minion Tasks Plugins-->
     <!-- Start Include Pinot Metrics Plugins-->
     <file>
-      <source>${pinot.root}/pinot-plugins/pinot-metrics/pinot-yammer/target/pinot-yammer-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-metrics/pinot-yammer/pinot-yammer-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-metrics/pinot-yammer/target/pinot-yammer-${project.version}.jar</source>
+      <destName>plugins/pinot-metrics/pinot-yammer/pinot-yammer-${project.version}.jar</destName>
     </file>
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-metrics/pinot-dropwizard/target/pinot-dropwizard-${project.version}-shaded.jar
-      </source>
-      <destName>plugins/pinot-metrics/pinot-dropwizard/pinot-dropwizard-${project.version}-shaded.jar</destName>
+      <source>${pinot.root}/pinot-plugins/pinot-metrics/pinot-dropwizard/target/pinot-dropwizard-${project.version}.jar</source>
+      <destName>plugins/pinot-metrics/pinot-dropwizard/pinot-dropwizard-${project.version}.jar</destName>
     </file>
     <!-- End Include Pinot Metrics Plugins-->
     <!-- Start Include Pinot Segment Writer Plugins-->
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/target/pinot-segment-writer-file-based-${project.version}.jar
-      </source>
-      <destName>
-        plugins/pinot-segment-writer/pinot-segment-writer-file-based/pinot-segment-writer-file-based-${project.version}.jar
-      </destName>
+      <source>${pinot.root}/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/target/pinot-segment-writer-file-based-${project.version}.jar</source>
+      <destName>plugins/pinot-segment-writer/pinot-segment-writer-file-based/pinot-segment-writer-file-based-${project.version}.jar</destName>
     </file>
     <!-- End Include Pinot Segment Writer Plugins-->
     <!-- Start Include Pinot Segment Uploader Plugins-->
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-segment-uploader/pinot-segment-uploader-default/target/pinot-segment-uploader-default-${project.version}.jar
-      </source>
-      <destName>
-        plugins/pinot-segment-uploader/pinot-segment-uploader-default/pinot-segment-uploader-default-${project.version}.jar
-      </destName>
+      <source>${pinot.root}/pinot-plugins/pinot-segment-uploader/pinot-segment-uploader-default/target/pinot-segment-uploader-default-${project.version}.jar</source>
+      <destName>plugins/pinot-segment-uploader/pinot-segment-uploader-default/pinot-segment-uploader-default-${project.version}.jar</destName>
     </file>
     <!-- End Include Pinot Segment Uploader Plugins-->
     <!-- Start Include Pinot Time Series Plugins -->
     <file>
-      <source>
-        ${pinot.root}/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/target/pinot-timeseries-m3ql-${project.version}-shaded.jar
-      </source>
-      <destName>
-        plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pinot-timeseries-m3ql-${project.version}-shaded.jar
-      </destName>
+      <source>${pinot.root}/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/target/pinot-timeseries-m3ql-${project.version}.jar</source>
+      <destName>plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pinot-timeseries-m3ql-${project.version}.jar</destName>
     </file>
     <!-- End Include Pinot Time Series Plugins -->
     <!-- End Include Pinot Plugins-->
   </files>
   <fileSets>
+    <!--
+      Shared plugin dependency store. A plugin's runtime dependencies are copied here instead of
+      being bundled into a per-plugin fat jar, so a library used by several plugins is stored once,
+      and version skew between plugins shows up as two differently-named files rather than being
+      hidden inside uber-jars. Identical file names denote the same artifact and version, so
+      merging these fileSets is safe. The launcher puts plugin-libs/* on the classpath in the same
+      position the per-plugin fat jars used to occupy, so the effective classpath is unchanged.
+    -->
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-file-system/pinot-adls/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-file-system/pinot-gcs/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-file-system/pinot-hdfs/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-file-system/pinot-s3/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-environment/pinot-azure/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-avro/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-clp-log/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-confluent-avro/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-csv/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-json/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-bson/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-orc/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-parquet/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-thrift/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-protobuf/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-confluent-protobuf/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-confluent-json/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-arrow/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-metrics/pinot-yammer/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-metrics/pinot-dropwizard/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-segment-uploader/pinot-segment-uploader-default/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/target/plugin-libs</directory>
+      <outputDirectory>plugin-libs</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
     <!-- Rename licenses-binary directory to licenses and include it to a distribution tarbell -->
     <fileSet>
       <useDefaultExcludes>false</useDefaultExcludes>

--- a/pinot-distribution/pinot-assembly.xml
+++ b/pinot-distribution/pinot-assembly.xml
@@ -46,24 +46,8 @@
     </file>
     <!-- Start Include Pinot Plugins-->
     <!-- Start Include Pinot Stream Ingestion Plugins-->
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/target/pinot-kafka-3.0-${project.version}.jar</source>
-      <destName>plugins/pinot-stream-ingestion/pinot-kafka-3.0/pinot-kafka-3.0-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/target/pinot-kinesis-${project.version}.jar</source>
-      <destName>plugins/pinot-stream-ingestion/pinot-kinesis/pinot-kinesis-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/target/pinot-pulsar-${project.version}.jar</source>
-      <destName>plugins/pinot-stream-ingestion/pinot-pulsar/pinot-pulsar-${project.version}.jar</destName>
-    </file>
     <!-- End Include Pinot Stream Ingestion Plugins-->
     <!-- Start Include Pinot Batch Ingestion Plugins-->
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/target/pinot-batch-ingestion-standalone-${project.version}.jar</source>
-      <destName>plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/pinot-batch-ingestion-standalone-${project.version}.jar</destName>
-    </file>
     <file>
       <source>
         ${pinot.root}/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/target/pinot-batch-ingestion-hadoop-${project.version}-shaded.jar
@@ -82,120 +66,254 @@
     </file>
     <!-- End Include Pinot Batch Ingestion Plugins-->
     <!-- Start Include Pinot File System Plugins-->
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-file-system/pinot-adls/target/pinot-adls-${project.version}.jar</source>
-      <destName>plugins/pinot-file-system/pinot-adls/pinot-adls-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-file-system/pinot-gcs/target/pinot-gcs-${project.version}.jar</source>
-      <destName>plugins/pinot-file-system/pinot-gcs/pinot-gcs-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-file-system/pinot-hdfs/target/pinot-hdfs-${project.version}.jar</source>
-      <destName>plugins/pinot-file-system/pinot-hdfs/pinot-hdfs-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-file-system/pinot-s3/target/pinot-s3-${project.version}.jar</source>
-      <destName>plugins/pinot-file-system/pinot-s3/pinot-s3-${project.version}.jar</destName>
-    </file>
     <!-- End Include Pinot File System Plugins-->
     <!-- Start Include Pinot Environment Plugins-->
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-environment/pinot-azure/target/pinot-azure-${project.version}.jar</source>
-      <destName>plugins/pinot-environment/pinot-azure/pinot-azure-${project.version}.jar</destName>
-    </file>
     <!-- End Include Pinot Environment Plugins-->
     <!-- Start Include Pinot Input Format Plugins-->
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-avro/target/pinot-avro-${project.version}.jar</source>
-      <destName>plugins/pinot-input-format/pinot-avro/pinot-avro-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-clp-log/target/pinot-clp-log-${project.version}.jar</source>
-      <destName>plugins/pinot-input-format/pinot-clp-log/pinot-clp-log-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-confluent-avro/target/pinot-confluent-avro-${project.version}.jar</source>
-      <destName>plugins/pinot-input-format/pinot-confluent-avro/pinot-confluent-avro-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-csv/target/pinot-csv-${project.version}.jar</source>
-      <destName>plugins/pinot-input-format/pinot-csv/pinot-csv-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-json/target/pinot-json-${project.version}.jar</source>
-      <destName>plugins/pinot-input-format/pinot-json/pinot-json-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-bson/target/pinot-bson-${project.version}.jar</source>
-      <destName>plugins/pinot-input-format/pinot-bson/pinot-bson-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-orc/target/pinot-orc-${project.version}.jar</source>
-      <destName>plugins/pinot-input-format/pinot-orc/pinot-orc-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-parquet/target/pinot-parquet-${project.version}.jar</source>
-      <destName>plugins/pinot-input-format/pinot-parquet/pinot-parquet-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-thrift/target/pinot-thrift-${project.version}.jar</source>
-      <destName>plugins/pinot-input-format/pinot-thrift/pinot-thrift-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-protobuf/target/pinot-protobuf-${project.version}.jar</source>
-      <destName>plugins/pinot-input-format/pinot-protobuf/pinot-protobuf-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-confluent-protobuf/target/pinot-confluent-protobuf-${project.version}.jar</source>
-      <destName>plugins/pinot-input-format/pinot-confluent-protobuf/pinot-confluent-protobuf-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-confluent-json/target/pinot-confluent-json-${project.version}.jar</source>
-      <destName>plugins/pinot-input-format/pinot-confluent-json/pinot-confluent-json-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-arrow/target/pinot-arrow-${project.version}.jar</source>
-      <destName>plugins/pinot-input-format/pinot-arrow/pinot-arrow-${project.version}.jar</destName>
-    </file>
     <!-- End Include Pinot Input Format Plugins-->
     <!-- Start Include Pinot Minion Tasks Plugins-->
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/target/pinot-minion-builtin-tasks-${project.version}.jar</source>
-      <destName>plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/pinot-minion-builtin-tasks-${project.version}.jar</destName>
-    </file>
     <!-- End Include Pinot Minion Tasks Plugins-->
     <!-- Start Include Pinot Metrics Plugins-->
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-metrics/pinot-yammer/target/pinot-yammer-${project.version}.jar</source>
-      <destName>plugins/pinot-metrics/pinot-yammer/pinot-yammer-${project.version}.jar</destName>
-    </file>
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-metrics/pinot-dropwizard/target/pinot-dropwizard-${project.version}.jar</source>
-      <destName>plugins/pinot-metrics/pinot-dropwizard/pinot-dropwizard-${project.version}.jar</destName>
-    </file>
     <!-- End Include Pinot Metrics Plugins-->
     <!-- Start Include Pinot Segment Writer Plugins-->
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/target/pinot-segment-writer-file-based-${project.version}.jar</source>
-      <destName>plugins/pinot-segment-writer/pinot-segment-writer-file-based/pinot-segment-writer-file-based-${project.version}.jar</destName>
-    </file>
     <!-- End Include Pinot Segment Writer Plugins-->
     <!-- Start Include Pinot Segment Uploader Plugins-->
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-segment-uploader/pinot-segment-uploader-default/target/pinot-segment-uploader-default-${project.version}.jar</source>
-      <destName>plugins/pinot-segment-uploader/pinot-segment-uploader-default/pinot-segment-uploader-default-${project.version}.jar</destName>
-    </file>
     <!-- End Include Pinot Segment Uploader Plugins-->
     <!-- Start Include Pinot Time Series Plugins -->
-    <file>
-      <source>${pinot.root}/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/target/pinot-timeseries-m3ql-${project.version}.jar</source>
-      <destName>plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pinot-timeseries-m3ql-${project.version}.jar</destName>
-    </file>
     <!-- End Include Pinot Time Series Plugins -->
     <!-- End Include Pinot Plugins-->
   </files>
   <fileSets>
+    <!--
+      Each plugin ships its thin module jar plus pinot-plugin.classpath, the list of shared-store
+      jars it needs (one distribution-relative path per line). PluginManager still identifies a
+      plugin by the directory its jar sits in, and the index is what lets PLUGINS_INCLUDE and the
+      Spark ingestion launcher select one plugin's dependencies out of the shared store.
+    -->
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/target</directory>
+      <outputDirectory>plugins/pinot-stream-ingestion/pinot-kafka-3.0</outputDirectory>
+      <includes>
+        <include>pinot-kafka-3.0-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/target</directory>
+      <outputDirectory>plugins/pinot-stream-ingestion/pinot-kinesis</outputDirectory>
+      <includes>
+        <include>pinot-kinesis-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/target</directory>
+      <outputDirectory>plugins/pinot-stream-ingestion/pinot-pulsar</outputDirectory>
+      <includes>
+        <include>pinot-pulsar-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/target</directory>
+      <outputDirectory>plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone</outputDirectory>
+      <includes>
+        <include>pinot-batch-ingestion-standalone-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-file-system/pinot-adls/target</directory>
+      <outputDirectory>plugins/pinot-file-system/pinot-adls</outputDirectory>
+      <includes>
+        <include>pinot-adls-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-file-system/pinot-gcs/target</directory>
+      <outputDirectory>plugins/pinot-file-system/pinot-gcs</outputDirectory>
+      <includes>
+        <include>pinot-gcs-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-file-system/pinot-hdfs/target</directory>
+      <outputDirectory>plugins/pinot-file-system/pinot-hdfs</outputDirectory>
+      <includes>
+        <include>pinot-hdfs-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-file-system/pinot-s3/target</directory>
+      <outputDirectory>plugins/pinot-file-system/pinot-s3</outputDirectory>
+      <includes>
+        <include>pinot-s3-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-environment/pinot-azure/target</directory>
+      <outputDirectory>plugins/pinot-environment/pinot-azure</outputDirectory>
+      <includes>
+        <include>pinot-azure-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-avro/target</directory>
+      <outputDirectory>plugins/pinot-input-format/pinot-avro</outputDirectory>
+      <includes>
+        <include>pinot-avro-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-clp-log/target</directory>
+      <outputDirectory>plugins/pinot-input-format/pinot-clp-log</outputDirectory>
+      <includes>
+        <include>pinot-clp-log-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-confluent-avro/target</directory>
+      <outputDirectory>plugins/pinot-input-format/pinot-confluent-avro</outputDirectory>
+      <includes>
+        <include>pinot-confluent-avro-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-csv/target</directory>
+      <outputDirectory>plugins/pinot-input-format/pinot-csv</outputDirectory>
+      <includes>
+        <include>pinot-csv-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-json/target</directory>
+      <outputDirectory>plugins/pinot-input-format/pinot-json</outputDirectory>
+      <includes>
+        <include>pinot-json-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-bson/target</directory>
+      <outputDirectory>plugins/pinot-input-format/pinot-bson</outputDirectory>
+      <includes>
+        <include>pinot-bson-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-orc/target</directory>
+      <outputDirectory>plugins/pinot-input-format/pinot-orc</outputDirectory>
+      <includes>
+        <include>pinot-orc-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-parquet/target</directory>
+      <outputDirectory>plugins/pinot-input-format/pinot-parquet</outputDirectory>
+      <includes>
+        <include>pinot-parquet-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-thrift/target</directory>
+      <outputDirectory>plugins/pinot-input-format/pinot-thrift</outputDirectory>
+      <includes>
+        <include>pinot-thrift-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-protobuf/target</directory>
+      <outputDirectory>plugins/pinot-input-format/pinot-protobuf</outputDirectory>
+      <includes>
+        <include>pinot-protobuf-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-confluent-protobuf/target</directory>
+      <outputDirectory>plugins/pinot-input-format/pinot-confluent-protobuf</outputDirectory>
+      <includes>
+        <include>pinot-confluent-protobuf-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-confluent-json/target</directory>
+      <outputDirectory>plugins/pinot-input-format/pinot-confluent-json</outputDirectory>
+      <includes>
+        <include>pinot-confluent-json-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-input-format/pinot-arrow/target</directory>
+      <outputDirectory>plugins/pinot-input-format/pinot-arrow</outputDirectory>
+      <includes>
+        <include>pinot-arrow-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/target</directory>
+      <outputDirectory>plugins/pinot-minion-tasks/pinot-minion-builtin-tasks</outputDirectory>
+      <includes>
+        <include>pinot-minion-builtin-tasks-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-metrics/pinot-yammer/target</directory>
+      <outputDirectory>plugins/pinot-metrics/pinot-yammer</outputDirectory>
+      <includes>
+        <include>pinot-yammer-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-metrics/pinot-dropwizard/target</directory>
+      <outputDirectory>plugins/pinot-metrics/pinot-dropwizard</outputDirectory>
+      <includes>
+        <include>pinot-dropwizard-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/target</directory>
+      <outputDirectory>plugins/pinot-segment-writer/pinot-segment-writer-file-based</outputDirectory>
+      <includes>
+        <include>pinot-segment-writer-file-based-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-segment-uploader/pinot-segment-uploader-default/target</directory>
+      <outputDirectory>plugins/pinot-segment-uploader/pinot-segment-uploader-default</outputDirectory>
+      <includes>
+        <include>pinot-segment-uploader-default-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${pinot.root}/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/target</directory>
+      <outputDirectory>plugins/pinot-timeseries-lang/pinot-timeseries-m3ql</outputDirectory>
+      <includes>
+        <include>pinot-timeseries-m3ql-${project.version}.jar</include>
+        <include>pinot-plugin.classpath</include>
+      </includes>
+    </fileSet>
     <!--
       Shared plugin dependency store. A plugin's runtime dependencies are copied here instead of
       being bundled into a per-plugin fat jar, so a library used by several plugins is stored once,

--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -45,6 +45,11 @@
         plugins/ with its dependencies in plugin-libs/. The copy in the uber-jar also wins on the
         classpath, so the plugin directory would be dead weight for exactly these plugins.
 
+        A plugin may only be excluded here if the distribution ships it under plugins/, otherwise it
+        would disappear from the distribution entirely rather than move: pinot-compound-metrics is
+        not in the plugin list below, so it stays in the uber-jar, which is the only place it has
+        ever been available from.
+
         Only plugins pinot-tools never references at compile time are excluded. It genuinely
         imports classes from pinot-avro, pinot-json, pinot-parquet and pinot-minion-builtin-tasks,
         which therefore stay; removing those needs the shared classes extracted into library
@@ -108,10 +113,6 @@
         <exclusion>
           <groupId>org.apache.pinot</groupId>
           <artifactId>pinot-dropwizard</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.pinot</groupId>
-          <artifactId>pinot-compound-metrics</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -38,6 +38,82 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-tools</artifactId>
+      <!--
+        pinot-tools depends on plugin modules even though ideally it would not; see the comment on
+        its dependencies. Without these exclusions the distribution ships each of those plugins
+        twice: once shaded into lib/pinot-all.jar through pinot-tools, and once as the plugin under
+        plugins/ with its dependencies in plugin-libs/. The copy in the uber-jar also wins on the
+        classpath, so the plugin directory would be dead weight for exactly these plugins.
+
+        Only plugins pinot-tools never references at compile time are excluded. It genuinely
+        imports classes from pinot-avro, pinot-json, pinot-parquet and pinot-minion-builtin-tasks,
+        which therefore stay; removing those needs the shared classes extracted into library
+        modules first. Everything listed here is reached by fully-qualified name at runtime and is
+        loaded from plugins/ instead.
+
+        Declaring the dependencies `provided` in pinot-tools would keep this list next to what it
+        describes and would be the better mechanism, but `provided` is not on the runtime
+        classpath, so quickstarts needing these plugins would no longer start from Maven or an IDE.
+        This list is the cost of keeping that working; it must stay in step with pinot-tools.
+      -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.pinot</groupId>
+          <artifactId>pinot-kafka-3.0</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.pinot</groupId>
+          <artifactId>pinot-kinesis</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.pinot</groupId>
+          <artifactId>pinot-pulsar</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.pinot</groupId>
+          <artifactId>pinot-batch-ingestion-standalone</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.pinot</groupId>
+          <artifactId>pinot-s3</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.pinot</groupId>
+          <artifactId>pinot-confluent-avro</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.pinot</groupId>
+          <artifactId>pinot-csv</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.pinot</groupId>
+          <artifactId>pinot-protobuf</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.pinot</groupId>
+          <artifactId>pinot-bson</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.pinot</groupId>
+          <artifactId>pinot-orc</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.pinot</groupId>
+          <artifactId>pinot-thrift</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.pinot</groupId>
+          <artifactId>pinot-yammer</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.pinot</groupId>
+          <artifactId>pinot-dropwizard</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.pinot</groupId>
+          <artifactId>pinot-compound-metrics</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/pom.xml
@@ -63,6 +63,35 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <!-- This artifact is consumed by a foreign JVM (an embedding application, or a Spark /
+           Hadoop executor), so the jackson/guava/scala it bundles are relocated to keep them
+           off the host's classpath. Pinot's own services no longer relocate anything; see the
+           note on the shade plugin in the root pom. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>com.fasterxml.jackson</pattern>
+              <shadedPattern>${shade.prefix}.com.fasterxml.jackson</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.common</pattern>
+              <shadedPattern>${shade.prefix}.com.google.common</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.scala-lang</pattern>
+              <shadedPattern>${shade.prefix}.org.scala-lang</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>pinot-fastdev</id>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pom.xml
@@ -77,6 +77,35 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <!-- This artifact is consumed by a foreign JVM (an embedding application, or a Spark /
+           Hadoop executor), so the jackson/guava/scala it bundles are relocated to keep them
+           off the host's classpath. Pinot's own services no longer relocate anything; see the
+           note on the shade plugin in the root pom. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>com.fasterxml.jackson</pattern>
+              <shadedPattern>${shade.prefix}.com.fasterxml.jackson</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.common</pattern>
+              <shadedPattern>${shade.prefix}.com.google.common</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.scala-lang</pattern>
+              <shadedPattern>${shade.prefix}.org.scala-lang</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>pinot-fastdev</id>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-base/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-base/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>
@@ -41,13 +40,4 @@
       <artifactId>pinot-batch-ingestion-common</artifactId>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>
@@ -48,13 +47,4 @@
     </dependency>
 
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-environment/pinot-azure/pom.xml
+++ b/pinot-plugins/pinot-environment/pinot-azure/pom.xml
@@ -31,7 +31,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>
@@ -40,13 +39,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -31,7 +31,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>
@@ -43,13 +42,4 @@
       <artifactId>azure-identity</artifactId>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-file-system/pinot-gcs/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>
@@ -89,13 +88,4 @@
       <artifactId>jersey-server</artifactId>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/pom.xml
@@ -31,7 +31,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>
@@ -52,13 +51,4 @@
       <artifactId>hadoop-shaded-protobuf_3_25</artifactId>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
@@ -58,25 +58,4 @@
       <artifactId>guava</artifactId>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <property>
-          <name>skipShade</name>
-          <value>!true</value>
-        </property>
-      </activation>
-      <properties>
-        <shade.phase.prop>package</shade.phase.prop>
-      </properties>
-    </profile>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-arrow/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>
@@ -62,13 +61,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/pom.xml
@@ -32,16 +32,5 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
-
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-avro/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-avro/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>
@@ -41,13 +40,4 @@
       <artifactId>pinot-avro-base</artifactId>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-bson/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-bson/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>
@@ -41,13 +40,4 @@
       <artifactId>bson</artifactId>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>
@@ -51,13 +50,4 @@
       <artifactId>clp-ffi</artifactId>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-confluent-avro/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-confluent-avro/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <repositories>
     <repository>
@@ -58,13 +57,4 @@
       <artifactId>kafka-avro-serializer</artifactId>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-confluent-json/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-confluent-json/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <repositories>
     <repository>
@@ -94,13 +93,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-confluent-protobuf/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-confluent-protobuf/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <repositories>
     <repository>
@@ -88,13 +87,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-csv/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-csv/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>
@@ -41,13 +40,4 @@
       <artifactId>commons-csv</artifactId>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-json/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-json/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>
@@ -46,13 +45,4 @@
       <artifactId>jackson-dataformat-cbor</artifactId>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>
@@ -81,13 +80,4 @@
       <artifactId>protobuf-java</artifactId>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>
@@ -78,13 +77,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-client-runtime</artifactId>
+      <artifactId>hadoop-common</artifactId>
       <scope>${hadoop.dependencies.scope}</scope>
     </dependency>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
@@ -33,7 +33,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>
@@ -68,13 +67,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-thrift/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-thrift/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>
@@ -41,13 +40,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-metrics/pinot-compound-metrics/pom.xml
+++ b/pinot-plugins/pinot-metrics/pinot-compound-metrics/pom.xml
@@ -59,6 +59,9 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-spi</artifactId>
+      <!-- The parent pom already declares pinot-spi as provided; keep that scope rather than
+           overriding it to compile, which would bundle it into the plugin -->
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.auto.service</groupId>

--- a/pinot-plugins/pinot-metrics/pinot-dropwizard/pom.xml
+++ b/pinot-plugins/pinot-metrics/pinot-dropwizard/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>
@@ -82,13 +81,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-metrics/pinot-yammer/pom.xml
+++ b/pinot-plugins/pinot-metrics/pinot-yammer/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>
@@ -78,13 +77,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/pom.xml
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/pom.xml
@@ -38,6 +38,10 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-materialized-view</artifactId>
+      <!-- Provided for the same reason as pinot-spi in the parent pom: Pinot's own modules are already
+           present wherever a plugin is loaded, and bundling this one also pulled in fastutil,
+           calcite-core and grpc-netty-shaded -->
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>
@@ -106,13 +105,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>
@@ -82,13 +81,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>
@@ -72,13 +71,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
@@ -38,6 +38,11 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-common</artifactId>
+      <!-- Pinot's own modules are always present where a plugin is loaded, from lib/pinot-all.jar or
+           the parent realm, so bundling them into the plugin would ship a second copy of them and of
+           their dependency tree - here fastutil, calcite-core and grpc-netty-shaded, none of which
+           this plugin uses directly -->
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
@@ -66,25 +66,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <property>
-          <name>skipShade</name>
-          <value>!true</value>
-        </property>
-      </activation>
-      <properties>
-        <shade.phase.prop>package</shade.phase.prop>
-      </properties>
-    </profile>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
 
   <properties>
-    <shade.phase.prop>package</shade.phase.prop>
     <pinot.root>${basedir}/../../..</pinot.root>
   </properties>
 
@@ -58,13 +57,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pom.xml
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pom.xml
@@ -75,25 +75,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <property>
-          <name>skipShade</name>
-          <value>!true</value>
-        </property>
-      </activation>
-      <properties>
-        <shade.phase.prop>package</shade.phase.prop>
-      </properties>
-    </profile>
-    <profile>
-      <id>pinot-fastdev</id>
-      <properties>
-        <shade.phase.prop>none</shade.phase.prop>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -138,6 +138,26 @@
                   <includeScope>runtime</includeScope>
                 </configuration>
               </execution>
+              <execution>
+                <!--
+                  Record which jars in the shared store belong to this plugin, one
+                  distribution-relative path per line. The store itself cannot answer that
+                  question, and several consumers need it: the launcher when PLUGINS_INCLUDE
+                  selects a subset of plugins, and LaunchSparkDataIngestionJobCommand when
+                  -pluginsToLoad / -pluginsToExclude decide what to ship to the executors.
+                -->
+                <id>plugin-classpath-index</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>build-classpath</goal>
+                </goals>
+                <configuration>
+                  <outputFile>${project.build.directory}/pinot-plugin.classpath</outputFile>
+                  <includeScope>runtime</includeScope>
+                  <prefix>plugin-libs</prefix>
+                  <pathSeparator>&#10;</pathSeparator>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -111,6 +111,39 @@
       </build>
     </profile>
     <profile>
+      <!--
+        Collect each plugin's runtime dependencies into target/plugin-libs so the distribution
+        assembly can place them all in the shared plugin-libs/ directory. Plugins no longer bundle
+        their dependencies into a fat jar, so this is how those jars reach the tarball. Scoped to
+        bin-dist because only a binary distribution build needs it; a plain `mvn install` pays
+        nothing.
+      -->
+      <id>bin-dist</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>collect-plugin-libs</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${project.build.directory}/plugin-libs</outputDirectory>
+                  <!-- compile + runtime; `provided` deps such as pinot-spi stay out, they are
+                       already in lib/pinot-all.jar -->
+                  <includeScope>runtime</includeScope>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>use-provided-hadoop</id>
       <activation>
         <property>

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -49,6 +49,25 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-minion</artifactId>
     </dependency>
+    <!--
+      pinot-tools depends on plugin modules, and ideally it would not. The quickstarts and the
+      admin commands reach for plugin classes: a few by import (pinot-avro, pinot-json,
+      pinot-parquet, pinot-minion-builtin-tasks below), but most only by fully-qualified name at
+      runtime, through a table config, a job spec or a ServiceLoader lookup.
+
+      The consequence is that a binary distribution would carry these plugins twice: once shaded
+      into lib/pinot-all.jar because pinot-tools pulls them in, and once as the plugin itself under
+      plugins/ with its dependencies in plugin-libs/. pinot-distribution therefore excludes the
+      ones pinot-tools does not actually compile against, and its pom carries the list; see the
+      comment on its pinot-tools dependency.
+
+      Declaring these `provided` here would be cleaner than excluding them there, because the list
+      would live in one place next to the dependencies it describes. It is not done because
+      `provided` is absent from the runtime classpath, so every quickstart that needs one of these
+      plugins would stop working when launched from Maven or an IDE, where there is no plugins/
+      directory for PluginManager to load them from. If that trade is ever acceptable, `provided`
+      is the better mechanism.
+    -->
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-minion-builtin-tasks</artifactId>

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommand.java
@@ -18,15 +18,22 @@
  */
 package org.apache.pinot.tools.admin.command;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
@@ -55,6 +62,13 @@ public class LaunchSparkDataIngestionJobCommand extends AbstractBaseAdminCommand
   public static final String BASEDIR = "basedir";
   public static final String LOCAL_FILE_PREFIX = "local://";
   public static final String PINOT_MAIN_JAR_PREFIX = "pinot-all";
+  /// Directory holding plugin dependencies that are shared between plugins, stored once each.
+  /// Its jars cannot be attributed to a plugin by their location, so they are never added by
+  /// walking the directory; they are added from the index of each selected plugin instead.
+  private static final String SHARED_PLUGIN_LIBS_DIR = "plugin-libs";
+  /// Written next to a plugin's jar at build time: the shared-store jars that plugin needs, as
+  /// distribution-relative paths in classpath form.
+  private static final String PLUGIN_CLASSPATH_INDEX = "pinot-plugin.classpath";
 
   @CommandLine.Option(names = {"-jobSpecFile", "-jobSpec"}, required = true, description = "Ingestion job spec file")
   private String _jobSpecFile;
@@ -253,18 +267,54 @@ public class LaunchSparkDataIngestionJobCommand extends AbstractBaseAdminCommand
       }
       PinotFS pinotFS = PinotFSFactory.create(depsJarDirURI.getScheme());
       String[] files = pinotFS.listFiles(depsJarDirURI, true);
+      Set<String> added = new LinkedHashSet<>();
       for (String file : files) {
-        if (!pinotFS.isDirectory(URI.create(file))) {
-          if (file.endsWith(".jar")) {
-            String parentDir = FilenameUtils.getName(file.substring(0, file.lastIndexOf('/')));
-
-            if (shouldLoadPlugin(parentDir)) {
-              addJarFilePath(sparkLauncher, extraClassPath, file);
+        if (pinotFS.isDirectory(URI.create(file))) {
+          continue;
+        }
+        String parentDir = FilenameUtils.getName(file.substring(0, file.lastIndexOf('/')));
+        if (file.endsWith(".jar")) {
+          // Shared-store jars are deliberately skipped here: the directory says nothing about
+          // which plugin needs them, so shipping it wholesale would ignore -pluginsToLoad and
+          // -pluginsToExclude. They arrive through the indexes handled below.
+          if (!SHARED_PLUGIN_LIBS_DIR.equals(parentDir) && shouldLoadPlugin(parentDir) && added.add(file)) {
+            addJarFilePath(sparkLauncher, extraClassPath, file);
+          }
+        } else if (PLUGIN_CLASSPATH_INDEX.equals(FilenameUtils.getName(file)) && shouldLoadPlugin(parentDir)) {
+          for (String dep : readPluginClasspathIndex(pinotFS, file)) {
+            String depFile = depsJarDir.endsWith("/") ? depsJarDir + dep : depsJarDir + "/" + dep;
+            if (added.add(depFile)) {
+              addJarFilePath(sparkLauncher, extraClassPath, depFile);
             }
           }
         }
       }
     }
+  }
+
+  /// Reads a plugin's shared-store dependency list. A plugin with no index (an old-format plugin
+  /// that keeps its own jars beside it) simply contributes nothing here, and an unreadable index
+  /// is logged rather than failing the submit - the plugin's own jars have already been added.
+  @VisibleForTesting
+  List<String> readPluginClasspathIndex(PinotFS pinotFS, String indexFile) {
+    List<String> deps = new ArrayList<>();
+    try (InputStream in = pinotFS.open(URI.create(indexFile));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        // The index is a classpath fragment, so entries may be ':'-separated as well as split
+        // across lines.
+        for (String entry : line.split(":")) {
+          String dep = entry.trim();
+          if (!dep.isEmpty()) {
+            deps.add(dep);
+          }
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Failed to read plugin classpath index: {}", indexFile, e);
+    }
+    return deps;
   }
 
   private boolean shouldLoadPlugin(String parentDir) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommand.java
@@ -134,6 +134,21 @@ public class LaunchSparkDataIngestionJobCommand extends AbstractBaseAdminCommand
     _propertyFile = propertyFile;
   }
 
+  @VisibleForTesting
+  void setSparkVersion(SparkType sparkVersion) {
+    _sparkVersion = sparkVersion;
+  }
+
+  @VisibleForTesting
+  void setPluginsToLoad(List<String> pluginsToLoad) {
+    _pluginsToLoad = pluginsToLoad;
+  }
+
+  @VisibleForTesting
+  void setPluginsToExclude(List<String> pluginsToExclude) {
+    _pluginsToExclude = pluginsToExclude;
+  }
+
   public void setAuthProvider(AuthProvider authProvider) {
     _authProvider = authProvider;
   }
@@ -260,36 +275,45 @@ public class LaunchSparkDataIngestionJobCommand extends AbstractBaseAdminCommand
 
   private void addDepsJarToDistributedCache(SparkLauncher sparkLauncher, String depsJarDir, List<String> extraClassPath)
       throws IOException {
-    if (depsJarDir != null) {
-      URI depsJarDirURI = URI.create(depsJarDir);
-      if (depsJarDirURI.getScheme() == null) {
-        depsJarDirURI = new File(depsJarDir).toURI();
+    for (String jar : resolveDepsJars(depsJarDir)) {
+      addJarFilePath(sparkLauncher, extraClassPath, jar);
+    }
+  }
+
+  /// Works out which jars under the Pinot installation should be shipped to the executors, honouring
+  /// [#shouldLoadPlugin]. A plugin is identified by the directory its jar sits in, so the shared
+  /// dependency store is a special case: every jar in it has the same parent directory and belongs
+  /// to no single plugin, and adding it wholesale would ignore `-pluginsToLoad` and
+  /// `-pluginsToExclude` entirely. Those jars are therefore reached only through the
+  /// `pinot-plugin.classpath` index of a plugin that was selected.
+  @VisibleForTesting
+  List<String> resolveDepsJars(String depsJarDir)
+      throws IOException {
+    Set<String> resolved = new LinkedHashSet<>();
+    if (depsJarDir == null) {
+      return new ArrayList<>(resolved);
+    }
+    URI depsJarDirURI = URI.create(depsJarDir);
+    if (depsJarDirURI.getScheme() == null) {
+      depsJarDirURI = new File(depsJarDir).toURI();
+    }
+    PinotFS pinotFS = PinotFSFactory.create(depsJarDirURI.getScheme());
+    for (String file : pinotFS.listFiles(depsJarDirURI, true)) {
+      if (pinotFS.isDirectory(URI.create(file))) {
+        continue;
       }
-      PinotFS pinotFS = PinotFSFactory.create(depsJarDirURI.getScheme());
-      String[] files = pinotFS.listFiles(depsJarDirURI, true);
-      Set<String> added = new LinkedHashSet<>();
-      for (String file : files) {
-        if (pinotFS.isDirectory(URI.create(file))) {
-          continue;
+      String parentDir = FilenameUtils.getName(file.substring(0, file.lastIndexOf('/')));
+      if (file.endsWith(".jar")) {
+        if (!SHARED_PLUGIN_LIBS_DIR.equals(parentDir) && shouldLoadPlugin(parentDir)) {
+          resolved.add(file);
         }
-        String parentDir = FilenameUtils.getName(file.substring(0, file.lastIndexOf('/')));
-        if (file.endsWith(".jar")) {
-          // Shared-store jars are deliberately skipped here: the directory says nothing about
-          // which plugin needs them, so shipping it wholesale would ignore -pluginsToLoad and
-          // -pluginsToExclude. They arrive through the indexes handled below.
-          if (!SHARED_PLUGIN_LIBS_DIR.equals(parentDir) && shouldLoadPlugin(parentDir) && added.add(file)) {
-            addJarFilePath(sparkLauncher, extraClassPath, file);
-          }
-        } else if (PLUGIN_CLASSPATH_INDEX.equals(FilenameUtils.getName(file)) && shouldLoadPlugin(parentDir)) {
-          for (String dep : readPluginClasspathIndex(pinotFS, file)) {
-            String depFile = depsJarDir.endsWith("/") ? depsJarDir + dep : depsJarDir + "/" + dep;
-            if (added.add(depFile)) {
-              addJarFilePath(sparkLauncher, extraClassPath, depFile);
-            }
-          }
+      } else if (PLUGIN_CLASSPATH_INDEX.equals(FilenameUtils.getName(file)) && shouldLoadPlugin(parentDir)) {
+        for (String dep : readPluginClasspathIndex(pinotFS, file)) {
+          resolved.add(depsJarDir.endsWith("/") ? depsJarDir + dep : depsJarDir + "/" + dep);
         }
       }
     }
+    return new ArrayList<>(resolved);
   }
 
   /// Reads a plugin's shared-store dependency list. A plugin with no index (an old-format plugin

--- a/pinot-tools/src/main/resources/appAssemblerScriptTemplate
+++ b/pinot-tools/src/main/resources/appAssemblerScriptTemplate
@@ -162,6 +162,14 @@ if [ -n "$PLUGINS_CLASSPATH" ] ; then
   CLASSPATH=$CLASSPATH:$PLUGINS_CLASSPATH
 fi
 
+# Shared plugin dependency store. Plugins ship as a thin jar plus their dependencies in
+# plugin-libs/, where a library needed by several plugins is stored once, instead of each plugin
+# bundling its own copy into a fat jar. Appended after the plugin jars so the effective classpath
+# matches the old fat-jar layout. Absent from custom layouts, hence the directory check.
+if [ -d "$BASEDIR"/plugin-libs ] ; then
+  CLASSPATH=$CLASSPATH:"$BASEDIR"/plugin-libs/*
+fi
+
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
   [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --windows "$CLASSPATH"`

--- a/pinot-tools/src/main/resources/appAssemblerScriptTemplate
+++ b/pinot-tools/src/main/resources/appAssemblerScriptTemplate
@@ -112,6 +112,11 @@ fi
 # $PLUGINS_DIR is semi-colon separated list of plugin directories, default to '"$BASEDIR"/plugins' if not set.
 # $PLUGINS_INCLUDE is semi-colon separated plugins name, e.g. pinot-avro;pinot-batch-ingestion-standalone. Default is not set, which means load all the plugin jars.
 # If the same plugin is found in multiple directories, it will only be picked up from the first directory it was found. The directories in $PLUGINS_DIR are traversed by their order.
+#
+# A plugin ships as a thin jar plus a pinot-plugin.classpath file listing the shared-store jars it
+# needs, as distribution-relative paths. Selecting a subset with $PLUGINS_INCLUDE therefore
+# means taking each named plugin's jars *and* the store entries its index names - the store as a
+# whole is not per-plugin, so adding all of it would defeat the selection.
 if [ -z "$PLUGINS_CLASSPATH" ] ; then
   if [ -z "$PLUGINS_DIR" ] ; then
     PLUGINS_DIR="$BASEDIR"/plugins
@@ -134,13 +139,28 @@ if [ -z "$PLUGINS_CLASSPATH" ] ; then
             exit 1
         fi
         export IFS=';'
-        for PLUGIN_JAR in $PLUGINS_INCLUDE; do
-            PLUGIN_JAR_PATH=$(find "$DIR" -path \*/"$PLUGIN_JAR"/"$PLUGIN_JAR"-\*.jar)
-            if [ -n "$PLUGINS_CLASSPATH" ] ; then
-              PLUGINS_CLASSPATH=$PLUGINS_CLASSPATH:$PLUGIN_JAR_PATH
-            else
-              PLUGINS_CLASSPATH=$PLUGIN_JAR_PATH
-            fi
+        for PLUGIN_NAME in $PLUGINS_INCLUDE; do
+            unset IFS
+            for PLUGIN_JAR_PATH in $(find "$DIR" -path \*/"$PLUGIN_NAME"/\*.jar) ; do
+              if [ -n "$PLUGINS_CLASSPATH" ] ; then
+                PLUGINS_CLASSPATH=$PLUGINS_CLASSPATH:$PLUGIN_JAR_PATH
+              else
+                PLUGINS_CLASSPATH=$PLUGIN_JAR_PATH
+              fi
+            done
+            # Add the shared-store jars this plugin declares. Paths are relative to $BASEDIR.
+            for PLUGIN_INDEX in $(find "$DIR" -path \*/"$PLUGIN_NAME"/pinot-plugin.classpath) ; do
+              # The index is a classpath fragment: entries separated by ':' and/or newlines.
+              for PLUGIN_DEP in $(tr ':' '\n' < "$PLUGIN_INDEX") ; do
+                if [ -n "$PLUGIN_DEP" ] && [ -f "$BASEDIR/$PLUGIN_DEP" ] ; then
+                  case ":$PLUGINS_CLASSPATH:" in
+                    *":$BASEDIR/$PLUGIN_DEP:"*) ;;
+                    *) PLUGINS_CLASSPATH=${PLUGINS_CLASSPATH:+$PLUGINS_CLASSPATH:}$BASEDIR/$PLUGIN_DEP ;;
+                  esac
+                fi
+              done
+            done
+            export IFS=';'
         done
         unset IFS
       else
@@ -152,6 +172,10 @@ if [ -z "$PLUGINS_CLASSPATH" ] ; then
             PLUGINS_CLASSPATH=$PLUGIN_JAR
           fi
         done
+        # No selection was made, so every plugin is loaded and the whole shared store is needed.
+        if [ -d "$BASEDIR"/plugin-libs ] ; then
+          PLUGINS_CLASSPATH=${PLUGINS_CLASSPATH:+$PLUGINS_CLASSPATH:}"$BASEDIR"/plugin-libs/*
+        fi
       fi
     fi
   done
@@ -160,14 +184,6 @@ fi
 
 if [ -n "$PLUGINS_CLASSPATH" ] ; then
   CLASSPATH=$CLASSPATH:$PLUGINS_CLASSPATH
-fi
-
-# Shared plugin dependency store. Plugins ship as a thin jar plus their dependencies in
-# plugin-libs/, where a library needed by several plugins is stored once, instead of each plugin
-# bundling its own copy into a fat jar. Appended after the plugin jars so the effective classpath
-# matches the old fat-jar layout. Absent from custom layouts, hence the directory check.
-if [ -d "$BASEDIR"/plugin-libs ] ; then
-  CLASSPATH=$CLASSPATH:"$BASEDIR"/plugin-libs/*
 fi
 
 # For Cygwin, switch paths to Windows format before running java

--- a/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommandTest.java
+++ b/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommandTest.java
@@ -22,7 +22,9 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
 import org.apache.pinot.tools.admin.command.LaunchSparkDataIngestionJobCommand.SparkType;
 import org.testng.annotations.AfterClass;
@@ -30,11 +32,15 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
-/// accepts newline-separated entries so the format can change without breaking the Spark submit.
+/// Covers how a Spark ingestion job decides which jars to ship to the executors, and how it reads
+/// the per-plugin shared-store dependency index. `dependency:build-classpath` writes that index as a
+/// classpath fragment, so entries arrive ':'-separated on one line; the reader also accepts
+/// newline-separated entries so the format can change without breaking the Spark submit.
 public class LaunchSparkDataIngestionJobCommandTest {
   private File _tempDir;
   private LocalPinotFS _fs;
@@ -59,6 +65,127 @@ public class LaunchSparkDataIngestionJobCommandTest {
     File f = new File(_tempDir, name);
     Files.write(f.toPath(), content.getBytes(StandardCharsets.UTF_8));
     return f.getAbsolutePath();
+  }
+
+  /// Builds a distribution-shaped tree: core in lib/, one thin jar per plugin under
+  /// plugins/<type>/<name>/ with its shared-store index beside it, the shared store in
+  /// plugin-libs/, and the external-process plugins under plugins-external/.
+  private File buildDistribution()
+      throws Exception {
+    File dist = new File(_tempDir, "dist-" + System.nanoTime());
+    for (String d : List.of("lib", "plugin-libs", "plugins/pinot-input-format/pinot-json",
+        "plugins/pinot-stream-ingestion/pinot-kafka-3.0", "plugins/pinot-file-system/pinot-s3",
+        "plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3")) {
+      FileUtils.forceMkdir(new File(dist, d));
+    }
+    for (String f : List.of("lib/pinot-all-1.0.jar",
+        "plugin-libs/jackson-core-2.22.jar", "plugin-libs/kafka-clients-3.9.jar",
+        "plugin-libs/scala-library-2.13.jar", "plugin-libs/s3-2.54.jar",
+        "plugins/pinot-input-format/pinot-json/pinot-json-1.0.jar",
+        "plugins/pinot-stream-ingestion/pinot-kafka-3.0/pinot-kafka-3.0-1.0.jar",
+        "plugins/pinot-file-system/pinot-s3/pinot-s3-1.0.jar",
+        "plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/spark3-1.0-shaded.jar")) {
+      FileUtils.touch(new File(dist, f));
+    }
+    Files.write(new File(dist, "plugins/pinot-input-format/pinot-json/pinot-plugin.classpath").toPath(),
+        "plugin-libs/jackson-core-2.22.jar".getBytes(StandardCharsets.UTF_8));
+    Files.write(new File(dist, "plugins/pinot-stream-ingestion/pinot-kafka-3.0/pinot-plugin.classpath").toPath(),
+        "plugin-libs/kafka-clients-3.9.jar:plugin-libs/scala-library-2.13.jar".getBytes(StandardCharsets.UTF_8));
+    Files.write(new File(dist, "plugins/pinot-file-system/pinot-s3/pinot-plugin.classpath").toPath(),
+        "plugin-libs/s3-2.54.jar:plugin-libs/jackson-core-2.22.jar".getBytes(StandardCharsets.UTF_8));
+    return dist;
+  }
+
+  /// picocli applies the option defaults when parsing a command line; a directly constructed
+  /// instance has none, so tests set the ones the selection logic reads.
+  private static LaunchSparkDataIngestionJobCommand commandWithCliDefaults() {
+    LaunchSparkDataIngestionJobCommand cmd = new LaunchSparkDataIngestionJobCommand();
+    cmd.setSparkVersion(LaunchSparkDataIngestionJobCommand.SparkType.SPARK_3);
+    cmd.setPluginsToExclude(List.of("pinot-kafka-3.0"));
+    return cmd;
+  }
+
+  private static List<String> names(List<String> paths) {
+    return paths.stream().map(FilenameUtils::getName).sorted().collect(Collectors.toList());
+  }
+
+  /// The default excludes the Kafka plugin because its Scala dependencies break on a running Spark.
+  /// The shared store must not slip those in behind that exclusion.
+  @Test
+  public void testDefaultSelectionExcludesKafkaPluginAndItsSharedDependencies()
+      throws Exception {
+    File dist = buildDistribution();
+    LaunchSparkDataIngestionJobCommand cmd = commandWithCliDefaults();
+    List<String> resolved = names(cmd.resolveDepsJars(dist.getAbsolutePath()));
+
+    assertTrue(resolved.contains("pinot-all-1.0.jar"), resolved.toString());
+    assertTrue(resolved.contains("pinot-json-1.0.jar"), resolved.toString());
+    assertTrue(resolved.contains("pinot-s3-1.0.jar"), resolved.toString());
+    assertTrue(resolved.contains("jackson-core-2.22.jar"), resolved.toString());
+    assertTrue(resolved.contains("s3-2.54.jar"), resolved.toString());
+    // the excluded plugin, and the store jars only it declares
+    assertFalse(resolved.contains("pinot-kafka-3.0-1.0.jar"), resolved.toString());
+    assertFalse(resolved.contains("kafka-clients-3.9.jar"), resolved.toString());
+    assertFalse(resolved.contains("scala-library-2.13.jar"), resolved.toString());
+    // spark plugins run inside the executor and are never shipped
+    assertFalse(resolved.contains("spark3-1.0-shaded.jar"), resolved.toString());
+  }
+
+  /// An explicit selection must ship the named plugin *with* its dependencies, which before the
+  /// index meant shipping the plugin jar alone.
+  @Test
+  public void testExplicitSelectionShipsOnlyThatPluginAndItsDependencies()
+      throws Exception {
+    File dist = buildDistribution();
+    LaunchSparkDataIngestionJobCommand cmd = commandWithCliDefaults();
+    cmd.setPluginsToLoad(List.of("pinot-s3"));
+    List<String> resolved = names(cmd.resolveDepsJars(dist.getAbsolutePath()));
+
+    assertTrue(resolved.contains("pinot-s3-1.0.jar"), resolved.toString());
+    assertTrue(resolved.contains("s3-2.54.jar"), resolved.toString());
+    assertTrue(resolved.contains("jackson-core-2.22.jar"), resolved.toString());
+    assertFalse(resolved.contains("pinot-json-1.0.jar"), resolved.toString());
+    assertFalse(resolved.contains("kafka-clients-3.9.jar"), resolved.toString());
+    assertFalse(resolved.contains("scala-library-2.13.jar"), resolved.toString());
+  }
+
+  /// Guards the specific regression the index exists to prevent: the shared store is never added
+  /// as a directory, only through a selected plugin's index. A store jar no plugin declares must
+  /// never appear.
+  @Test
+  public void testSharedStoreIsNeverShippedWholesale()
+      throws Exception {
+    File dist = buildDistribution();
+    FileUtils.touch(new File(dist, "plugin-libs/orphan-not-declared-1.0.jar"));
+    LaunchSparkDataIngestionJobCommand cmd = commandWithCliDefaults();
+    List<String> resolved = names(cmd.resolveDepsJars(dist.getAbsolutePath()));
+    assertFalse(resolved.contains("orphan-not-declared-1.0.jar"), resolved.toString());
+  }
+
+  /// A shared jar declared by two selected plugins must be shipped once.
+  @Test
+  public void testSharedDependencyIsNotDuplicated()
+      throws Exception {
+    File dist = buildDistribution();
+    LaunchSparkDataIngestionJobCommand cmd = commandWithCliDefaults();
+    cmd.setPluginsToLoad(List.of("pinot-json", "pinot-s3"));
+    List<String> resolved = names(cmd.resolveDepsJars(dist.getAbsolutePath()));
+    assertEquals(resolved.stream().filter("jackson-core-2.22.jar"::equals).count(), 1L, resolved.toString());
+  }
+
+  /// An old-format plugin keeps its jars beside its own jar and ships no index; it must still be
+  /// shipped in full.
+  @Test
+  public void testOldFormatPluginWithoutIndexStillShipsItsOwnJars()
+      throws Exception {
+    File dist = buildDistribution();
+    FileUtils.forceMkdir(new File(dist, "plugins/acme-thirdparty"));
+    FileUtils.touch(new File(dist, "plugins/acme-thirdparty/acme-thirdparty-1.0.jar"));
+    FileUtils.touch(new File(dist, "plugins/acme-thirdparty/acme-internal-dep-1.0.jar"));
+    LaunchSparkDataIngestionJobCommand cmd = commandWithCliDefaults();
+    List<String> resolved = names(cmd.resolveDepsJars(dist.getAbsolutePath()));
+    assertTrue(resolved.contains("acme-thirdparty-1.0.jar"), resolved.toString());
+    assertTrue(resolved.contains("acme-internal-dep-1.0.jar"), resolved.toString());
   }
 
   @Test

--- a/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommandTest.java
+++ b/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommandTest.java
@@ -75,7 +75,9 @@ public class LaunchSparkDataIngestionJobCommandTest {
     File dist = new File(_tempDir, "dist-" + System.nanoTime());
     for (String d : List.of("lib", "plugin-libs", "plugins/pinot-input-format/pinot-json",
         "plugins/pinot-stream-ingestion/pinot-kafka-3.0", "plugins/pinot-file-system/pinot-s3",
-        "plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3")) {
+        "plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3",
+        "plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-2",
+        "plugins/pinot-connectors/pinot-spark-3-connector")) {
       FileUtils.forceMkdir(new File(dist, d));
     }
     for (String f : List.of("lib/pinot-all-1.0.jar",
@@ -84,7 +86,9 @@ public class LaunchSparkDataIngestionJobCommandTest {
         "plugins/pinot-input-format/pinot-json/pinot-json-1.0.jar",
         "plugins/pinot-stream-ingestion/pinot-kafka-3.0/pinot-kafka-3.0-1.0.jar",
         "plugins/pinot-file-system/pinot-s3/pinot-s3-1.0.jar",
-        "plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/spark3-1.0-shaded.jar")) {
+        "plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/spark3-1.0-shaded.jar",
+        "plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-2/spark2-1.0-shaded.jar",
+        "plugins/pinot-connectors/pinot-spark-3-connector/spark-connector-1.0.jar")) {
       FileUtils.touch(new File(dist, f));
     }
     Files.write(new File(dist, "plugins/pinot-input-format/pinot-json/pinot-plugin.classpath").toPath(),
@@ -127,8 +131,28 @@ public class LaunchSparkDataIngestionJobCommandTest {
     assertFalse(resolved.contains("pinot-kafka-3.0-1.0.jar"), resolved.toString());
     assertFalse(resolved.contains("kafka-clients-3.9.jar"), resolved.toString());
     assertFalse(resolved.contains("scala-library-2.13.jar"), resolved.toString());
-    // spark plugins run inside the executor and are never shipped
-    assertFalse(resolved.contains("spark3-1.0-shaded.jar"), resolved.toString());
+    // The ingestion plugin for the selected Spark version is required in the executor, and is the
+    // one exception to the rule that "spark"-named plugin directories are skipped.
+    assertTrue(resolved.contains("spark3-1.0-shaded.jar"), resolved.toString());
+    // Every other Spark-named plugin stays behind: a different Spark version's ingestion plugin,
+    // and the Spark connector, which is not an ingestion plugin at all.
+    assertFalse(resolved.contains("spark2-1.0-shaded.jar"), resolved.toString());
+    assertFalse(resolved.contains("spark-connector-1.0.jar"), resolved.toString());
+  }
+
+  /// Regression test: SparkType.SPARK_3 named the plugin "pinot-batch-ingestion-spark-3.2" while
+  /// the module ships in pinot-batch-ingestion-spark-3, so shouldLoadPlugin never re-included it
+  /// after the "spark" directory-name exclusion and the job died in the executor with
+  /// ClassNotFoundException: SparkSegmentGenerationJobRunner.
+  @Test
+  public void testSparkIngestionPluginNameMatchesItsDirectory()
+      throws Exception {
+    File dist = buildDistribution();
+    String pluginDir = LaunchSparkDataIngestionJobCommand.SparkType.SPARK_3.getPluginName();
+    assertTrue(new File(dist, "plugins-external/pinot-batch-ingestion/" + pluginDir).isDirectory(),
+        "SparkType plugin name must match the directory the plugin ships in, got: " + pluginDir);
+    assertTrue(names(commandWithCliDefaults().resolveDepsJars(dist.getAbsolutePath()))
+        .contains("spark3-1.0-shaded.jar"));
   }
 
   /// An explicit selection must ship the named plugin *with* its dependencies, which before the
@@ -224,7 +248,7 @@ public class LaunchSparkDataIngestionJobCommandTest {
   public void testMissingIndexIsToleratedAndYieldsNoDependencies() {
     String missing = new File(_tempDir, "does-not-exist.classpath").getAbsolutePath();
     assertTrue(_command.readPluginClasspathIndex(_fs, missing).isEmpty());
-
+  }
 
   /// `shouldLoadPlugin` skips any plugin directory whose name contains "spark", so that only the
   /// ingestion plugin for the selected Spark version is re-included, by comparing the directory
@@ -256,6 +280,5 @@ public class LaunchSparkDataIngestionJobCommandTest {
       }
     }
     return null;
-}
   }
 }

--- a/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommandTest.java
+++ b/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommandTest.java
@@ -19,14 +19,85 @@
 package org.apache.pinot.tools.admin.command;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.filesystem.LocalPinotFS;
 import org.apache.pinot.tools.admin.command.LaunchSparkDataIngestionJobCommand.SparkType;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
+/// accepts newline-separated entries so the format can change without breaking the Spark submit.
 public class LaunchSparkDataIngestionJobCommandTest {
+  private File _tempDir;
+  private LocalPinotFS _fs;
+  private LaunchSparkDataIngestionJobCommand _command;
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    _tempDir = Files.createTempDirectory("plugin-index-test").toFile();
+    _fs = new LocalPinotFS();
+    _command = new LaunchSparkDataIngestionJobCommand();
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    FileUtils.deleteQuietly(_tempDir);
+  }
+
+  private String writeIndex(String name, String content)
+      throws Exception {
+    File f = new File(_tempDir, name);
+    Files.write(f.toPath(), content.getBytes(StandardCharsets.UTF_8));
+    return f.getAbsolutePath();
+  }
+
+  @Test
+  public void testReadsColonSeparatedIndexAsWrittenByBuildClasspath()
+      throws Exception {
+    String idx = writeIndex("colon.classpath",
+        "plugin-libs/jackson-core-2.22.2.jar:plugin-libs/jackson-databind-2.22.2.jar");
+    assertEquals(_command.readPluginClasspathIndex(_fs, idx),
+        List.of("plugin-libs/jackson-core-2.22.2.jar", "plugin-libs/jackson-databind-2.22.2.jar"));
+  }
+
+  @Test
+  public void testReadsNewlineSeparatedIndex()
+      throws Exception {
+    String idx = writeIndex("newline.classpath",
+        "plugin-libs/a-1.jar\nplugin-libs/b-2.jar\n");
+    assertEquals(_command.readPluginClasspathIndex(_fs, idx), List.of("plugin-libs/a-1.jar", "plugin-libs/b-2.jar"));
+  }
+
+  @Test
+  public void testSkipsBlankAndWhitespaceEntries()
+      throws Exception {
+    String idx = writeIndex("blanks.classpath", "  plugin-libs/a-1.jar  ::\n\n plugin-libs/b-2.jar \n");
+    assertEquals(_command.readPluginClasspathIndex(_fs, idx), List.of("plugin-libs/a-1.jar", "plugin-libs/b-2.jar"));
+  }
+
+  @Test
+  public void testEmptyIndexYieldsNoDependencies()
+      throws Exception {
+    assertTrue(_command.readPluginClasspathIndex(_fs, writeIndex("empty.classpath", "")).isEmpty());
+  }
+
+  /// A plugin that ships no index at all - an old-format plugin keeping its jars beside it - must
+  /// not fail the submit; its own jars have already been added by the directory walk.
+  @Test
+  public void testMissingIndexIsToleratedAndYieldsNoDependencies() {
+    String missing = new File(_tempDir, "does-not-exist.classpath").getAbsolutePath();
+    assertTrue(_command.readPluginClasspathIndex(_fs, missing).isEmpty());
+
 
   /// `shouldLoadPlugin` skips any plugin directory whose name contains "spark", so that only the
   /// ingestion plugin for the selected Spark version is re-included, by comparing the directory
@@ -58,5 +129,6 @@ public class LaunchSparkDataIngestionJobCommandTest {
       }
     }
     return null;
+}
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,8 @@
     <checkstyle.fail.on.violation>true</checkstyle.fail.on.violation>
 
     <!-- Configuration for Packaging -->
+    <!-- Only used by artifacts loaded into a foreign JVM (clients, Spark connector,
+         Spark / Hadoop batch ingestion), which relocate in their own poms. -->
     <shade.prefix>org.apache.pinot.shaded</shade.prefix>
     <shade.phase.prop>none</shade.phase.prop>
     <!-- Keep these enabled by default; fastdev can disable them for incremental builds. -->
@@ -2894,6 +2896,17 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
       </plugin>
+      <!--
+        This shared configuration deliberately declares no <relocations>. Relocating here bought
+        no isolation: every module relocated to the same ${shade.prefix}, and the launcher puts
+        lib/* ahead of the plugin jars on the classpath, so a plugin's relocated copy always lost
+        to the distribution's copy of the same class. It only cost build time and made stack
+        traces and CVE scans harder to read.
+
+        Relocation is still correct for artifacts loaded by a JVM we do not control - the
+        java/jdbc client drivers, the Spark connector, and the Spark / Hadoop batch ingestion
+        jars - so those modules declare <relocations> themselves.
+      -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
@@ -2964,20 +2977,6 @@
               </excludes>
             </filter>
           </filters>
-          <relocations>
-            <relocation>
-              <pattern>com.fasterxml.jackson</pattern>
-              <shadedPattern>${shade.prefix}.com.fasterxml.jackson</shadedPattern>
-            </relocation>
-            <relocation>
-              <pattern>com.google.common</pattern>
-              <shadedPattern>${shade.prefix}.com.google.common</shadedPattern>
-            </relocation>
-            <relocation>
-              <pattern>org.scala-lang</pattern>
-              <shadedPattern>${shade.prefix}.org.scala-lang</shadedPattern>
-            </relocation>
-          </relocations>
         </configuration>
       </plugin>
       <!-- Include apache LICENSE, NOTICE files for jar resource bundle -->

--- a/pom.xml
+++ b/pom.xml
@@ -847,6 +847,20 @@
         <groupId>org.apache.orc</groupId>
         <artifactId>orc-core</artifactId>
         <version>${orc.version}</version>
+        <exclusions>
+          <!-- ORC pulls hadoop-client-api, which is the API half of Hadoop's shaded client pair:
+               its bytecode references third-party classes relocated under
+               org.apache.hadoop.shaded, and those live only in hadoop-client-runtime. Pinot uses
+               the unshaded hadoop-common instead, so hadoop-client-api would put a second, and
+               incompatible, copy of org.apache.hadoop.conf.Configuration on the classpath. Which
+               one wins is decided by classpath order, and when hadoop-client-api wins, loading a
+               Configuration fails with NoClassDefFoundError on the relocated Woodstox it expects
+               hadoop-client-runtime to supply. Exclude it so Hadoop comes from one flavour only. -->
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.orc</groupId>


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

PR replaces plugin fat jars with thin jars and a shared dependency index, updating assembly, launcher, and Spark ingestion to use the new layout\.

```mermaid
flowchart TD
  N0["Build plugin#58; thin jar #43; plugin#45;libs #43; pinot#45;plugin#46;classpath #40;F38#41;"]:::stAdded
  N1["Assembly packages thin jars and shared plugin#45;libs #40;F3#41;"]:::stModified
  N2["Distribution layout#58; lib#47;pinot#45;all#46;jar#44; plugins#47;#42;#47;thin#46;jar#44; plugin#45;libs#47;#42; #40;F3#41;"]:::stModified
  N3["Launcher selects plugins via PLUGINS#95;INCLUDE#44; adds thin jars and resolves deps #40;F42#41;"]:::stModified
  N4["Spark ingestion command uses plugin index to ship selected plugins#39; deps #40;F40#41;"]:::stModified
  N0 -->|"assembly consumes build outputs"| N1
  N1 -->|"assembly creates distribution"| N2
  N2 -->|"launcher reads plugins and plugin#45;libs"| N3
  N2 -->|"Spark command resolves deps via plugin#45;libs"| N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

Partial evidence: 0 file patches omitted; 1 truncated.

<details>
<summary>Diff evidence</summary>

- F3: pinot\-distribution/pinot\-assembly\.xml — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-distribution/pinot-assembly.xml) · [after](https://github.com/apache/pinot/blob/2b51c3ea6ee1d15e155334851880b1ac032e0e22/pinot-distribution/pinot-assembly.xml)
- F38: pinot\-plugins/pom\.xml — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-plugins/pom.xml) · [after](https://github.com/apache/pinot/blob/2b51c3ea6ee1d15e155334851880b1ac032e0e22/pinot-plugins/pom.xml)
- F40: pinot\-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommand\.java — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommand.java) · [after](https://github.com/apache/pinot/blob/2b51c3ea6ee1d15e155334851880b1ac032e0e22/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommand.java)
- F42: pinot\-tools/src/main/resources/appAssemblerScriptTemplate — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-tools/src/main/resources/appAssemblerScriptTemplate) · [after](https://github.com/apache/pinot/blob/2b51c3ea6ee1d15e155334851880b1ac032e0e22/pinot-tools/src/main/resources/appAssemblerScriptTemplate)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImQwOGFjOTEzNjVmZDJjZWMzZGI1OTViZGI2MzY4NzhjODMzYTlkNWIiLCJjb250ZXh0X2hhc2giOiJiNjAzZjgwNGQ3ZWU2MTkzYTYyMDI1NWM0NzZkMzk1ZjI1YmFkYjdkOTI1NjJkYmI0ZWNkNzdjMjllZmNjMTA0IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NTIwNTg0LCJoZWFkX3NoYSI6IjJiNTFjM2VhNmVlMWQxNWUxNTUzMzQ4NTE4ODBiMWFjMDMyZTBlMjIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJkMDhhYzkxMzY1ZmQyY2VjM2RiNTk1YmRiNjM2ODc4YzgzM2E5ZDViIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 64aa86f18e8577c0277bcf6426335eca15e16db96b6209a7c1299cd728340755 -->
<!-- pinot-pr-flow:end -->

## Summary

Pinot shades almost everything it builds, and the shading does not do what it looks like it does.

The shared shade configuration in the root pom relocates exactly three packages: `com.fasterxml.jackson`, `com.google.common` and `org.scala-lang`. Every module relocates them to the same `org.apache.pinot.shaded` prefix, and the launcher puts `lib/*` on the classpath ahead of the plugin jars, so a plugin's relocated copy of a class always lost to the distribution's copy of the same class. Two plugins that relocated the same library collided with each other for the same reason. Everything else a plugin bundles - kafka-clients, hadoop, avro, parquet, aws-sdk, netty - was never relocated at all and has always been merged onto one flat classpath, first match winning.

So the isolation was not real. The costs were:

- **Build time.** Roughly 37 modules opt into shading. The root `shade.phase.prop` default of `none` looks like it disables this, but almost every module overrides it to `package` in its own properties or in an `activeByDefault` profile, so an ordinary `mvn install` shades them all. Each execution unpacks its full dependency tree, rewrites every class entry and writes a merged jar. The cost multiplies where the dependency graph converges: hadoop is embedded independently by hdfs, parquet and orc; aws-sdk by s3 and kinesis; avro by three modules.
- **Distribution size.** Because every plugin embeds its own copy of every shared library, the plugin payload is 640 MB for what is really about 330 MB of distinct content.
- **Legibility.** Version skew between plugins is invisible when it is buried inside uber-jars. Stack traces name relocated classes, `jar tf` tells you little, and CVE scanners either flag one library once per fat jar that embeds it or miss it entirely. `KafkaConfigBackwardCompatibleUtils` exists solely to rewrite stream configs that name shaded Kafka classes, and its own comment is a `FIXME` about shade rewriting string constants inside classes.

This PR removes relocation where it was doing nothing and replaces the per-plugin fat jars with a thin jar plus a shared dependency directory.

## What changed

**Relocation** is removed from the shared shade configuration and re-declared in the modules where it is genuinely correct - artifacts loaded by a JVM Pinot does not control:

| Module | Why it still relocates |
|---|---|
| `pinot-java-client`, `pinot-jdbc-client` | Driver jars embedded in a user's application |
| `pinot-batch-ingestion-spark-3`, `pinot-batch-ingestion-hadoop` | Run inside Spark / Hadoop executors |
| `pinot-spark-3-connector` | Unchanged; it already had its own shade configuration and relocations |

**Plugin packaging.** 28 plugin modules stop building a fat jar: the `shade.phase.prop` property and the now-pointless `pinot-fastdev` / `build-shaded-jar` profiles are deleted, which is why much of this diff is deletions. The distribution ships each plugin as its thin module jar under `plugins/<type>/<name>/`, with plugin dependencies collected into a new shared top-level `plugin-libs/` directory where each artifact is stored once.

```
lib/pinot-all-<version>.jar          core (still shaded, no relocations)
plugin-libs/                         shared dependency store, one copy per artifact
  slf4j-api-2.0.18.jar               (was embedded in 15 plugin fat jars)
  jackson-annotations-2.22.jar       (was embedded in 13)
  ...
plugins/pinot-input-format/pinot-json/
  pinot-json-<version>.jar           thin jar
  pinot-plugin.classpath             the store entries this plugin needs
plugins-external/                    unchanged: shaded fat jars for Spark / Hadoop
```

**A per-plugin dependency index.** Collecting dependencies into one directory removes the information a jar's location used to carry: which plugin needs it. Two existing consumers depend on that. The launcher's `PLUGINS_INCLUDE` path selects jars by matching a plugin name against the jar's parent directory, and `LaunchSparkDataIngestionJobCommand` does the same to honour `-pluginsToLoad` / `-pluginsToExclude` when deciding what to ship to Spark executors. With a shared store every dependency's parent directory is `plugin-libs`, so selection would either ship all of them or none - and shipping all of them would have sent the Kafka plugin's Scala dependencies to the executors, which the hard-coded `-pluginsToExclude pinot-kafka-3.0` default exists to prevent.

Each plugin therefore ships a `pinot-plugin.classpath` next to its jar, generated by `dependency:build-classpath`, naming the store jars it needs as distribution-relative paths. The launcher and the Spark command resolve a selected plugin's dependencies through it; the store is added wholesale only when nothing was selected. Entries are accepted `:`-separated - the classpath fragment `build-classpath` actually writes - or newline-separated. A plugin with no index, such as an old-format plugin that keeps its jars beside its own jar, contributes nothing extra and keeps working unchanged.

**`pinot-parquet` drops the `hadoop-client-runtime` uber-jar.** That artifact is Hadoop's own uber-jar of third-party runtime dependencies, pre-relocated under `org.apache.hadoop.shaded`, and it bundles Jetty for Hadoop's embedded `HttpServer2` web UIs - which Pinot never starts; `HttpServer2` is not referenced anywhere in the codebase. That bundled Jetty carries CVE-2026-2332, and because the classes are baked into the uber-jar rather than resolved as a dependency node, a Maven exclusion cannot remove them: the root pom needed a `maven-shade-plugin` filter, which only worked while the consuming plugin was shaded. Without this change the distribution would regain 1059 Jetty classes.

`pinot-parquet` was its only consumer, and everything it needs is in `hadoop-common`, where Jetty is an ordinary graph dependency already excluded centrally in the root pom - the same arrangement `pinot-hdfs` has always used, and what `parquet-hadoop` itself declares. `hadoop-client-api` is not an alternative: it holds only `org/apache/hadoop/*` classes and its bytecode makes 169 references to `org/apache/hadoop/shaded/org/eclipse` (Jetty) among 13 relocated packages, so it cannot be used without `hadoop-client-runtime` and would bring the same Jetty back. The shade filter is retained because the two external-process batch plugins still shade.

**Plugins `pinot-tools` does not compile against are excluded from the uber-jar.** `pinot-tools` depends on sixteen plugin modules, and ideally it would not: the quickstarts and admin commands reach for plugin classes, a few by import but most only by fully-qualified name at runtime. The distribution therefore carried those plugins twice - once shaded into `lib/pinot-all.jar` through `pinot-tools`, once as the plugin itself - and the uber-jar copy wins on the classpath, making the plugin directory dead weight for exactly those plugins. `pinot-distribution` now excludes the fourteen `pinot-tools` never references at compile time; `pinot-avro`, `pinot-json`, `pinot-parquet` and `pinot-minion-builtin-tasks` stay, because it genuinely imports from them and removing those needs their shared classes extracted into library modules first.

Declaring those dependencies `provided` in `pinot-tools` would keep the list next to what it describes and would be the better mechanism, but `provided` is not on the runtime classpath, so every quickstart needing one of these plugins would stop working when launched from Maven or an IDE, where there is no `plugins/` directory for `PluginManager` to load from. Both poms carry that reasoning.

**Plugins declare their dependencies on Pinot's own modules as `provided`.** A plugin depending on a Pinot module at compile scope bundles that module and its whole dependency tree into the plugin, even though Pinot's modules are always present wherever a plugin is loaded. The parent pom already does this for `pinot-spi`; three modules did not follow it. `pinot-kinesis` declared `pinot-common` and `pinot-minion-builtin-tasks` declared `pinot-materialized-view`, which between them dragged in `fastutil` (22.9 MB), `calcite-core` (8.6 MB) and `grpc-netty-shaded`, none of which either plugin uses directly; `pinot-compound-metrics` re-declared `pinot-spi` as compile, overriding the scope it inherits. Cutting a Pinot module at the root prunes `calcite-babel`, `calcite-linq4j`, `avatica-core`, `asm` and 85 more jars with it.

Note the invariant this exposed: a plugin may only be excluded from the uber-jar if the distribution ships it under `plugins/`, otherwise it disappears rather than moves. `pinot-compound-metrics` is not in the assembly's plugin list, so it stays in the uber-jar, which is the only place it has ever been available from. The pom records that.

**Out of scope, deliberately.** `pinot-spi`, `pinot-core`, `pinot-common` and `pinot-distribution` keep publishing their shaded classifiers, and `pinot-cli` and `pinot-perf` keep their runnable fat jars. `pinot-spi` and `pinot-core` in fact already do not shade on a default build - their `build-shaded-jar` profiles are `activeByDefault=false`. Nothing in the repo consumes a `<classifier>shaded</classifier>` dependency, so `pinot-common`'s shaded classifier may well be unnecessary, but these are published artifacts with external consumers I cannot enumerate. `lib/pinot-all.jar` also stays a single shaded jar; splitting it deserves its own change.

## Why this does not change runtime behavior

The launcher has always globbed every jar under `plugins/` onto the JVM classpath, so all plugin classes and all plugin dependencies were already on one flat classpath, resolved first-match-wins. Splitting a fat jar into a thin jar plus its dependency jars, all still on that same classpath in the same position, produces the same set of classes with the same resolution order. Plugin discovery is unaffected: `PluginManager` finds a plugin by locating a jar and taking its parent directory name, and the thin jar sits exactly where the fat jar did.

Relocation removal has one narrow effect. A third-party plugin that bundles its own *unrelocated* jackson, guava or scala used to get its own copy, because Pinot's copies lived under `org.apache.pinot.shaded`; it will now resolve Pinot's copies instead, by classpath order. This is the same exposure such a plugin already had for every other library, and the standard fix - relocating your own dependencies in your own fat jar - is unaffected.

One more honest footnote. Where two plugins disagreed on the version of a library, the fat-jar layout resolved that by whichever plugin jar the classpath reached first; the shared store resolves it by whichever of the two jars the `plugin-libs/*` expansion reaches first. Both are arbitrary and neither is specified, but the winner can change. Auditing the built distribution, exactly one such case exists: `threeten-extra` 1.7.1 (via `pinot-orc`) against 1.8.0 (via `pinot-gcs`). The other apparent duplicates are not conflicts - `swagger-annotations` 1.x and 2.x use different packages, `metrics-core` 2.2.0 and 4.2.39 are the unrelated Yammer and Dropwizard artifacts, `netty-transport-native-epoll` and `jffi` differ only by classifier, and the three `annotations-*.jar` files are unrelated artifacts from AWS, JetBrains and gRPC that merely share a file-name stem.

That last case is worth naming as a limitation: the store keys on `artifactId-version.jar`, so two artifacts from different groups with the same artifactId *and* the same version would silently overwrite each other. Every jar in the built store was hashed and no such collision exists; if it ever becomes a concern the assembly can switch to an `outputFileNameMapping` that includes the groupId.

## Verification

Measured on one machine, same warm local repository, `-T 1C -P 'bin-dist,!pinot-fastdev'` with the same checks skipped on both sides, against a distribution built from the same commit without these changes:

| | before | after |
|---|---|---|
| `bin-dist` wall clock | 4:13 | **3:23** (-20%) |
| modules running shade | 37 | **8** |
| distribution size | 1144 MB | **660 MB** (-42%) |
| `lib/pinot-all.jar` | 316 MB | **250 MB** |
| shared dependency store | n/a | **375 jars, 259 MB** |
| `org.apache.kafka` classes in the uber-jar | 5024 | **0** |
| Jetty classes on the runtime classpath | 0 | **0** |

- **Deduplication**: across the 28 shipped plugins, 1115 dependency-jar copies reduce to 464 distinct artifacts, eliminating 651 copies (58%). `slf4j-api` was embedded 15 times, `jackson-annotations` 13, `jackson-databind` and `jackson-core` 12 each. Scoping the Pinot-module dependencies as `provided` then takes the store from 464 jars to 375, and from 331 MB to 259 MB.
- **The shared store is complete and consistent**: every expected dependency jar is present, nothing missing and nothing extra. Every jar was hashed - no two plugins contribute the same file name with different content, so merging them is safe.
- **Every plugin excluded from the uber-jar is still shipped under `plugins/`**, checked against the built distribution, so no class was removed from the distribution rather than relocated. `jdeps --missing-deps` reports nothing missing for `pinot-kinesis` and `pinot-minion-builtin-tasks` against exactly the classpath the launcher gives them: `lib/*` plus their own jar plus the store entries their index names.
- **No classes lost.** Comparing the class sets reachable on the runtime classpath of both built distributions (`lib/*` + `plugins/**` + `plugin-libs/*`), everything absent afterwards is accounted for by design: the relocated `org/apache/pinot/shaded/*` copies, now present at their real coordinates, and the relocated `org/apache/hadoop/shaded/*` payload of the dropped uber-jar. Nothing else.
- **Plugin selection still works**, checked against the artifacts the build produces: `PLUGINS_INCLUDE=pinot-json` yields that plugin's jar plus exactly its five jackson dependencies; `PLUGINS_INCLUDE=pinot-s3` yields its jar plus 57 AWS jars and no Kafka or Scala jar at all; selecting nothing yields every plugin jar plus the whole store, as before; and an old-format plugin directory with no index still contributes its own jars.
- **A real Spark ingestion launch** against the built distribution, with `SPARK_HOME` pointing at a Spark 3.5.9 `scala2.13` build: the default selection ships 439 store jars, each traceable to a plugin that declares it, with Scala correctly withheld because only the excluded `pinot-kafka-3.0` declares it; `-pluginsToLoad pinot-batch-ingestion-spark-3:pinot-csv:pinot-batch-ingestion-standalone` ships 6 store jars instead of 439. `SparkSubmit` starts and `PluginManager` loads plugins from the new layout. Segment generation itself cannot complete on a Java 25 build for a known unrelated reason (Hadoop 3.4's `UserGroupInformation` calls `Subject.getSubject`, which throws on JDK 23+).
- **Tests**: `LaunchSparkDataIngestionJobCommandTest` 12 run, 0 failures, covering the selection rules and the index reader (`:`-separated, newline-separated, blank, empty and absent). `pinot-parquet` 59 run, 0 failures.
- `quick-start-batch.sh` runs end to end from the built distribution: 15 tables, sample queries return, and no `NoClassDefFoundError`, `ClassNotFoundException` or plugin-loading failure.
- `quick-start-streaming.sh` was exercised with an external Kafka. The Kafka plugin loads and drives a real broker - its classes are absent from `lib/pinot-all.jar` and present only in `plugins/.../pinot-kafka-3.0-*.jar` - topics are created, and there are no classloading failures. A complete green run was not obtained in my environment: it needs Docker for its managed Kafka, and with an external broker the controller timed out validating the `githubEvents` stream. I could not attribute that to this change and did not compare it against an unmodified build in the same setup, so I am flagging it rather than claiming a pass.

Both distributions also hit the same pre-existing `Unable to create index directory` failure on `dimBaseballTeams_OFFLINE`, a check-then-act race in `BaseTableDataManager` where `mkdirs()` returns false for the losing thread of two concurrent state transitions on a dimension table. Unrelated to this PR.

## Backward incompatibility

Labelled `backward-incompat`; for the release notes:

1. `org.apache.pinot.shaded.*` classes are gone from `pinot-all.jar` and from the plugin jars. Anything compiled against those relocated coordinates must move to the real coordinates.
2. Plugin jars in the distribution are no longer named `*-shaded.jar`, and a plugin's dependencies now live in the new top-level `plugin-libs/` directory rather than inside the plugin jar. Tooling that copies individual plugin jars out of the tarball must take `plugin-libs/` too. The per-plugin directory layout under `plugins/` is unchanged.
3. Third-party plugins that bundle unrelocated jackson, guava or scala now resolve Pinot's copies of those libraries. Relocate them in your own plugin jar if you need your own versions.
4. `hadoop-client-runtime` is no longer shipped in the distribution.
5. Each plugin directory gains a `pinot-plugin.classpath` file. `PLUGINS_INCLUDE` and the Spark launcher's `-pluginsToLoad` / `-pluginsToExclude` keep their meaning; a third-party plugin that ships no index keeps its current behaviour.
6. `lib/pinot-all.jar` no longer contains the plugin classes and third-party payload that `pinot-tools` used to drag in.

## Follow-ups

- Classloader-realm isolation - plugin realms, realm-aware service discovery, the plugin verifier - is the other half of #18459 and is being rebased onto this change as a separate PR. Note for that work: a realm built from a plugin directory does not see `plugin-libs/`, so it must build its URL list from the plugin's `pinot-plugin.classpath` rather than from `Files.list(pluginDir)`. The index this PR adds is exactly what it needs; the mistake to avoid is adding `pinot-plugin.properties` files without consuming it, which would leave every realm-loaded plugin without its dependencies.
- `lib/pinot-all.jar` could dissolve into the same shared-store model, removing the largest remaining shade execution and most of the remaining duplication. A library needed by both core and a plugin still exists twice, once merged into the uber-jar and once as a loose jar in the store. Measured on this build, 246 of the store's jars (173 MB before the `provided` scoping) are fully contained in `lib/pinot-all.jar` and so are never resolved from the store at all, since `lib/*` precedes the plugin jars on the classpath. The launcher needs no change since it already globs `lib/*`. The compat question is that `pinot-all.jar` is matched by name by `LaunchSparkDataIngestionJobCommand` and is what users pass to `spark-submit`, so the tarball would stop using a single merged jar while `pinot-distribution` keeps publishing one.
- A tempting shortcut to avoid: 306 of the 464 jars in `plugin-libs/` (237 MB) are fully shadowed by `lib/pinot-all.jar` and so are never resolved from the store, which makes omitting them look free. It is not. Much of that shadowing existed only because `pinot-tools` pulled plugin modules into the uber-jar, which this PR largely removes; it would couple the plugin layout to whatever the uber-jar happens to contain; and a plugin loaded in a strict realm never sees `lib/` at all, so its dependencies must really be present.
- `pinot-common`'s shaded classifier appears to have no consumers and could be dropped.
- The remaining four compile-time plugin dependencies of `pinot-tools` could be removed by extracting their shared classes into `-base` library modules, which would take the last plugin classes out of `pinot-all.jar`.
