### PR TITLE
Add metric for CRC-driven segment replacements

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -100,6 +100,7 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   SEGMENT_DOWNLOAD_FAILURES("segments", false),
   SEGMENT_DOWNLOAD_FROM_REMOTE_FAILURES("segments", false),
   SEGMENT_DOWNLOAD_FROM_PEERS_FAILURES("segments", false),
+  SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH("segments", false),
   SEGMENT_BUILD_FAILURE("segments", false),
   SEGMENT_UPLOAD_FAILURE("segments", false),
   SEGMENT_UPLOAD_SUCCESS("segments", false),

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -484,6 +484,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     _logger.info("Replacing segment: {} because its CRC has changed from: {} to: {}", segmentName,
         localMetadata.getCrc(), zkMetadata.getCrc());
     downloadAndLoadSegment(zkMetadata, indexLoadingConfig);
+    _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
     _logger.info("Replaced segment: {} with new CRC: {}", segmentName, zkMetadata.getCrc());
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.Utils;
@@ -176,6 +177,18 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     public boolean isFinal() {
       return this.equals(ERROR) || this.equals(COMMITTED) || this.equals(RETAINED) || this.equals(DISCARDED);
     }
+  }
+
+  /// Outcome of building the consuming segment locally and swapping it in.
+  /// Download of the committed segment is a separate fallback the caller performs when the outcome is not SUCCESS.
+  protected enum BuildSegmentResult {
+    /// Local build completed and the consuming segment was replaced with the local copy.
+    SUCCESS,
+    /// Local build failed, or the local CRC could not be read. Caller should download the committed segment.
+    FAILURE,
+    /// Local build completed, but the CRC does not match ZK. Caller should download the committed segment
+    /// instead of swapping in the divergent local copy.
+    CRC_MISMATCH
   }
 
   @VisibleForTesting
@@ -1393,56 +1406,58 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
 
   protected boolean buildSegmentAndReplace()
       throws Exception {
-    return buildSegmentAndReplace(null);
+    return buildSegmentAndReplace(null) == BuildSegmentResult.SUCCESS;
   }
 
   /// Builds the segment from the in-memory rows and replaces the CONSUMING segment with the local copy.
   ///
   /// A locally-built segment can diverge in CRC from the one the winning replica committed (e.g. different docId
   /// ordering); swapping in a divergent copy corrupts upsert metadata and leaves replicas inconsistent otherwise. So
-  /// when `committedSegmentZKMetadata` carries a CRC, a mismatch discards the local build (returns `false`) and the
+  /// when `committedSegmentZKMetadata` carries a CRC, a mismatch discards the local build and the
   /// caller downloads the committed segment. Skipped for pauseless tables and segments whose CRC is not yet set (the
   /// COMMITTING window), so we never download a not-yet-uploaded segment (see PR #17885).
   ///
   /// @param committedSegmentZKMetadata committed ZK metadata carrying the CRC, or `null` to skip the check
-  /// @return `true` if built and replaced locally; `false` if the build failed or was rejected on a CRC mismatch
-  protected boolean buildSegmentAndReplace(@Nullable SegmentZKMetadata committedSegmentZKMetadata)
+  /// @return result indicating success, build failure, or rejection caused by a confirmed CRC mismatch
+  protected BuildSegmentResult buildSegmentAndReplace(@Nullable SegmentZKMetadata committedSegmentZKMetadata)
       throws Exception {
     SegmentBuildDescriptor descriptor;
     try {
       descriptor = buildSegmentInternal(false);
     } catch (Exception e) {
-      return false;
+      return BuildSegmentResult.FAILURE;
     }
     if (descriptor == null) {
-      return false;
+      return BuildSegmentResult.FAILURE;
     }
     boolean crcCheckEnabled = committedSegmentZKMetadata != null && committedSegmentZKMetadata.getCrc() >= 0
         && !PauselessConsumptionUtils.isPauselessEnabled(_tableConfig);
-    if (crcCheckEnabled && !isLocalSegmentCrcMatchingZk(committedSegmentZKMetadata)) {
-      _segmentLogger.warn("Locally-built segment: {} CRC does not match committed CRC: {} in zk. "
-          + "Skipping local build to replace", _segmentNameStr, committedSegmentZKMetadata.getCrc());
-      return false;
+    if (crcCheckEnabled) {
+      try {
+        if (!isLocalSegmentCrcMatchingZk(committedSegmentZKMetadata)) {
+          _segmentLogger.warn("Locally-built segment: {} CRC does not match committed CRC: {} in zk. "
+              + "Skipping local build to replace", _segmentNameStr, committedSegmentZKMetadata.getCrc());
+          return BuildSegmentResult.CRC_MISMATCH;
+        }
+      } catch (Exception e) {
+        _segmentLogger.warn("Failed to read CRC of locally-built segment: {}; treating as a build failure to download "
+            + "the committed segment", _segmentNameStr, e);
+        return BuildSegmentResult.FAILURE;
+      }
     }
     // On a CRC match use the committed metadata; otherwise the construction-time metadata.
     _realtimeTableDataManager.replaceConsumingSegment(_segmentNameStr,
         crcCheckEnabled ? committedSegmentZKMetadata : _segmentZKMetadata);
-    return true;
+    return BuildSegmentResult.SUCCESS;
   }
 
-  /// Whether the just-built local segment's CRC matches the committed CRC in ZK. Returns `false` if the local metadata
-  /// cannot be read, so the caller downloads the committed segment rather than failing the transition.
+  /// Whether the just-built local segment's CRC matches the committed CRC in ZK.
   @VisibleForTesting
-  protected boolean isLocalSegmentCrcMatchingZk(SegmentZKMetadata committedSegmentZKMetadata) {
+  protected boolean isLocalSegmentCrcMatchingZk(SegmentZKMetadata committedSegmentZKMetadata)
+      throws IOException, ConfigurationException {
     File indexDir = new File(_resourceDataDir, _segmentNameStr);
-    try {
-      SegmentMetadataImpl localMetadata = new SegmentMetadataImpl(indexDir);
-      return BaseTableDataManager.hasSameCRC(committedSegmentZKMetadata, localMetadata);
-    } catch (Exception e) {
-      _segmentLogger.warn("Failed to read CRC of locally-built segment: {}; treating as CRC mismatch to download the "
-          + "committed segment", _segmentNameStr, e);
-      return false;
-    }
+    SegmentMetadataImpl localMetadata = new SegmentMetadataImpl(indexDir);
+    return BaseTableDataManager.hasSameCRC(committedSegmentZKMetadata, localMetadata);
   }
 
   private void closeStreamConsumer() {
@@ -1673,10 +1688,15 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
           } else if (_currentOffset.compareTo(endOffset) == 0) {
             _segmentLogger.info("Current offset {} matches offset in zk {}. Replacing segment", _currentOffset,
                 endOffset);
-            if (!buildSegmentAndReplace(segmentZKMetadata)) {
+            BuildSegmentResult buildSegmentResult = buildSegmentAndReplace(segmentZKMetadata);
+            if (buildSegmentResult != BuildSegmentResult.SUCCESS) {
               _segmentLogger.warn("Failed to build the segment: {} and replace. Downloading to replace",
                   _segmentNameStr);
               downloadSegmentAndReplace(segmentZKMetadata);
+              if (buildSegmentResult == BuildSegmentResult.CRC_MISMATCH) {
+                _serverMetrics.addMeteredTableValue(_tableNameWithType,
+                    ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
+              }
             }
           } else {
             boolean success = false;
@@ -1695,10 +1715,15 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
             if (success) {
               _segmentLogger.info("Caught up to offset {}", _currentOffset);
               // After catching up the offset matches zk; apply the same CRC guard as the matched-offset case.
-              if (!buildSegmentAndReplace(segmentZKMetadata)) {
+              BuildSegmentResult buildSegmentResult = buildSegmentAndReplace(segmentZKMetadata);
+              if (buildSegmentResult != BuildSegmentResult.SUCCESS) {
                 _segmentLogger.warn("Failed to build the segment: {} after catchup. Downloading to replace",
                     _segmentNameStr);
                 downloadSegmentAndReplace(segmentZKMetadata);
+                if (buildSegmentResult == BuildSegmentResult.CRC_MISMATCH) {
+                  _serverMetrics.addMeteredTableValue(_tableNameWithType,
+                      ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
+                }
               }
             } else {
               _segmentLogger

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.common.utils.TarCompressionUtils;
@@ -81,6 +82,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -379,12 +381,34 @@ public class BaseTableDataManagerTest {
     // the one in zk, thus raw segment is downloaded and loaded.
     ImmutableSegmentDataManager segmentDataManager = createImmutableSegmentDataManager(SEGMENT_NAME, 0);
 
+    ServerMetrics serverMetrics = ServerMetrics.get();
+    clearInvocations(serverMetrics);
     BaseTableDataManager tableDataManager = createTableManager();
     File dataDir = tableDataManager.getSegmentDataDir(SEGMENT_NAME);
     assertFalse(dataDir.exists());
     tableDataManager.replaceSegmentIfCrcMismatch(segmentDataManager, zkMetadata, new IndexLoadingConfig());
+    verify(serverMetrics)
+        .addMeteredTableValue(OFFLINE_TABLE_NAME, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
     assertTrue(dataDir.exists());
     assertEquals(new SegmentMetadataImpl(dataDir).getTotalDocs(), 5);
+  }
+
+  @Test
+  public void testCrcReplacementMetricNotEmittedWhenDownloadFails()
+      throws Exception {
+    SegmentZKMetadata zkMetadata = createRawSegment(SegmentVersion.v3, 5);
+    ImmutableSegmentDataManager segmentDataManager = createImmutableSegmentDataManager(SEGMENT_NAME, 0);
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
+    ServerMetrics serverMetrics = ServerMetrics.get();
+    clearInvocations(serverMetrics);
+    BaseTableDataManager tableDataManager = spy(createTableManager());
+    doThrow(new IOException("download failed")).when(tableDataManager)
+        .downloadAndLoadSegment(zkMetadata, indexLoadingConfig);
+
+    assertThrows(IOException.class,
+        () -> tableDataManager.replaceSegmentIfCrcMismatch(segmentDataManager, zkMetadata, indexLoadingConfig));
+    verify(serverMetrics, never())
+        .addMeteredTableValue(OFFLINE_TABLE_NAME, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
   }
 
   @Test
@@ -428,11 +452,37 @@ public class BaseTableDataManagerTest {
 
     ImmutableSegmentDataManager segmentDataManager = createImmutableSegmentDataManager(segmentName, 1024L);
 
+    ServerMetrics serverMetrics = ServerMetrics.get();
+    clearInvocations(serverMetrics);
     BaseTableDataManager tableDataManager = createTableManager();
     assertFalse(tableDataManager.getSegmentDataDir(segmentName).exists());
     tableDataManager.replaceSegmentIfCrcMismatch(segmentDataManager, zkMetadata, new IndexLoadingConfig());
+    verify(serverMetrics, never())
+        .addMeteredTableValue(OFFLINE_TABLE_NAME, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
     // As CRC is same, the index dir is left as is, so not get created by the test.
     assertFalse(tableDataManager.getSegmentDataDir(segmentName).exists());
+  }
+
+  @Test
+  public void testCrcMismatchMetricNotEmittedWhenCrcCheckDisabled()
+      throws Exception {
+    SegmentZKMetadata zkMetadata = createRawSegment(SegmentVersion.v3, 5);
+    InstanceDataManagerConfig instanceDataManagerConfig = createDefaultInstanceDataManagerConfig();
+    when(instanceDataManagerConfig.shouldCheckCRCOnSegmentLoad()).thenReturn(false);
+    ServerMetrics serverMetrics = ServerMetrics.get();
+    clearInvocations(serverMetrics);
+
+    BaseTableDataManager tableDataManager = createTableManager(instanceDataManagerConfig);
+    File indexDir = createSegment(SegmentVersion.v3, 3);
+    tableDataManager.addNewOnlineSegment(zkMetadata, new IndexLoadingConfig());
+    verify(serverMetrics, never())
+        .addMeteredTableValue(OFFLINE_TABLE_NAME, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
+    assertEquals(new SegmentMetadataImpl(indexDir).getTotalDocs(), 3);
+
+    ImmutableSegmentDataManager segmentDataManager = createImmutableSegmentDataManager(SEGMENT_NAME, 0);
+    tableDataManager.replaceSegmentIfCrcMismatch(segmentDataManager, zkMetadata, new IndexLoadingConfig());
+    verify(serverMetrics, never())
+        .addMeteredTableValue(OFFLINE_TABLE_NAME, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
   }
 
   @Test
@@ -680,6 +730,8 @@ public class BaseTableDataManagerTest {
 
     // Create a local segment with fewer rows, making its CRC different from the raw segment.
     // So that the raw segment is downloaded and loaded in the end.
+    ServerMetrics serverMetrics = ServerMetrics.get();
+    clearInvocations(serverMetrics);
     BaseTableDataManager tableDataManager = createTableManager();
     File indexDir = createSegment(SegmentVersion.v3, 3);
     File backupDir =
@@ -688,6 +740,8 @@ public class BaseTableDataManagerTest {
 
     assertFalse(indexDir.exists());
     tableDataManager.addNewOnlineSegment(zkMetadata, new IndexLoadingConfig());
+    verify(serverMetrics, never())
+        .addMeteredTableValue(OFFLINE_TABLE_NAME, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
     assertEquals(tableDataManager.getSegmentDataDir(SEGMENT_NAME), indexDir);
     assertTrue(indexDir.exists());
     assertEquals(new SegmentMetadataImpl(indexDir).getTotalDocs(), 5);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -35,9 +35,11 @@ import java.util.concurrent.locks.Lock;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.common.utils.LLCSegmentName;
@@ -87,6 +89,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
 
 
 // TODO Re-write this test using the stream abstraction
@@ -184,6 +189,14 @@ public class RealtimeSegmentDataManagerTest {
   private FakeRealtimeSegmentDataManager createFakeSegmentManager(boolean noUpsert, TimeSupplier timeSupplier,
       @Nullable String maxRows, @Nullable String maxDuration, @Nullable TableConfig tableConfig)
       throws Exception {
+    return createFakeSegmentManager(noUpsert, timeSupplier, maxRows, maxDuration, tableConfig,
+        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()));
+  }
+
+  private FakeRealtimeSegmentDataManager createFakeSegmentManager(boolean noUpsert, TimeSupplier timeSupplier,
+      @Nullable String maxRows, @Nullable String maxDuration, @Nullable TableConfig tableConfig,
+      ServerMetrics serverMetrics)
+      throws Exception {
     SegmentZKMetadata segmentZKMetadata = createZkMetadata();
     if (tableConfig == null) {
       tableConfig = createTableConfig();
@@ -208,7 +221,6 @@ public class RealtimeSegmentDataManagerTest {
     _partitionGroupIdToConsumerCoordinatorMap.putIfAbsent(PARTITION_GROUP_ID,
         new ConsumerCoordinator(false, tableDataManager));
     Schema schema = Fixtures.createSchema();
-    ServerMetrics serverMetrics = new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
     return new FakeRealtimeSegmentDataManager(segmentZKMetadata, tableConfig, tableDataManager,
         new File(TEMP_DIR, REALTIME_TABLE_NAME).getAbsolutePath(), schema, llcSegmentName,
         _partitionGroupIdToConsumerCoordinatorMap, serverMetrics, timeSupplier);
@@ -641,7 +653,9 @@ public class RealtimeSegmentDataManagerTest {
     }
 
     // Test downloadAndReplace is called after buildAndReplace fails.
-    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
+    ServerMetrics buildFailureServerMetrics = mock(ServerMetrics.class);
+    try (FakeRealtimeSegmentDataManager segmentDataManager =
+        createFakeSegmentManager(false, new TimeSupplier(), null, null, null, buildFailureServerMetrics)) {
       segmentDataManager._failSegmentBuildAndReplace = true;
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, RealtimeSegmentDataManager.State.HOLDING);
@@ -649,6 +663,8 @@ public class RealtimeSegmentDataManagerTest {
       segmentDataManager.goOnlineFromConsuming(metadata);
       Assert.assertTrue(segmentDataManager._downloadAndReplaceCalled);
       Assert.assertTrue(segmentDataManager._buildAndReplaceCalled);
+      verify(buildFailureServerMetrics, never())
+          .addMeteredTableValue(REALTIME_TABLE_NAME, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
     }
   }
 
@@ -658,11 +674,15 @@ public class RealtimeSegmentDataManagerTest {
     long finalOffsetValue = START_OFFSET_VALUE + 600;
 
     // Upsert + committed CRC set + local CRC mismatch -> discard local build, download the committed segment.
-    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
+    ServerMetrics crcMismatchServerMetrics = mock(ServerMetrics.class);
+    try (FakeRealtimeSegmentDataManager segmentDataManager =
+        createFakeSegmentManager(false, new TimeSupplier(), null, null, null, crcMismatchServerMetrics)) {
       when(segmentDataManager._tableDataManager.isUpsertEnabled()).thenReturn(true);
       runGoOnlineForCrcGuard(segmentDataManager, crcMetadata(finalOffsetValue, 12345L), false, finalOffsetValue);
-      Assert.assertTrue(segmentDataManager._buildAndReplaceCalled);
-      Assert.assertTrue(segmentDataManager._downloadAndReplaceCalled);
+      assertTrue(segmentDataManager._buildAndReplaceCalled);
+      assertTrue(segmentDataManager._downloadAndReplaceCalled);
+      verify(crcMismatchServerMetrics)
+          .addMeteredTableValue(REALTIME_TABLE_NAME, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
     }
 
     // Non-upsert + committed CRC set + local CRC mismatch -> discard local build, download the committed segment.
@@ -674,48 +694,170 @@ public class RealtimeSegmentDataManagerTest {
     }
 
     // Upsert + committed CRC set + local CRC match -> build locally, no download, swap in committed metadata.
-    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
+    ServerMetrics matchingUpsertServerMetrics = mock(ServerMetrics.class);
+    try (FakeRealtimeSegmentDataManager segmentDataManager =
+        createFakeSegmentManager(false, new TimeSupplier(), null, null, null, matchingUpsertServerMetrics)) {
       when(segmentDataManager._tableDataManager.isUpsertEnabled()).thenReturn(true);
       SegmentZKMetadata committedMetadata = crcMetadata(finalOffsetValue, 12345L);
       runGoOnlineForCrcGuard(segmentDataManager, committedMetadata, true, finalOffsetValue);
       Assert.assertTrue(segmentDataManager._buildAndReplaceCalled);
       Assert.assertFalse(segmentDataManager._downloadAndReplaceCalled);
+      verify(matchingUpsertServerMetrics, never())
+          .addMeteredTableValue(REALTIME_TABLE_NAME, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
       verify(segmentDataManager._tableDataManager)
           .replaceConsumingSegment(eq(SEGMENT_NAME_STR), same(committedMetadata));
     }
 
     // Non-upsert + committed CRC set + local CRC match -> build locally, no download, swap in committed metadata.
-    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
+    ServerMetrics matchingNonUpsertServerMetrics = mock(ServerMetrics.class);
+    try (FakeRealtimeSegmentDataManager segmentDataManager =
+        createFakeSegmentManager(false, new TimeSupplier(), null, null, null, matchingNonUpsertServerMetrics)) {
       when(segmentDataManager._tableDataManager.isUpsertEnabled()).thenReturn(false);
       SegmentZKMetadata committedMetadata = crcMetadata(finalOffsetValue, 12345L);
       runGoOnlineForCrcGuard(segmentDataManager, committedMetadata, true, finalOffsetValue);
       Assert.assertTrue(segmentDataManager._buildAndReplaceCalled);
       Assert.assertFalse(segmentDataManager._downloadAndReplaceCalled);
+      verify(matchingNonUpsertServerMetrics, never())
+          .addMeteredTableValue(REALTIME_TABLE_NAME, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
       verify(segmentDataManager._tableDataManager)
           .replaceConsumingSegment(eq(SEGMENT_NAME_STR), same(committedMetadata));
     }
 
     // Committed CRC unset (-1) -> guard skipped, build locally with construction-time metadata.
-    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
+    ServerMetrics unsetCrcServerMetrics = mock(ServerMetrics.class);
+    try (FakeRealtimeSegmentDataManager segmentDataManager =
+        createFakeSegmentManager(false, new TimeSupplier(), null, null, null, unsetCrcServerMetrics)) {
       when(segmentDataManager._tableDataManager.isUpsertEnabled()).thenReturn(false);
       SegmentZKMetadata committedMetadata = crcMetadata(finalOffsetValue, -1L);
       runGoOnlineForCrcGuard(segmentDataManager, committedMetadata, false, finalOffsetValue);
       Assert.assertTrue(segmentDataManager._buildAndReplaceCalled);
       Assert.assertFalse(segmentDataManager._downloadAndReplaceCalled);
+      verify(unsetCrcServerMetrics, never())
+          .addMeteredTableValue(REALTIME_TABLE_NAME, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
       verify(segmentDataManager._tableDataManager)
           .replaceConsumingSegment(eq(SEGMENT_NAME_STR), argThat(m -> m != committedMetadata));
     }
 
     // Pauseless table -> guard skipped, build locally with construction-time metadata.
+    ServerMetrics pauselessServerMetrics = mock(ServerMetrics.class);
     try (FakeRealtimeSegmentDataManager segmentDataManager =
-        createFakeSegmentManager(false, new TimeSupplier(), null, null, createPauselessTableConfig())) {
+        createFakeSegmentManager(false, new TimeSupplier(), null, null, createPauselessTableConfig(),
+            pauselessServerMetrics)) {
       when(segmentDataManager._tableDataManager.isUpsertEnabled()).thenReturn(false);
       SegmentZKMetadata committedMetadata = crcMetadata(finalOffsetValue, 12345L);
       runGoOnlineForCrcGuard(segmentDataManager, committedMetadata, false, finalOffsetValue);
       Assert.assertTrue(segmentDataManager._buildAndReplaceCalled);
       Assert.assertFalse(segmentDataManager._downloadAndReplaceCalled);
+      verify(pauselessServerMetrics, never())
+          .addMeteredTableValue(REALTIME_TABLE_NAME, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
       verify(segmentDataManager._tableDataManager)
           .replaceConsumingSegment(eq(SEGMENT_NAME_STR), argThat(m -> m != committedMetadata));
+    }
+  }
+
+  @Test
+  public void testCrcReplacementMetricForCatchup()
+      throws Exception {
+    long finalOffsetValue = START_OFFSET_VALUE + 600;
+    LongMsgOffset finalOffset = new LongMsgOffset(finalOffsetValue);
+    SegmentZKMetadata metadata = crcMetadata(finalOffsetValue, 12345L);
+    ServerMetrics serverMetrics = mock(ServerMetrics.class);
+    try (FakeRealtimeSegmentDataManager segmentDataManager =
+        createFakeSegmentManager(false, new TimeSupplier(), null, null, null, serverMetrics)) {
+      segmentDataManager._useRealBuildAndReplace = true;
+      segmentDataManager._localSegmentCrcMatchesZk = false;
+      segmentDataManager.getConsumerSemaphoreAcquired().set(true);
+      segmentDataManager._stopWaitTimeMs = 0;
+      segmentDataManager._state.set(segmentDataManager, RealtimeSegmentDataManager.State.CATCHING_UP);
+      segmentDataManager._consumeOffsets.add(finalOffset);
+
+      segmentDataManager.goOnlineFromConsuming(metadata);
+
+      assertTrue(segmentDataManager._buildAndReplaceCalled);
+      assertTrue(segmentDataManager._downloadAndReplaceCalled);
+      verify(serverMetrics)
+          .addMeteredTableValue(REALTIME_TABLE_NAME, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
+    }
+  }
+
+  @Test
+  public void testCrcReplacementMetricNotEmittedForCatchupBuildFailure()
+      throws Exception {
+    long finalOffsetValue = START_OFFSET_VALUE + 600;
+    SegmentZKMetadata metadata = crcMetadata(finalOffsetValue, 12345L);
+    ServerMetrics serverMetrics = mock(ServerMetrics.class);
+    try (FakeRealtimeSegmentDataManager segmentDataManager =
+        createFakeSegmentManager(false, new TimeSupplier(), null, null, null, serverMetrics)) {
+      segmentDataManager._failSegmentBuildAndReplace = true;
+      segmentDataManager.getConsumerSemaphoreAcquired().set(true);
+      segmentDataManager._stopWaitTimeMs = 0;
+      segmentDataManager._state.set(segmentDataManager, RealtimeSegmentDataManager.State.CATCHING_UP);
+      segmentDataManager._consumeOffsets.add(new LongMsgOffset(finalOffsetValue));
+
+      segmentDataManager.goOnlineFromConsuming(metadata);
+
+      assertTrue(segmentDataManager._buildAndReplaceCalled);
+      assertTrue(segmentDataManager._downloadAndReplaceCalled);
+      verify(serverMetrics, never())
+          .addMeteredTableValue(REALTIME_TABLE_NAME, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
+    }
+  }
+
+  @Test
+  public void testCrcReplacementMetricNotEmittedForCrcReadError()
+      throws Exception {
+    long finalOffsetValue = START_OFFSET_VALUE + 600;
+    ServerMetrics serverMetrics = mock(ServerMetrics.class);
+    try (FakeRealtimeSegmentDataManager segmentDataManager =
+        createFakeSegmentManager(false, new TimeSupplier(), null, null, null, serverMetrics)) {
+      segmentDataManager._useRealCrcCheck = true;
+      FileUtils.deleteQuietly(new File(new File(TEMP_DIR, REALTIME_TABLE_NAME), SEGMENT_NAME_STR));
+      runGoOnlineForCrcGuard(segmentDataManager, crcMetadata(finalOffsetValue, 12345L), false, finalOffsetValue);
+
+      assertTrue(segmentDataManager._buildAndReplaceCalled);
+      assertTrue(segmentDataManager._downloadAndReplaceCalled);
+      verify(serverMetrics, never())
+          .addMeteredTableValue(REALTIME_TABLE_NAME, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
+    }
+  }
+
+  @Test
+  public void testCrcReplacementMetricNotEmittedWhenMatchedOffsetDownloadFails()
+      throws Exception {
+    long finalOffsetValue = START_OFFSET_VALUE + 600;
+    ServerMetrics serverMetrics = mock(ServerMetrics.class);
+    try (FakeRealtimeSegmentDataManager segmentDataManager =
+        createFakeSegmentManager(false, new TimeSupplier(), null, null, null, serverMetrics)) {
+      segmentDataManager._failDownloadAndReplace = true;
+
+      assertThrows(IOException.class, () ->
+          runGoOnlineForCrcGuard(segmentDataManager, crcMetadata(finalOffsetValue, 12345L), false, finalOffsetValue));
+
+      verify(serverMetrics, never())
+          .addMeteredTableValue(REALTIME_TABLE_NAME, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
+    }
+  }
+
+  @Test
+  public void testCrcReplacementMetricNotEmittedWhenCatchupDownloadFails()
+      throws Exception {
+    long finalOffsetValue = START_OFFSET_VALUE + 600;
+    SegmentZKMetadata metadata = crcMetadata(finalOffsetValue, 12345L);
+    ServerMetrics serverMetrics = mock(ServerMetrics.class);
+    try (FakeRealtimeSegmentDataManager segmentDataManager =
+        createFakeSegmentManager(false, new TimeSupplier(), null, null, null, serverMetrics)) {
+      segmentDataManager._useRealBuildAndReplace = true;
+      segmentDataManager._localSegmentCrcMatchesZk = false;
+      segmentDataManager._failDownloadAndReplace = true;
+      segmentDataManager.getConsumerSemaphoreAcquired().set(true);
+      segmentDataManager._stopWaitTimeMs = 0;
+      segmentDataManager._state.set(segmentDataManager, RealtimeSegmentDataManager.State.CATCHING_UP);
+      segmentDataManager._consumeOffsets.add(new LongMsgOffset(finalOffsetValue));
+
+      assertThrows(IOException.class, () -> segmentDataManager.goOnlineFromConsuming(metadata));
+
+      verify(serverMetrics, never())
+          .addMeteredTableValue(REALTIME_TABLE_NAME, ServerMeter.SEGMENT_REPLACED_DUE_TO_CRC_MISMATCH, 1);
     }
   }
 
@@ -766,26 +908,11 @@ public class RealtimeSegmentDataManagerTest {
 
       SegmentZKMetadata matchingMetadata = new SegmentZKMetadata(SEGMENT_NAME_STR);
       matchingMetadata.setCrc(localCrc);
-      Assert.assertTrue(segmentDataManager.isLocalSegmentCrcMatchingZk(matchingMetadata));
+      assertTrue(segmentDataManager.isLocalSegmentCrcMatchingZk(matchingMetadata));
 
       SegmentZKMetadata mismatchingMetadata = new SegmentZKMetadata(SEGMENT_NAME_STR);
       mismatchingMetadata.setCrc(localCrc + 1);
-      Assert.assertFalse(segmentDataManager.isLocalSegmentCrcMatchingZk(mismatchingMetadata));
-    }
-  }
-
-  // When the locally-built segment cannot be read (e.g. missing/corrupt), the CRC check must report a mismatch so the
-  // ONLINE transition downloads the committed segment instead of throwing.
-  @Test
-  public void testIsLocalSegmentCrcMatchingZkTreatsUnreadableSegmentAsMismatch()
-      throws Exception {
-    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
-      segmentDataManager._useRealCrcCheck = true;
-      // No segment was built under the resource dir, so the metadata read fails.
-      FileUtils.deleteQuietly(new File(new File(TEMP_DIR, REALTIME_TABLE_NAME), SEGMENT_NAME_STR));
-      SegmentZKMetadata metadata = new SegmentZKMetadata(SEGMENT_NAME_STR);
-      metadata.setCrc(12345L);
-      Assert.assertFalse(segmentDataManager.isLocalSegmentCrcMatchingZk(metadata));
+      assertFalse(segmentDataManager.isLocalSegmentCrcMatchingZk(mismatchingMetadata));
     }
   }
 
@@ -1355,11 +1482,8 @@ public class RealtimeSegmentDataManagerTest {
     public Field _stopReason;
     public Field _segmentBuildFailedWithDeterministicError;
     public boolean _failSegmentBuildAndReplace = false;
-    // When set, buildSegmentAndReplace runs the real implementation (including the upsert CRC guard) instead of being
-    // short-circuited, and isLocalSegmentCrcMatchingZk returns _localSegmentCrcMatchesZk.
     public boolean _useRealBuildAndReplace = false;
     public boolean _localSegmentCrcMatchesZk = true;
-    // When set, isLocalSegmentCrcMatchingZk runs the real on-disk metadata read + CRC comparison.
     public boolean _useRealCrcCheck = false;
     private Field _streamMsgOffsetFactory;
     public LinkedList<LongMsgOffset> _consumeOffsets = new LinkedList<>();
@@ -1368,6 +1492,7 @@ public class RealtimeSegmentDataManagerTest {
     public boolean _buildSegmentCalled = false;
     public boolean _failSegmentBuild = false;
     public boolean _buildAndReplaceCalled = false;
+    public boolean _failDownloadAndReplace = false;
     public int _stopWaitTimeMs = 100;
     private boolean _downloadAndReplaceCalled = false;
     private boolean _notifySegmentBuildFailedWithDeterministicErrorCalled = false;
@@ -1530,18 +1655,19 @@ public class RealtimeSegmentDataManagerTest {
     }
 
     @Override
-    protected boolean buildSegmentAndReplace(SegmentZKMetadata committedSegmentZKMetadata)
+    protected BuildSegmentResult buildSegmentAndReplace(SegmentZKMetadata committedSegmentZKMetadata)
         throws Exception {
       terminateLoopIfNecessary();
       _buildAndReplaceCalled = true;
       if (_useRealBuildAndReplace) {
         return super.buildSegmentAndReplace(committedSegmentZKMetadata);
       }
-      return !_failSegmentBuildAndReplace;
+      return _failSegmentBuildAndReplace ? BuildSegmentResult.FAILURE : BuildSegmentResult.SUCCESS;
     }
 
     @Override
-    protected boolean isLocalSegmentCrcMatchingZk(SegmentZKMetadata committedSegmentZKMetadata) {
+    protected boolean isLocalSegmentCrcMatchingZk(SegmentZKMetadata committedSegmentZKMetadata)
+        throws IOException, ConfigurationException {
       if (_useRealCrcCheck) {
         return super.isLocalSegmentCrcMatchingZk(committedSegmentZKMetadata);
       }
@@ -1580,8 +1706,12 @@ public class RealtimeSegmentDataManagerTest {
     }
 
     @Override
-    protected void downloadSegmentAndReplace(SegmentZKMetadata metadata) {
+    protected void downloadSegmentAndReplace(SegmentZKMetadata metadata)
+        throws Exception {
       terminateLoopIfNecessary();
+      if (_failDownloadAndReplace) {
+        throw new IOException("download failed");
+      }
       _downloadAndReplaceCalled = true;
     }
 


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Tracks CRC‑driven segment replacements in offline and realtime paths, incrementing metric only on successful replacement after CRC mismatch\.

```mermaid
flowchart TD
  N0["Add metric SEGMENT#95;REPLACED#95;DUE#95;TO#95;CRC#95;MISMATCH #40;F1#41;"]:::stModified
  N1["Offline replaceSegmentIfCrcMismatch#58; downloadAndLoadSegment then increment meter #40;F2#41;"]:::stModified
  N2["Realtime goOnlineFromConsuming#58; invoke buildSegmentAndReplace #40;F3#41;"]:::stModified
  N3["buildSegmentAndReplace returns BuildSegmentResult #40;SUCCESS#47;FAILURE#47;CRC#95;MISMATCH#41; #40;F3#41;"]:::stModified
  N4["If result #33;#61; SUCCESS then downloadSegmentAndReplace #40;F3#41;"]:::stModified
  N5["If result #61;#61; CRC#95;MISMATCH then increment meter #40;F3#41;"]:::stModified
  N0 -->|"uses"| N1
  N0 -->|"uses"| N5
  N2 -->|"calls"| N3
  N3 -->|"branches on #33;#61; SUCCESS"| N4
  N4 -->|"after download#44; branches on #61;#61; CRC#95;MISMATCH"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter\.java — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java) · [after](https://github.com/apache/pinot/blob/3693722c4fb11eec919af28a57106e9031e0b525/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager\.java — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java) · [after](https://github.com/apache/pinot/blob/3693722c4fb11eec919af28a57106e9031e0b525/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java)
- F3: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager\.java — [before](https://github.com/apache/pinot/blob/d08ac91365fd2cec3db595bdb636878c833a9d5b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java) · [after](https://github.com/apache/pinot/blob/3693722c4fb11eec919af28a57106e9031e0b525/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImQwOGFjOTEzNjVmZDJjZWMzZGI1OTViZGI2MzY4NzhjODMzYTlkNWIiLCJjb250ZXh0X2hhc2giOiIwODJhODA1OTgwOTg3ZDhmMmVhNTJmNmViY2QzZGIyM2E5MTJhMWYwMTMyM2ExNjVmNTIwMDZlZjBhNTZlYjFkIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NTM2NDgxLCJoZWFkX3NoYSI6IjM2OTM3MjJjNGZiMTFlZWM5MTlhZjI4YTU3MTA2ZTkwMzFlMGI1MjUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJhODQ3NmY5ODhjZmQ4MjNiMzZlMDA2OWY2ZDAwZjNiZmQzOTFhNTMxIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 27064483d746dbca19ae6e88f7fc6c7a350a03780d06ec349ce9e04d7f3e41ca -->
<!-- pinot-pr-flow:end -->

Expose table-level observability for replicas that replace a segment after a confirmed CRC mismatch. Count only successful replacements so failed downloads and CRC read errors do not inflate the signal.
