### PR TITLE
Query Performance: Optimise sketch accumulator for threshold condition

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/CpcSketchAccumulator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/CpcSketchAccumulator.java
@@ -46,11 +46,21 @@ public class CpcSketchAccumulator extends CustomObjectAccumulator<CpcSketch> {
   }
 
   @Override
-  public CpcSketch getResult() {
-    return unionAll();
+  protected void flush() {
+    if (_accumulator == null || _accumulator.isEmpty()) {
+      return;
+    }
+    if (_union == null) {
+      _union = new CpcUnion(_lgNominalEntries);
+    }
+    for (CpcSketch accumulatedSketch : _accumulator) {
+      _union.update(accumulatedSketch);
+    }
+    _accumulator.clear();
   }
 
-  private CpcSketch unionAll() {
+  @Override
+  public CpcSketch getResult() {
     if (_union == null) {
       _union = new CpcUnion(_lgNominalEntries);
     }
@@ -62,14 +72,10 @@ public class CpcSketchAccumulator extends CustomObjectAccumulator<CpcSketch> {
     // This single sketch might have been the result of a previously accumulated union and
     // would already have the parameters set.  The sketch is returned as-is without adjusting
     // nominal entries which requires an additional union operation.
-    if (getNumInputs() == 1) {
+    if (getNumInputs() == 1 && _accumulator != null && _accumulator.size() == 1) {
       return _accumulator.get(0);
     }
-
-    for (CpcSketch accumulatedSketch : _accumulator) {
-      _union.update(accumulatedSketch);
-    }
-
+    flush();
     return _union.getResult();
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/CustomObjectAccumulator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/CustomObjectAccumulator.java
@@ -66,9 +66,12 @@ public abstract class CustomObjectAccumulator<T> {
   }
 
   /// Forces the item T in internal state to be merged with all pending items in the accumulator state
-  /// and returns the result.  This should not result in the accumulator state being updated or cleared.
+  /// and returns the result.
   /// @return T result of the merge.
   public abstract T getResult();
+
+  /// Merges the pending items into the internal state and clears them, without building a result.
+  protected abstract void flush();
 
   /// Merges another accumulator with this one, by extracting the result from "other".
   /// @param other the custom object accumulator to merge.
@@ -96,8 +99,7 @@ public abstract class CustomObjectAccumulator<T> {
     _numInputs += 1;
 
     if (_accumulator.size() >= _threshold) {
-      getResult();
-      _accumulator.clear();
+      flush();
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/ThetaSketchAccumulator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/ThetaSketchAccumulator.java
@@ -52,24 +52,12 @@ public class ThetaSketchAccumulator extends CustomObjectAccumulator<ThetaSketch>
   }
 
   @Override
-  public ThetaSketch getResult() {
-    return unionAll();
-  }
-
-  private ThetaSketch unionAll() {
+  protected void flush() {
+    if (_accumulator == null || _accumulator.isEmpty()) {
+      return;
+    }
     if (_union == null) {
       _union = _setOperationBuilder.buildUnion();
-    }
-    // Return the default update "gadget" sketch as a compact sketch
-    if (isEmpty()) {
-      return _union.getResult(false, null);
-    }
-    // Corner-case: the parameters are not strictly respected when there is a single sketch.
-    // This single sketch might have been the result of a previously accumulated union and
-    // would already have the parameters set.  The sketch is returned as-is without adjusting
-    // nominal entries which requires an additional union operation.
-    if (getNumInputs() == 1) {
-      return _accumulator.get(0);
     }
 
     // Performance optimization: ensure that the minimum Theta is used for "early stop".
@@ -86,7 +74,25 @@ public class ThetaSketchAccumulator extends CustomObjectAccumulator<ThetaSketch>
       _union.union(accumulatedSketch);
     }
     _accumulator.clear();
+  }
 
+  @Override
+  public ThetaSketch getResult() {
+    if (_union == null) {
+      _union = _setOperationBuilder.buildUnion();
+    }
+    // Return the default update "gadget" sketch as a compact sketch
+    if (isEmpty()) {
+      return _union.getResult(false, null);
+    }
+    // Corner-case: the parameters are not strictly respected when there is a single sketch.
+    // This single sketch might have been the result of a previously accumulated union and
+    // would already have the parameters set.  The sketch is returned as-is without adjusting
+    // nominal entries which requires an additional union operation.
+    if (getNumInputs() == 1 && _accumulator != null && _accumulator.size() == 1) {
+      return _accumulator.get(0);
+    }
+    flush();
     return _union.getResult(false, null);
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/TupleIntSketchAccumulator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/TupleIntSketchAccumulator.java
@@ -60,24 +60,12 @@ public class TupleIntSketchAccumulator extends CustomObjectAccumulator<TupleSket
   }
 
   @Override
-  public TupleSketch<IntegerSummary> getResult() {
-    return unionAll();
-  }
-
-  private TupleSketch<IntegerSummary> unionAll() {
+  protected void flush() {
+    if (_accumulator == null || _accumulator.isEmpty()) {
+      return;
+    }
     if (_union == null) {
       _union = new TupleUnion<>(_nominalEntries, _setOperations);
-    }
-    // Return the default update "gadget" sketch as a compact sketch
-    if (isEmpty()) {
-      return _union.getResult();
-    }
-    // Corner-case: the parameters are not strictly respected when there is a single sketch.
-    // This single sketch might have been the result of a previously accumulated union and
-    // would already have the parameters set.  The sketch is returned as-is without adjusting
-    // nominal entries which requires an additional union operation.
-    if (getNumInputs() == 1) {
-      return _accumulator.get(0);
     }
 
     // Performance optimization: ensure that the minimum Theta is used for "early stop".
@@ -94,7 +82,25 @@ public class TupleIntSketchAccumulator extends CustomObjectAccumulator<TupleSket
       _union.union(accumulatedSketch);
     }
     _accumulator.clear();
+  }
 
+  @Override
+  public TupleSketch<IntegerSummary> getResult() {
+    if (_union == null) {
+      _union = new TupleUnion<>(_nominalEntries, _setOperations);
+    }
+    // Return the default update "gadget" sketch as a compact sketch
+    if (isEmpty()) {
+      return _union.getResult();
+    }
+    // Corner-case: the parameters are not strictly respected when there is a single sketch.
+    // This single sketch might have been the result of a previously accumulated union and
+    // would already have the parameters set.  The sketch is returned as-is without adjusting
+    // nominal entries which requires an additional union operation.
+    if (getNumInputs() == 1 && _accumulator != null && _accumulator.size() == 1) {
+      return _accumulator.get(0);
+    }
+    flush();
     return _union.getResult();
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/customobject/CpcSketchAccumulatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/customobject/CpcSketchAccumulatorTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.local.customobject;
 
 import java.util.stream.IntStream;
 import org.apache.datasketches.cpc.CpcSketch;
+import org.apache.datasketches.cpc.CpcUnion;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -77,6 +78,37 @@ public class CpcSketchAccumulatorTest {
     accumulator.apply(sketch2);
 
     Assert.assertEquals(accumulator.getResult().getEstimate(), sketch1.getEstimate() + sketch2.getEstimate(), _epsilon);
+  }
+
+  @Test
+  public void testInputsSurviveRepeatedFlushes() {
+    for (int threshold = 1; threshold <= 4; threshold++) {
+      CpcSketchAccumulator accumulator = new CpcSketchAccumulator(_lgNominalEntries, threshold);
+      CpcUnion expected = new CpcUnion(_lgNominalEntries);
+      for (int i = 0; i < 7; i++) {
+        CpcSketch sketch = new CpcSketch(_lgNominalEntries);
+        int base = i * 1000;
+        IntStream.range(base, base + 1000).forEach(sketch::update);
+        accumulator.apply(sketch);
+        expected.update(sketch);
+      }
+      Assert.assertEquals(accumulator.getResult().getEstimate(), expected.getResult().getEstimate(), _epsilon,
+          "threshold " + threshold);
+    }
+  }
+
+  @Test
+  public void testRepeatedGetResultIsStable() {
+    CpcSketchAccumulator accumulator = new CpcSketchAccumulator(_lgNominalEntries, 2);
+    for (int i = 0; i < 5; i++) {
+      CpcSketch sketch = new CpcSketch(_lgNominalEntries);
+      int base = i * 1000;
+      IntStream.range(base, base + 1000).forEach(sketch::update);
+      accumulator.apply(sketch);
+    }
+    double first = accumulator.getResult().getEstimate();
+    Assert.assertEquals(accumulator.getResult().getEstimate(), first, 0.0);
+    Assert.assertEquals(accumulator.getResult().getEstimate(), first, 0.0);
   }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/customobject/ThetaSketchAccumulatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/customobject/ThetaSketchAccumulatorTest.java
@@ -22,6 +22,7 @@ package org.apache.pinot.segment.local.customobject;
 import java.util.stream.IntStream;
 import org.apache.datasketches.theta.ThetaSetOperationBuilder;
 import org.apache.datasketches.theta.ThetaSketch;
+import org.apache.datasketches.theta.ThetaUnion;
 import org.apache.datasketches.theta.UpdatableThetaSketch;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -88,6 +89,38 @@ public class ThetaSketchAccumulatorTest {
     accumulator.apply(sketch2);
 
     Assert.assertEquals(accumulator.getResult().getEstimate(), sketch1.getEstimate() + sketch2.getEstimate());
+  }
+
+  @Test
+  public void testInputsSurviveRepeatedFlushes() {
+    for (int threshold = 1; threshold <= 4; threshold++) {
+      ThetaSketchAccumulator accumulator = new ThetaSketchAccumulator(_setOperationBuilder, threshold);
+      ThetaUnion expected = _setOperationBuilder.buildUnion();
+      for (int i = 0; i < 7; i++) {
+        UpdatableThetaSketch input = UpdatableThetaSketch.builder().build();
+        int base = i * 1000;
+        IntStream.range(base, base + 1000).forEach(input::update);
+        ThetaSketch sketch = input.compact();
+        accumulator.apply(sketch);
+        expected.union(sketch);
+      }
+      Assert.assertEquals(accumulator.getResult().getEstimate(), expected.getResult().getEstimate(), 0.0,
+          "threshold " + threshold);
+    }
+  }
+
+  @Test
+  public void testRepeatedGetResultIsStable() {
+    ThetaSketchAccumulator accumulator = new ThetaSketchAccumulator(_setOperationBuilder, 2);
+    for (int i = 0; i < 5; i++) {
+      UpdatableThetaSketch input = UpdatableThetaSketch.builder().build();
+      int base = i * 1000;
+      IntStream.range(base, base + 1000).forEach(input::update);
+      accumulator.apply(input.compact());
+    }
+    double first = accumulator.getResult().getEstimate();
+    Assert.assertEquals(accumulator.getResult().getEstimate(), first, 0.0);
+    Assert.assertEquals(accumulator.getResult().getEstimate(), first, 0.0);
   }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/customobject/TupleIntSketchAccumulatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/customobject/TupleIntSketchAccumulatorTest.java
@@ -21,6 +21,9 @@ package org.apache.pinot.segment.local.customobject;
 
 import java.util.stream.IntStream;
 import org.apache.datasketches.tuple.CompactTupleSketch;
+import org.apache.datasketches.tuple.TupleSketch;
+import org.apache.datasketches.tuple.TupleSketchIterator;
+import org.apache.datasketches.tuple.TupleUnion;
 import org.apache.datasketches.tuple.aninteger.IntegerSummary;
 import org.apache.datasketches.tuple.aninteger.IntegerSummarySetOperations;
 import org.apache.datasketches.tuple.aninteger.IntegerTupleSketch;
@@ -91,6 +94,50 @@ public class TupleIntSketchAccumulatorTest {
     accumulator.apply(sketch2);
 
     Assert.assertEquals(accumulator.getResult().getEstimate(), sketch1.getEstimate() + sketch2.getEstimate());
+  }
+
+  // Summaries are summed, so a sketch merged twice doubles a summary while leaving the estimate right.
+  @Test
+  public void testInputsSurviveRepeatedFlushes() {
+    for (int threshold = 1; threshold <= 4; threshold++) {
+      TupleIntSketchAccumulator accumulator = new TupleIntSketchAccumulator(_setOps, _nominalEntries, threshold);
+      TupleUnion<IntegerSummary> expected = new TupleUnion<>(_nominalEntries, _setOps);
+      for (int i = 0; i < 7; i++) {
+        IntegerTupleSketch input = new IntegerTupleSketch(_lgK, IntegerSummary.Mode.Sum);
+        int base = i * 1000;
+        IntStream.range(base, base + 1000).forEach(k -> input.update(k, 1));
+        CompactTupleSketch<IntegerSummary> sketch = input.compact();
+        accumulator.apply(sketch);
+        expected.union(sketch);
+      }
+      TupleSketch<IntegerSummary> actual = accumulator.getResult();
+      TupleSketch<IntegerSummary> want = expected.getResult();
+      Assert.assertEquals(actual.getEstimate(), want.getEstimate(), 0.0, "threshold " + threshold);
+      Assert.assertEquals(summarySum(actual), summarySum(want), "threshold " + threshold);
+    }
+  }
+
+  @Test
+  public void testRepeatedGetResultIsStable() {
+    TupleIntSketchAccumulator accumulator = new TupleIntSketchAccumulator(_setOps, _nominalEntries, 2);
+    for (int i = 0; i < 5; i++) {
+      IntegerTupleSketch input = new IntegerTupleSketch(_lgK, IntegerSummary.Mode.Sum);
+      int base = i * 1000;
+      IntStream.range(base, base + 1000).forEach(k -> input.update(k, 1));
+      accumulator.apply(input.compact());
+    }
+    long first = summarySum(accumulator.getResult());
+    Assert.assertEquals(summarySum(accumulator.getResult()), first);
+    Assert.assertEquals(summarySum(accumulator.getResult()), first);
+  }
+
+  private static long summarySum(TupleSketch<IntegerSummary> sketch) {
+    long sum = 0;
+    TupleSketchIterator<IntegerSummary> it = sketch.iterator();
+    while (it.next()) {
+      sum += it.getSummary().getValue();
+    }
+    return sum;
   }
 
   @Test


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Apply internal now flushes pending batches; getResult flushes before returning final union\.

```mermaid
flowchart TD
  N0["applyInternal #40;F2#41;"]:::stModified
  N1["flush #40;abstract#41; #40;F2#41;"]:::stAdded
  N2["flush #40;Cpc#41; #40;F1#41;"]:::stAdded
  N3["getResult #40;Cpc#41; #40;F1#41;"]:::stModified
  N4["flush #40;Theta#41; #40;F3#41;"]:::stAdded
  N5["getResult #40;Theta#41; #40;F3#41;"]:::stModified
  N6["flush #40;TupleInt#41; #40;F4#41;"]:::stAdded
  N7["getResult #40;TupleInt#41; #40;F4#41;"]:::stModified
  N0 -->|"calls"| N1
  N3 -->|"calls"| N2
  N5 -->|"calls"| N4
  N7 -->|"calls"| N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/customobject/CpcSketchAccumulator\.java — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/CpcSketchAccumulator.java) · [after](https://github.com/apache/pinot/blob/f34e5e264b974a74b55eeda6281502d227a62c83/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/CpcSketchAccumulator.java)
- F2: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/customobject/CustomObjectAccumulator\.java — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/CustomObjectAccumulator.java) · [after](https://github.com/apache/pinot/blob/f34e5e264b974a74b55eeda6281502d227a62c83/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/CustomObjectAccumulator.java)
- F3: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/customobject/ThetaSketchAccumulator\.java — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/ThetaSketchAccumulator.java) · [after](https://github.com/apache/pinot/blob/f34e5e264b974a74b55eeda6281502d227a62c83/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/ThetaSketchAccumulator.java)
- F4: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/customobject/TupleIntSketchAccumulator\.java — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/TupleIntSketchAccumulator.java) · [after](https://github.com/apache/pinot/blob/f34e5e264b974a74b55eeda6281502d227a62c83/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/TupleIntSketchAccumulator.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImQwOGFjOTEzNjVmZDJjZWMzZGI1OTViZGI2MzY4NzhjODMzYTlkNWIiLCJjb250ZXh0X2hhc2giOiJmNzM4ODY1YmQzOTljMWVmZjk1ZjViMzY4ZTk5MDQxNGQ1NjA4MWMwMWFiOTNkYThlZDM1NGRmYzExNTVhNDAxIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NTIwNjY4LCJoZWFkX3NoYSI6ImYzNGU1ZTI2NGI5NzRhNzRiNTVlZWRhNjI4MTUwMmQyMjdhNjJjODMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJkMDhhYzkxMzY1ZmQyY2VjM2RiNTk1YmRiNjM2ODc4YzgzM2E5ZDViIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 4c17caf9ade0219090483a512e361dce65f7a0a595e552bcf62e8875f3596bb4 -->
<!-- pinot-pr-flow:end -->

## What

When an accumulator reaches its threshold, `applyInternal` calls `getResult()` to push the pending
batch into the union, and throws the returned sketch away:

```java
if (_accumulator.size() >= _threshold) {
  getResult();
  _accumulator.clear();
}
```

The union is the part that's needed. Building a sketch out of it is not.

This splits the union out of `getResult()` into a new `flush()`, and calls that instead. For Theta
the discarded result was five passes over the union gadget's hash table plus a compact sketch of up
to `nominalEntries` hashes, on every batch; for Tuple it also copied every summary.

Merging 400 stored sketches at `accumulatorThreshold=10`:

| | before | after |
| --- | --- | --- |
| Theta, lgK=14 | 16.01 ms / 17.92 MB | **5.20 ms / 2.91 MB** |
| Tuple, lgK=12 | 9.05 ms / 9.97 MB | **4.26 ms / 2.58 MB** |
| CPC, lgK=10 | 0.39 ms / 3.20 MB | 0.43 ms / 3.14 MB |

CPC is unchanged — `CpcUnion.getResult()` is cheap next to Theta's. It's included for consistency
and for the fix below.

Profiling a production cluster (80 minutes of live traffic) put
`ThetaUnionImpl.getResult` at 10.3% of all server CPU, and 21% in a Theta-heavy window. Almost all
of it was discarded.

## It also fixes data loss at accumulatorThreshold=1

The threshold branch called `getResult()`, which returns the single accumulated sketch *without*
unioning it, and `applyInternal` then cleared the accumulator — so the first sketch of every group
was silently dropped, and a later `getResult()` hit `IndexOutOfBoundsException` on the empty list.
`flush()` always unions, and the single-sketch shortcut now checks the sketch is still pending.

Seven sketches of 1000 distinct values each, at threshold 1, before this change:

```
ThetaSketchAccumulatorTest    expected [6960.14] but found [5914.93]
CpcSketchAccumulatorTest      expected [7000.78] but found [6003.72]
TupleIntSketchAccumulatorTest expected [6960.14] but found [5914.93]
```

## Tests

No existing test crossed a threshold — `testThresholdBehavior` sets it to 3 and applies 2 sketches
— so the flush path was uncovered, which is how both problems survived. Each accumulator test now
merges seven sketches at thresholds one through four and compares against a direct union of the
same sketches. The Tuple one also compares summary sums, since summaries are summed and a sketch
merged twice doubles a summary while leaving the estimate correct.

## Note for reviewers

`flush()` is `protected abstract`, so any accumulator outside this repo would need to implement it.
