### PR TITLE
Detect servers that stop answering queries but keep their connection open

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -21,6 +21,7 @@ package org.apache.pinot.broker.requesthandler;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -157,9 +158,51 @@ public class SingleConnectionBrokerRequestHandler extends BaseSingleStageBrokerR
         serversNotResponded.add(entry.getKey());
       }
     }
+    reportScatterOutcomeToFailureDetector(timedOut, dataTableMap.keySet(), serversNotResponded);
+
     ScatterResultStats stats = new ScatterResultStats(
         dataTableMap.size() + serversNotResponded.size(), dataTableMap.size(), totalResponseSize);
     return new ScatterResult(dataTableMap, serversNotResponded, stats, timedOut, asyncQueryResponse.getException());
+  }
+
+  /// Reports the per-server outcome of a scatter-gather to the failure detector, which is how a server that stops
+  /// answering while keeping its connection open is detected at all — see
+  /// [FailureDetector#notifyServerNotResponded], whose sole-non-responder contract this honours.
+  ///
+  /// Nothing is attributed unless the query timed out: a `FAILED` response was aborted early by a send failure or a
+  /// channel teardown, both already reported through [AsyncQueryResponse#getFailedServer()], and aborting leaves
+  /// servers that were never given a chance to answer in `serversNotResponded`.
+  private void reportScatterOutcomeToFailureDetector(boolean timedOut,
+      Collection<ServerRoutingInstance> serversResponded, Collection<ServerRoutingInstance> serversNotResponded) {
+    // Any response clears the server's accumulated unanswered-request count, so this runs on every query and not just
+    // on timed-out ones.
+    for (ServerRoutingInstance serverRoutingInstance : serversResponded) {
+      _failureDetector.notifyServerResponded(serverRoutingInstance.getInstanceId());
+    }
+    if (timedOut) {
+      ServerRoutingInstance soleServerNotResponded = getSoleServerNotResponded(serversNotResponded);
+      if (soleServerNotResponded != null) {
+        _failureDetector.notifyServerNotResponded(soleServerNotResponded.getInstanceId(),
+            soleServerNotResponded.getHostname());
+      }
+    }
+  }
+
+  /// Returns the single server behind `serversNotResponded`, or `null` if it is empty or covers more than one server.
+  /// A hybrid query sends a separate request to the OFFLINE and REALTIME halves of the same server, so two routing
+  /// instances sharing one instance id are one server, not two.
+  @Nullable
+  private static ServerRoutingInstance getSoleServerNotResponded(
+      Collection<ServerRoutingInstance> serversNotResponded) {
+    ServerRoutingInstance sole = null;
+    for (ServerRoutingInstance serverRoutingInstance : serversNotResponded) {
+      if (sole == null) {
+        sole = serverRoutingInstance;
+      } else if (!sole.getInstanceId().equals(serverRoutingInstance.getInstanceId())) {
+        return null;
+      }
+    }
+    return sole;
   }
 
   /// Executes the reduce step on the scatter result and populates the response with server stats.
@@ -241,8 +284,9 @@ public class SingleConnectionBrokerRequestHandler extends BaseSingleStageBrokerR
     Map<ServerRoutingInstance, ServerResponse> baseFinalResponses = baseAsyncResponse.getFinalResponses();
     Map<ServerRoutingInstance, ServerResponse> viewFinalResponses = materializedViewAsyncResponse.getFinalResponses();
 
-    if (baseAsyncResponse.getStatus() == QueryResponse.Status.TIMED_OUT
-        || materializedViewAsyncResponse.getStatus() == QueryResponse.Status.TIMED_OUT) {
+    boolean timedOut = baseAsyncResponse.getStatus() == QueryResponse.Status.TIMED_OUT
+        || materializedViewAsyncResponse.getStatus() == QueryResponse.Status.TIMED_OUT;
+    if (timedOut) {
       _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.BROKER_RESPONSES_WITH_TIMEOUTS, 1);
     }
 
@@ -272,6 +316,11 @@ public class SingleConnectionBrokerRequestHandler extends BaseSingleStageBrokerR
             totalResponseSizeHolder);
     long totalResponseSize = totalResponseSizeHolder[0];
     int numServersResponded = dataTableMap.size();
+
+    // Report here too, not only from doScatter. Reporting the responders is what resets their unanswered-request
+    // counts, so a path that stays silent would let a server accumulate counts from other queries while it is
+    // answering these ones perfectly well, and eventually get it ejected.
+    reportScatterOutcomeToFailureDetector(timedOut, dataTableMap.keySet(), serversNotResponded);
 
     /// On a SPLIT query, base and MV scatter-gathers cover DISJOINT halves of the timeline
     /// (base covers `ts < boundary`, MV covers `ts >= boundary`).  Partial failure on either
@@ -437,11 +486,13 @@ public class SingleConnectionBrokerRequestHandler extends BaseSingleStageBrokerR
       return FailureDetector.ServerState.UNKNOWN;
     }
 
-    if (_queryRouter.connect(serverInstance)) {
-      LOGGER.info("Successfully connect to server: {}, marking it healthy", instanceId);
+    // A fresh connection proves the server is reachable, not that it can answer a query: a process that is alive
+    // but wedged passes this. Erring that way keeps a merely busy server from being stranded.
+    if (_queryRouter.probeConnection(serverInstance)) {
+      LOGGER.info("Server: {} accepted a new connection, marking it healthy", instanceId);
       return FailureDetector.ServerState.HEALTHY;
     } else {
-      LOGGER.warn("Still cannot connect to server: {}, retry later", instanceId);
+      LOGGER.warn("Server: {} still does not accept connections, retry later", instanceId);
       return FailureDetector.ServerState.UNHEALTHY;
     }
   }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandlerFailureDetectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandlerFailureDetectorTest.java
@@ -1,0 +1,435 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.pinot.broker.broker.AllowAllAccessControlFactory;
+import org.apache.pinot.broker.queryquota.QueryQuotaManager;
+import org.apache.pinot.broker.routing.manager.BrokerRoutingManager;
+import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.datatable.DataTable.MetadataKey;
+import org.apache.pinot.common.failuredetector.FailureDetector;
+import org.apache.pinot.common.failuredetector.FailureDetectorFactory;
+import org.apache.pinot.common.metrics.BrokerGauge;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.metrics.MetricValueUtils;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.core.common.datatable.DataTableBuilderFactory;
+import org.apache.pinot.core.routing.ImplicitHybridTableRouteInfo;
+import org.apache.pinot.core.routing.MultiClusterRoutingContext;
+import org.apache.pinot.core.routing.SegmentsToQuery;
+import org.apache.pinot.core.routing.TableRouteInfo;
+import org.apache.pinot.core.transport.QueryServer;
+import org.apache.pinot.core.transport.QueryServerTestUtils;
+import org.apache.pinot.core.transport.ServerInstance;
+import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
+import org.apache.pinot.spi.accounting.ThreadAccountantUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.eventlistener.query.BrokerQueryEventListenerFactory;
+import org.apache.pinot.spi.utils.CommonConstants.Broker;
+import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
+import org.apache.pinot.util.TestUtils;
+import org.mockito.stubbing.Answer;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+/// Reproduction and regression coverage for the "broker keeps routing to a wedged server" defect.
+///
+/// A Pinot server that stops answering queries but keeps its TCP connection open — a wedged process, a blackholed
+/// network path, a disk-stalled JVM — produces query *timeouts* and nothing else. It never raises a send exception
+/// and never tears the Netty channel down, so
+/// [org.apache.pinot.core.transport.AsyncQueryResponse#getFailedServer()] stays `null`. Before the fix that was the
+/// only signal [SingleConnectionBrokerRequestHandler#doScatter] fed to the [FailureDetector], so the broker kept
+/// selecting the dead server for every subsequent query while healthy replicas sat idle, until Helix eventually
+/// noticed minutes later.
+///
+/// These tests drive the real [SingleConnectionBrokerRequestHandler] and a real [FailureDetector] against real
+/// Netty query servers, so the whole broker-side chain (timeout → failure detector → routing exclusion callback)
+/// is exercised over real sockets rather than mocks.
+public class SingleConnectionBrokerRequestHandlerFailureDetectorTest {
+  private static final BrokerRequest BROKER_REQUEST =
+      CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM testTable");
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final long REQUEST_ID = 123L;
+  private static final long TIMEOUT_MS = 1_000L;
+  private static final int TIMEOUT_THRESHOLD = 3;
+  /// Long enough that the retry thread never fires underneath a test that is not about recovery.
+  private static final long RETRY_DISABLED_DELAY_MS = 600_000L;
+  private static final long FAST_RETRY_DELAY_MS = 100L;
+
+  private final List<QueryServer> _startedServers = new ArrayList<>();
+
+  private BrokerRoutingManager _routingManager;
+  private SingleConnectionBrokerRequestHandler _requestHandler;
+  private FailureDetector _failureDetector;
+  private List<String> _excludedServers;
+  private List<String> _reincludedServers;
+
+  @BeforeMethod
+  public void setUp() {
+    startBroker(RETRY_DISABLED_DELAY_MS);
+  }
+
+  /// Builds the broker-side stack under test: a real request handler wired to a real failure detector whose
+  /// notifiers are recorded, mirroring the wiring `BaseBrokerStarter` performs in production.
+  private void startBroker(long retryInitialDelayMs) {
+    // BrokerMetrics is a JVM-wide singleton, so the gauge carries over from whatever ran before in this fork.
+    BrokerMetrics.get().setValueOfGlobalGauge(BrokerGauge.UNHEALTHY_SERVERS, 0);
+
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty(Broker.FailureDetector.CONFIG_OF_TYPE, Broker.FailureDetector.Type.CONNECTION.name());
+    config.setProperty(Broker.FailureDetector.CONFIG_OF_CONSECUTIVE_TIMEOUT_THRESHOLD, TIMEOUT_THRESHOLD);
+    config.setProperty(Broker.FailureDetector.CONFIG_OF_RETRY_INITIAL_DELAY_MS, retryInitialDelayMs);
+
+    _failureDetector = FailureDetectorFactory.getFailureDetector(config, BrokerMetrics.get());
+    // Mirror BaseBrokerStarter: an unhealthy server is excluded from routing, a recovered one is put back.
+    _excludedServers = new CopyOnWriteArrayList<>();
+    _reincludedServers = new CopyOnWriteArrayList<>();
+    _failureDetector.registerUnhealthyServerNotifier(instanceId -> _excludedServers.add(instanceId));
+    _failureDetector.registerHealthyServerNotifier(instanceId -> _reincludedServers.add(instanceId));
+    _failureDetector.start();
+
+    BrokerQueryEventListenerFactory.init(new PinotConfiguration());
+    ServerRoutingStatsManager serverRoutingStatsManager =
+        new ServerRoutingStatsManager(new PinotConfiguration(), BrokerMetrics.get());
+    serverRoutingStatsManager.init();
+
+    _routingManager = mock(BrokerRoutingManager.class);
+    _requestHandler =
+        new SingleConnectionBrokerRequestHandler(config, "testBroker", new BrokerRequestIdGenerator(), _routingManager,
+            new AllowAllAccessControlFactory(), mock(QueryQuotaManager.class), mock(TableCache.class), null, null,
+            serverRoutingStatsManager, _failureDetector, ThreadAccountantUtils.getNoOpAccountant(),
+            mock(MultiClusterRoutingContext.class));
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    stopBroker();
+    stopStartedServers();
+  }
+
+  private void stopBroker() {
+    if (_requestHandler != null) {
+      _requestHandler.shutDown();
+      _requestHandler = null;
+    }
+    if (_failureDetector != null) {
+      _failureDetector.stop();
+      _failureDetector = null;
+    }
+    // The gauge is a JVM-wide singleton; do not leave it dirty for the next test.
+    BrokerMetrics.get().setValueOfGlobalGauge(BrokerGauge.UNHEALTHY_SERVERS, 0);
+  }
+
+  private void stopStartedServers() {
+    for (QueryServer server : _startedServers) {
+      server.shutDown();
+    }
+    _startedServers.clear();
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Fixtures
+  // ---------------------------------------------------------------------------------------------------------------
+
+  /// Starts a server that accepts connections and requests but never writes a response.
+  ///
+  /// A [SettableFuture] that is never completed is a faithful stand-in for a wedged server: the event loop stays
+  /// free, so the connection stays healthy from the broker's point of view, and the response callback simply never
+  /// fires. It must NOT be simulated by shutting the server down -- that tears the channel down and exercises the
+  /// already-working `markServerDown` path instead of the defect under test.
+  private ServerInstance startWedgedServer() {
+    return startServer(invocation -> SettableFuture.<byte[]>create());
+  }
+
+  /// Starts a server that answers immediately with an empty DataTable carrying [#REQUEST_ID], which is the request
+  /// id every scatter in this class uses. A response whose request id does not match is dropped by
+  /// `DataTableHandler`, which would silently turn this into a second wedged server.
+  private ServerInstance startRespondingServer()
+      throws Exception {
+    byte[] responseBytes = emptyDataTableBytes();
+    return startServer(invocation -> Futures.immediateFuture(responseBytes));
+  }
+
+  /// Starts a server that answers every other request, so a hybrid query gets exactly one of its two halves back.
+  /// Both halves arrive on the same channel and are decoded on the same event loop, so the alternation is stable.
+  private ServerInstance startHalfAnsweringServer()
+      throws Exception {
+    byte[] responseBytes = emptyDataTableBytes();
+    AtomicInteger numRequests = new AtomicInteger();
+    return startServer(invocation -> numRequests.getAndIncrement() % 2 == 0 ? Futures.immediateFuture(responseBytes)
+        : SettableFuture.<byte[]>create());
+  }
+
+  private ServerInstance startServer(Answer<?> submitAnswer) {
+    QueryServer server = QueryServerTestUtils.newQueryServer(submitAnswer);
+    _startedServers.add(server);
+    return QueryServerTestUtils.serverInstance("localhost", QueryServerTestUtils.startAndGetPort(server));
+  }
+
+  private static byte[] emptyDataTableBytes()
+      throws Exception {
+    DataTable dataTable = DataTableBuilderFactory.getEmptyDataTable();
+    dataTable.getMetadata().put(MetadataKey.REQUEST_ID.getName(), Long.toString(REQUEST_ID));
+    return dataTable.toBytes();
+  }
+
+  private static TableRouteInfo routeTo(ServerInstance... servers) {
+    Map<ServerInstance, SegmentsToQuery> routingTable = new HashMap<>();
+    for (ServerInstance server : servers) {
+      routingTable.put(server, new SegmentsToQuery(List.of("segment0"), List.of()));
+    }
+    return new ImplicitHybridTableRouteInfo(BROKER_REQUEST, null, routingTable, null);
+  }
+
+  private static TableRouteInfo hybridRouteTo(ServerInstance server) {
+    Map<ServerInstance, SegmentsToQuery> routingTable =
+        Map.of(server, new SegmentsToQuery(List.of("segment0"), List.of()));
+    return new ImplicitHybridTableRouteInfo(BROKER_REQUEST, BROKER_REQUEST, routingTable, routingTable);
+  }
+
+  private SingleConnectionBrokerRequestHandler.ScatterResult scatter(TableRouteInfo route)
+      throws Exception {
+    return _requestHandler.doScatter(REQUEST_ID, RAW_TABLE_NAME, route, TIMEOUT_MS,
+        new BaseSingleStageBrokerRequestHandler.ServerStats());
+  }
+
+  /// Runs one scatter and asserts it timed out with every routed server reported as not-responded, which is what
+  /// the customer-visible `427 SERVER_NOT_RESPONDING` error is built from.
+  private void scatterAndAssertAllTimedOut(TableRouteInfo route, int expectedNumServers)
+      throws Exception {
+    SingleConnectionBrokerRequestHandler.ScatterResult result = scatter(route);
+    assertTrue(result.isTimedOut(), "Query against a wedged server must time out");
+    assertEquals(result.getDataTableMap().size(), 0, "Wedged server must not have returned a DataTable");
+    assertEquals(result.getServersNotResponded().size(), expectedNumServers);
+    // Nothing broke at the transport layer, so getFailedServer() was null and connection-failure detection --
+    // the only mechanism that existed before the fix -- had nothing to report.
+    assertNull(result.getSendException(), "A wedged server produces no send exception");
+  }
+
+  private static int unhealthyServerGauge() {
+    return (int) MetricValueUtils.getGlobalGaugeValue(BrokerMetrics.get(), BrokerGauge.UNHEALTHY_SERVERS);
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Tests
+  // ---------------------------------------------------------------------------------------------------------------
+
+  /// THE REPRODUCTION.
+  ///
+  /// Before the fix this test failed on the last assertions: after repeated timeouts against the same wedged
+  /// server the failure detector had never been told about it, so the server was never excluded from routing and
+  /// every subsequent query was scattered to it again.
+  @Test
+  public void testRepeatedTimeoutsAgainstWedgedServerMarkItUnhealthy()
+      throws Exception {
+    ServerInstance wedgedServer = startWedgedServer();
+    TableRouteInfo route = routeTo(wedgedServer);
+
+    for (int i = 0; i < TIMEOUT_THRESHOLD; i++) {
+      scatterAndAssertAllTimedOut(route, 1);
+      if (i < TIMEOUT_THRESHOLD - 1) {
+        // A slow-but-healthy server, one heavy query or a GC pause must never cost a replica; only sustained
+        // silence may.
+        assertEquals(_failureDetector.getUnhealthyServers(), Set.of(),
+            "A server must not be ejected before it has missed the configured number of consecutive requests");
+      }
+    }
+
+    assertEquals(_failureDetector.getUnhealthyServers(), Set.of(wedgedServer.getInstanceId()),
+        "A server that repeatedly leaves requests unanswered while its connection stays open must be marked "
+            + "unhealthy. If this set is empty the broker keeps routing queries to the dead server until Helix "
+            + "notices minutes later, while healthy replicas sit idle.");
+    assertEquals(_excludedServers, List.of(wedgedServer.getInstanceId()),
+        "The unhealthy-server notifier must fire exactly once so the server is excluded from routing");
+    assertEquals(unhealthyServerGauge(), 1);
+  }
+
+  /// Safety rule: a timeout is only attributed to a server that is the sole non-responder. When several servers miss
+  /// the same deadline a shared cause — the broker, the query, or the network — is far more likely than every server
+  /// failing at once, and ejecting them all would turn a slow query into a hard outage.
+  @Test(dataProvider = "numRespondingPeers")
+  public void testTimeoutSharedBySeveralServersEjectsNobody(int numRespondingPeers)
+      throws Exception {
+    List<ServerInstance> servers = new ArrayList<>(List.of(startWedgedServer(), startWedgedServer()));
+    for (int i = 0; i < numRespondingPeers; i++) {
+      servers.add(startRespondingServer());
+    }
+    TableRouteInfo route = routeTo(servers.toArray(new ServerInstance[0]));
+
+    // Well past the threshold: the rule is unconditional, not merely a delay.
+    for (int i = 0; i < TIMEOUT_THRESHOLD + 2; i++) {
+      SingleConnectionBrokerRequestHandler.ScatterResult result = scatter(route);
+      assertTrue(result.isTimedOut());
+      assertEquals(result.getServersNotResponded().size(), 2);
+    }
+
+    assertEquals(_failureDetector.getUnhealthyServers(), Set.of(),
+        "No server may be ejected when more than one of them failed to respond");
+    assertEquals(_excludedServers, List.of());
+    assertEquals(unhealthyServerGauge(), 0);
+  }
+
+  /// Covers both shapes of a shared timeout: the whole route failing, and part of it failing while peers answer.
+  @DataProvider(name = "numRespondingPeers")
+  public Object[][] numRespondingPeers() {
+    return new Object[][]{{0}, {1}};
+  }
+
+  /// The partial-failure case that matters in production: one server in the route is wedged while its peers keep
+  /// answering. Only the wedged server is ejected, and the healthy peer is never touched.
+  @Test
+  public void testOnlyTheNonRespondingServerInAPartiallyHealthyRouteIsEjected()
+      throws Exception {
+    ServerInstance wedgedServer = startWedgedServer();
+    ServerInstance healthyServer = startRespondingServer();
+    TableRouteInfo route = routeTo(wedgedServer, healthyServer);
+
+    for (int i = 0; i < TIMEOUT_THRESHOLD; i++) {
+      SingleConnectionBrokerRequestHandler.ScatterResult result = scatter(route);
+      assertTrue(result.isTimedOut());
+      assertEquals(result.getDataTableMap().size(), 1, "The healthy server must have answered");
+      assertEquals(result.getServersNotResponded().size(), 1);
+      assertEquals(result.getServersNotResponded().get(0).getInstanceId(), wedgedServer.getInstanceId());
+    }
+
+    assertEquals(_failureDetector.getUnhealthyServers(), Set.of(wedgedServer.getInstanceId()),
+        "Only the server that stopped answering may be ejected");
+    assertEquals(_excludedServers, List.of(wedgedServer.getInstanceId()));
+  }
+
+  /// A hybrid query sends a separate request to the OFFLINE and REALTIME halves of the same server, which shows up
+  /// as two routing instances sharing one instance id. The sole-non-responder rule must count those as one server, or
+  /// a hybrid table served by a single wedged server would be shielded from detection forever.
+  @Test
+  public void testHybridRouteToOneWedgedServerCountsAsOneNonResponder()
+      throws Exception {
+    ServerInstance wedgedServer = startWedgedServer();
+    TableRouteInfo hybridRoute = hybridRouteTo(wedgedServer);
+
+    // Each scatter leaves two requests -- the OFFLINE one and the REALTIME one -- unanswered on the one server.
+    for (int i = 0; i < TIMEOUT_THRESHOLD; i++) {
+      scatterAndAssertAllTimedOut(hybridRoute, 2);
+    }
+
+    assertEquals(_failureDetector.getUnhealthyServers(), Set.of(wedgedServer.getInstanceId()),
+        "Two routing instances for the same physical server must count as one non-responder, or the sole-non-"
+            + "responder rule would permanently shield a single-server hybrid table from detection");
+  }
+
+  /// A hybrid server that answers one half of the query and stalls the other is deliberately never ejected: the
+  /// answered half resets the count that the stalled half then sets back to one, so the threshold is never reached.
+  ///
+  /// This is the conservative direction and it is intentional. A server producing results for some requests is
+  /// serving, and pulling it costs capacity that the remaining requests still need. It is pinned here because it
+  /// falls out of the ordering inside `reportScatterOutcomeToFailureDetector` rather than from an explicit branch.
+  @Test
+  public void testHybridServerAnsweringOneHalfIsNeverEjected()
+      throws Exception {
+    ServerInstance server = startHalfAnsweringServer();
+    TableRouteInfo hybridRoute = hybridRouteTo(server);
+
+    for (int i = 0; i < TIMEOUT_THRESHOLD + 2; i++) {
+      SingleConnectionBrokerRequestHandler.ScatterResult result = scatter(hybridRoute);
+      assertEquals(result.getDataTableMap().size(), 1, "The OFFLINE half must have answered");
+      assertEquals(result.getServersNotResponded().size(), 1, "The REALTIME half must not have answered");
+    }
+
+    assertEquals(_failureDetector.getUnhealthyServers(), Set.of(),
+        "A server that answers part of a hybrid query is still serving and must not be ejected");
+  }
+
+  /// A server that still accepts connections is put back into routing by the failure detector's existing retrier.
+  ///
+  /// This is the deliberate fail-safe direction, and it pins the known limit of the probe: it proves the server can
+  /// still be reached, not that it can still answer a query. A process that is alive but wedged passes it. Erring
+  /// this way keeps a merely busy server from being stranded, which is the outcome that would make an overload worse.
+  @Test
+  public void testServerThatAcceptsConnectionsIsIncludedAgain()
+      throws Exception {
+    stopBroker();
+    startBroker(FAST_RETRY_DELAY_MS);
+    ServerInstance wedgedServer = startWedgedServer();
+    when(_routingManager.getEnabledServerInstanceMap()).thenReturn(
+        Map.of(wedgedServer.getInstanceId(), wedgedServer));
+    TableRouteInfo route = routeTo(wedgedServer);
+    for (int i = 0; i < TIMEOUT_THRESHOLD; i++) {
+      scatterAndAssertAllTimedOut(route, 1);
+    }
+    assertEquals(_excludedServers, List.of(wedgedServer.getInstanceId()));
+
+    TestUtils.waitForCondition(aVoid -> _reincludedServers.contains(wedgedServer.getInstanceId()), 10_000L,
+        "Failed to re-include the server through the failure detector's retrier");
+    assertEquals(_failureDetector.getUnhealthyServers(), Set.of());
+    assertEquals(unhealthyServerGauge(), 0);
+  }
+
+  /// A server that has stopped accepting connections stays ejected, and the retry backoff grows.
+  ///
+  /// This is what the fresh-connection probe buys. The pooled channel to a server whose node disappeared stays
+  /// established — nothing sends a FIN or an RST — so the previous probe reused it, always succeeded, and put the
+  /// dead server back into routing every few seconds.
+  @Test
+  public void testServerThatRefusesConnectionsStaysEjected()
+      throws Exception {
+    stopBroker();
+    startBroker(FAST_RETRY_DELAY_MS);
+    ServerInstance wedgedServer = startWedgedServer();
+    // retryUnhealthyServer() looks the server up here once per probe, so this counts probes.
+    AtomicInteger numProbes = new AtomicInteger();
+    when(_routingManager.getEnabledServerInstanceMap()).thenAnswer(invocation -> {
+      numProbes.incrementAndGet();
+      return Map.of(wedgedServer.getInstanceId(), wedgedServer);
+    });
+
+    // One scatter, so that the query router holds a pooled channel to the server -- without one the retrier bails
+    // out with UNKNOWN before it ever probes. This stays below the ejection threshold.
+    scatterAndAssertAllTimedOut(routeTo(wedgedServer), 1);
+    assertEquals(_failureDetector.getUnhealthyServers(), Set.of());
+
+    // Stop the server BEFORE anything is queued for retry, so the retry loop can never race a live listener. The
+    // pooled channel is left behind exactly as it would be by a server whose node vanished.
+    stopStartedServers();
+    _failureDetector.markServerUnhealthy(wedgedServer.getInstanceId(), wedgedServer.getHostname());
+    assertEquals(_excludedServers, List.of(wedgedServer.getInstanceId()));
+
+    // Wait until the retrier has actually probed several times, so the assertion below cannot pass vacuously.
+    TestUtils.waitForCondition(aVoid -> numProbes.get() >= 3, 10_000L, "Retrier did not probe the server");
+    assertEquals(_failureDetector.getUnhealthyServers(), Set.of(wedgedServer.getInstanceId()));
+    assertEquals(_reincludedServers, List.of());
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/failuredetector/BaseExponentialBackoffRetryFailureDetector.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/failuredetector/BaseExponentialBackoffRetryFailureDetector.java
@@ -43,9 +43,18 @@ import org.slf4j.LoggerFactory;
 public abstract class BaseExponentialBackoffRetryFailureDetector implements FailureDetector {
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseExponentialBackoffRetryFailureDetector.class);
 
+  /// How long a consecutive-timeout count stays valid. Well beyond any sane query timeout, but short enough that
+  /// counts do not survive an idle period or a rolling restart and eject a server on its first miss afterwards.
+  private static final long TIMEOUT_COUNT_EXPIRY_NS = TimeUnit.MINUTES.toNanos(5);
+
   protected final String _name = getClass().getSimpleName();
   protected final ConcurrentHashMap<String, RetryInfo> _unhealthyServerRetryInfoMap = new ConcurrentHashMap<>();
   protected final DelayQueue<RetryInfo> _retryInfoDelayQueue = new DelayQueue<>();
+
+  /// Per-server count of consecutive requests left unanswered, keyed by instance id. An entry is dropped as soon as
+  /// the server answers anything, and a count older than [#TIMEOUT_COUNT_EXPIRY_NS] restarts from one so that
+  /// "consecutive" stays consecutive in time and not merely in arrival order.
+  protected final ConcurrentHashMap<String, TimeoutCount> _consecutiveTimeoutCountMap = new ConcurrentHashMap<>();
 
   protected final List<Function<String, ServerState>> _unhealthyServerRetriers = new ArrayList<>();
   protected Consumer<String> _healthyServerNotifier;
@@ -54,6 +63,7 @@ public abstract class BaseExponentialBackoffRetryFailureDetector implements Fail
   protected long _retryInitialDelayNs;
   protected double _retryDelayFactor;
   protected int _maxRetries;
+  protected int _consecutiveTimeoutThreshold;
   protected Thread _retryThread;
 
   protected volatile boolean _running;
@@ -68,8 +78,11 @@ public abstract class BaseExponentialBackoffRetryFailureDetector implements Fail
         Broker.FailureDetector.DEFAULT_RETRY_DELAY_FACTOR);
     _maxRetries =
         config.getProperty(Broker.FailureDetector.CONFIG_OF_MAX_RETRIES, Broker.FailureDetector.DEFAULT_MAX_RETRIES);
-    LOGGER.info("Initialized {} with retry initial delay: {}ms, exponential backoff factor: {}, max retries: {}", _name,
-        retryInitialDelayMs, _retryDelayFactor, _maxRetries);
+    _consecutiveTimeoutThreshold = config.getProperty(Broker.FailureDetector.CONFIG_OF_CONSECUTIVE_TIMEOUT_THRESHOLD,
+        Broker.FailureDetector.DEFAULT_CONSECUTIVE_TIMEOUT_THRESHOLD);
+    LOGGER.info("Initialized {} with retry initial delay: {}ms, exponential backoff factor: {}, max retries: {}, "
+            + "consecutive timeout threshold: {}", _name, retryInitialDelayMs, _retryDelayFactor, _maxRetries,
+        _consecutiveTimeoutThreshold);
   }
 
   @Override
@@ -139,6 +152,7 @@ public abstract class BaseExponentialBackoffRetryFailureDetector implements Fail
 
   @Override
   public void markServerHealthy(String instanceId, @Nullable String hostName) {
+    _consecutiveTimeoutCountMap.remove(instanceId);
     _unhealthyServerRetryInfoMap.computeIfPresent(instanceId, (id, retryInfo) -> {
       LOGGER.info("Mark server: {} {} as healthy", instanceId, hostName);
       _brokerMetrics.setValueOfGlobalGauge(BrokerGauge.UNHEALTHY_SERVERS, _unhealthyServerRetryInfoMap.size() - 1);
@@ -160,6 +174,37 @@ public abstract class BaseExponentialBackoffRetryFailureDetector implements Fail
   }
 
   @Override
+  public void notifyServerResponded(String instanceId) {
+    _consecutiveTimeoutCountMap.remove(instanceId);
+  }
+
+  /// {@inheritDoc}
+  ///
+  /// Marks the server unhealthy once it has left
+  /// [Broker.FailureDetector#CONFIG_OF_CONSECUTIVE_TIMEOUT_THRESHOLD] consecutive requests unanswered. Any number of
+  /// servers may be held out this way: given the caller reports only sole non-responders, a shared cause accuses
+  /// nobody, while servers going silent independently should all come out.
+  @Override
+  public void notifyServerNotResponded(String instanceId, @Nullable String hostName) {
+    if (_consecutiveTimeoutThreshold <= 0) {
+      return;
+    }
+    long nowNs = System.nanoTime();
+    // compute() applies the whole update under the map's per-key lock, so it cannot interleave with the remove() in
+    // notifyServerResponded and drop a reset on the floor.
+    TimeoutCount timeoutCount = _consecutiveTimeoutCountMap.compute(instanceId,
+        (id, current) -> current == null || nowNs - current._lastTimeoutNs > TIMEOUT_COUNT_EXPIRY_NS
+            ? new TimeoutCount(1, nowNs) : new TimeoutCount(current._count + 1, nowNs));
+    // Only act on the crossing: past it the server is already unhealthy, so re-marking would just re-log every query.
+    if (timeoutCount._count != _consecutiveTimeoutThreshold) {
+      return;
+    }
+    LOGGER.warn("Server: {} {} left {} consecutive requests unanswered while staying connected, marking it unhealthy",
+        instanceId, hostName, timeoutCount._count);
+    markServerUnhealthy(instanceId, hostName);
+  }
+
+  @Override
   public Set<String> getUnhealthyServers() {
     return _unhealthyServerRetryInfoMap.keySet();
   }
@@ -174,6 +219,18 @@ public abstract class BaseExponentialBackoffRetryFailureDetector implements Fail
       _retryThread.join();
     } catch (InterruptedException e) {
       throw new RuntimeException("Interrupted while waiting for retry thread to finish", e);
+    }
+  }
+
+  /// A count of consecutive unanswered requests, with the time of the last one so that the count can expire.
+  /// Not a record: pinot-common still targets Java 11 bytecode.
+  private static class TimeoutCount {
+    final int _count;
+    final long _lastTimeoutNs;
+
+    TimeoutCount(int count, long lastTimeoutNs) {
+      _count = count;
+      _lastTimeoutNs = lastTimeoutNs;
     }
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/failuredetector/ConnectionFailureDetector.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/failuredetector/ConnectionFailureDetector.java
@@ -21,8 +21,13 @@ package org.apache.pinot.common.failuredetector;
 import javax.annotation.concurrent.ThreadSafe;
 
 
-/// The `ConnectionFailureDetector` marks failed server (connection failure) from query response as unhealthy, and
-/// retries the unhealthy servers with exponential increasing delays.
+/// The `ConnectionFailureDetector` marks a server as unhealthy when a query response reports it as failed
+/// (connection failure) or when it repeatedly leaves requests unanswered while staying connected (see
+/// [FailureDetector#notifyServerNotResponded]), and retries the unhealthy servers with exponentially increasing
+/// delays.
+///
+/// Only the single-stage Netty query path reports unanswered requests today; the gRPC and multi-stage paths report
+/// connection failures only.
 ///
 /// This class doesn't currently implement any additional logic over BaseExponentialBackoffRetryFailureDetector and is
 /// retained for backward compatibility.

--- a/pinot-common/src/main/java/org/apache/pinot/common/failuredetector/FailureDetector.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/failuredetector/FailureDetector.java
@@ -73,6 +73,28 @@ public interface FailureDetector {
   /// Marks a server as unhealthy.
   void markServerUnhealthy(String instanceId, @Nullable String hostName);
 
+  /// Notifies the detector that a server answered a request, clearing whatever [#notifyServerNotResponded] has
+  /// accumulated for it. Called for every responding server on the query path, so it must be cheap when nothing is
+  /// being tracked.
+  default void notifyServerResponded(String instanceId) {
+  }
+
+  /// Notifies the detector that a server left a request unanswered until the query deadline, without its connection
+  /// ever breaking.
+  ///
+  /// A server that stays connected but stops serving — a wedged process, a blackholed network path, a disk-stalled
+  /// JVM — produces no other signal. Writing into an open socket succeeds even when the peer is gone, so there is no
+  /// send exception, the channel is never torn down, and connection-failure detection cannot see it at all. The
+  /// query simply times out.
+  ///
+  /// Callers must only report a server that was the **sole** non-responder of its query. When several servers miss
+  /// the same deadline a shared cause — the broker, the query, the network — is far more likely than every server
+  /// failing at once, and this method cannot tell the difference. Implementations rely on that, and must further
+  /// require several consecutive unanswered requests before acting, since one is a normal consequence of a slow
+  /// query.
+  default void notifyServerNotResponded(String instanceId, @Nullable String hostName) {
+  }
+
   /// Returns all the unhealthy servers.
   Set<String> getUnhealthyServers();
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/failuredetector/ConnectionFailureDetectorTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/failuredetector/ConnectionFailureDetectorTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.common.failuredetector;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -39,6 +41,8 @@ import static org.testng.Assert.assertTrue;
 public class ConnectionFailureDetectorTest {
   private static final String INSTANCE_ID = "Server_localhost_1234";
   private static final String HOST_NAME = "localhost";
+
+  private static final String OTHER_INSTANCE_ID = "Server_localhost_5678";
 
   private BrokerMetrics _brokerMetrics;
   private FailureDetector _failureDetector;
@@ -177,6 +181,103 @@ public class ConnectionFailureDetectorTest {
     assertEquals(_unhealthyServerRetrier._retryUnhealthyServerCalled, 8);
   }
 
+  /// A server that leaves requests unanswered while staying connected is only ejected once it has missed
+  /// [Broker.FailureDetector#DEFAULT_CONSECUTIVE_TIMEOUT_THRESHOLD] consecutive requests. This pins the shipped
+  /// default: lowering it would make the broker quicker to eject a slow-but-healthy replica.
+  @Test
+  public void testTimeoutDetectionUsesConfiguredThreshold() {
+    int threshold = Broker.FailureDetector.DEFAULT_CONSECUTIVE_TIMEOUT_THRESHOLD;
+    assertTrue(threshold > 1, "The default must require more than one unanswered request");
+
+    for (int i = 0; i < threshold - 1; i++) {
+      _failureDetector.notifyServerNotResponded(INSTANCE_ID, HOST_NAME);
+      verify(Set.of(), 0, 0);
+    }
+
+    _failureDetector.notifyServerNotResponded(INSTANCE_ID, HOST_NAME);
+    verify(Set.of(INSTANCE_ID), 1, 0);
+  }
+
+  /// The count is consecutive, not cumulative: any response from the server discards it, so timeouts on either
+  /// side of a successful response can never be summed into an ejection.
+  @Test
+  public void testResponseResetsConsecutiveTimeoutCount() {
+    int threshold = Broker.FailureDetector.DEFAULT_CONSECUTIVE_TIMEOUT_THRESHOLD;
+    for (int i = 0; i < threshold - 1; i++) {
+      _failureDetector.notifyServerNotResponded(INSTANCE_ID, HOST_NAME);
+    }
+    verify(Set.of(), 0, 0);
+
+    _failureDetector.notifyServerResponded(INSTANCE_ID);
+
+    for (int i = 0; i < threshold - 1; i++) {
+      _failureDetector.notifyServerNotResponded(INSTANCE_ID, HOST_NAME);
+    }
+    verify(Set.of(), 0, 0);
+  }
+
+  /// A response is not the only way a count is cleared: the retrier marking the server healthy again clears it too,
+  /// so a server that has genuinely recovered starts from a clean slate.
+  @Test
+  public void testMarkServerHealthyClearsTimeoutCount() {
+    int threshold = Broker.FailureDetector.DEFAULT_CONSECUTIVE_TIMEOUT_THRESHOLD;
+    for (int i = 0; i < threshold; i++) {
+      _failureDetector.notifyServerNotResponded(INSTANCE_ID, HOST_NAME);
+    }
+    verify(Set.of(INSTANCE_ID), 1, 0);
+
+    _failureDetector.markServerHealthy(INSTANCE_ID, HOST_NAME);
+    verify(Set.of(), 1, 1);
+
+    // The full threshold has to be reached again, so a single further unanswered request changes nothing.
+    _failureDetector.notifyServerNotResponded(INSTANCE_ID, HOST_NAME);
+    verify(Set.of(), 1, 1);
+  }
+
+  /// Several servers going silent at once are all ejected. There is no cap: a shared cause makes servers fail
+  /// together, and the caller only attributes a timeout to a sole non-responder, so a shared cause accuses nobody.
+  /// Independent servers each going silent while their peers serve is the case that should shed all of them.
+  @Test
+  public void testEveryServerThatGoesSilentIsEjected() {
+    int threshold = Broker.FailureDetector.DEFAULT_CONSECUTIVE_TIMEOUT_THRESHOLD;
+    for (int i = 0; i < threshold; i++) {
+      _failureDetector.notifyServerNotResponded(INSTANCE_ID, HOST_NAME);
+      _failureDetector.notifyServerNotResponded(OTHER_INSTANCE_ID, HOST_NAME);
+    }
+    assertEquals(_failureDetector.getUnhealthyServers(), Set.of(INSTANCE_ID, OTHER_INSTANCE_ID));
+    assertEquals(_unhealthyServerNotifier._notifiedServers, List.of(INSTANCE_ID, OTHER_INSTANCE_ID));
+  }
+
+  /// A threshold of zero or less disables timeout-based detection, leaving only connection-failure detection --
+  /// the escape hatch for operators who do not want the new behaviour.
+  @Test
+  public void testNonPositiveThresholdDisablesTimeoutDetection() {
+    FailureDetector failureDetector = newFailureDetector(0);
+    for (int i = 0; i < Broker.FailureDetector.DEFAULT_CONSECUTIVE_TIMEOUT_THRESHOLD * 2; i++) {
+      failureDetector.notifyServerNotResponded(INSTANCE_ID, HOST_NAME);
+    }
+    assertEquals(failureDetector.getUnhealthyServers(), Set.of());
+
+    // Connection-failure detection still works.
+    failureDetector.markServerUnhealthy(INSTANCE_ID, HOST_NAME);
+    assertEquals(failureDetector.getUnhealthyServers(), Set.of(INSTANCE_ID));
+  }
+
+  /// Builds an extra detector with its own metrics registry, so that it does not share the gauge with the one built
+  /// by [#setUp()]. Not started: no caller here needs the retry thread.
+  private FailureDetector newFailureDetector(int consecutiveTimeoutThreshold) {
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty(Broker.FailureDetector.CONFIG_OF_TYPE, Broker.FailureDetector.Type.CONNECTION.name());
+    config.setProperty(Broker.FailureDetector.CONFIG_OF_CONSECUTIVE_TIMEOUT_THRESHOLD, consecutiveTimeoutThreshold);
+    FailureDetector failureDetector =
+        FailureDetectorFactory.getFailureDetector(config, new BrokerMetrics(new NoopPinotMetricsRegistry()));
+    failureDetector.registerHealthyServerNotifier(instanceId -> {
+    });
+    failureDetector.registerUnhealthyServerNotifier(instanceId -> {
+    });
+    return failureDetector;
+  }
+
   private void verify(Set<String> expectedUnhealthyServers, int expectedNotifyUnhealthyServerCalled,
       int expectedNotifyHealthyServerCalled) {
     assertEquals(_failureDetector.getUnhealthyServers(), expectedUnhealthyServers);
@@ -202,11 +303,12 @@ public class ConnectionFailureDetectorTest {
   }
 
   private static class UnhealthyServerNotifier implements Consumer<String> {
+    final List<String> _notifiedServers = new ArrayList<>();
     int _notifyUnhealthyServerCalled = 0;
 
     @Override
     public void accept(String instanceId) {
-      assertEquals(instanceId, INSTANCE_ID);
+      _notifiedServers.add(instanceId);
       _notifyUnhealthyServerCalled++;
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
@@ -147,30 +147,31 @@ public class QueryRouter {
   }
 
   public boolean hasChannel(ServerInstance serverInstance) {
-    if (_serverChannelsTls != null) {
-      return _serverChannelsTls.hasChannel(
-          serverInstance.toServerRoutingInstance(TableType.OFFLINE, ServerInstance.RoutingType.NETTY_TLS));
-    } else {
-      return _serverChannels.hasChannel(
-          serverInstance.toServerRoutingInstance(TableType.OFFLINE, ServerInstance.RoutingType.NETTY));
+    return channels().hasChannel(offlineRoutingInstance(serverInstance));
+  }
+
+  /// Tests whether the given server still accepts connections, on a fresh connection.
+  /// See [ServerChannels#probeConnection]. Note this is a plain TCP probe even for a TLS server: it deliberately
+  /// tests reachability of the query port rather than the TLS handshake.
+  public boolean probeConnection(ServerInstance serverInstance) {
+    try {
+      return channels().probeConnection(offlineRoutingInstance(serverInstance));
+    } catch (Exception e) {
+      // toServerRoutingInstance() rejects a server that has not advertised the port, which happens mid-rollout.
+      // The caller is the failure detector's retry loop: letting this escape would abandon the RetryInfo and strand
+      // the server as unhealthy forever.
+      LOGGER.debug("Failed to probe server: {}", serverInstance, e);
+      return false;
     }
   }
 
-  /// Connects to the given server, returns `true` if the server is successfully connected.
-  public boolean connect(ServerInstance serverInstance) {
-    try {
-      if (_serverChannelsTls != null) {
-        _serverChannelsTls.connect(
-            serverInstance.toServerRoutingInstance(TableType.OFFLINE, ServerInstance.RoutingType.NETTY_TLS));
-      } else {
-        _serverChannels.connect(
-            serverInstance.toServerRoutingInstance(TableType.OFFLINE, ServerInstance.RoutingType.NETTY));
-      }
-      return true;
-    } catch (Exception e) {
-      LOGGER.debug("Failed to connect to server: {}", serverInstance, e);
-      return false;
-    }
+  private ServerChannels channels() {
+    return _serverChannelsTls != null ? _serverChannelsTls : _serverChannels;
+  }
+
+  private ServerRoutingInstance offlineRoutingInstance(ServerInstance serverInstance) {
+    return serverInstance.toServerRoutingInstance(TableType.OFFLINE,
+        _serverChannelsTls != null ? ServerInstance.RoutingType.NETTY_TLS : ServerInstance.RoutingType.NETTY);
   }
 
   public void shutDown() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
@@ -24,6 +24,8 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocatorMetric;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
@@ -66,7 +68,12 @@ import org.slf4j.LoggerFactory;
 public class ServerChannels {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerChannels.class);
   public static final String CHANNEL_LOCK_TIMEOUT_MSG = "Timeout while acquiring channel lock";
-  private static final long TRY_CONNECT_CHANNEL_LOCK_TIMEOUT_MS = 5_000L;
+  /// Kept short: a TCP connect to a healthy server in the same datacenter completes in well under a millisecond, so
+  /// a longer deadline only buys a slower "no" -- and the single failure-detector retry thread probes serially, so
+  /// every second here is head-of-line blocking for the next unhealthy server.
+  private static final long PROBE_CONNECT_TIMEOUT_MS = 2_000L;
+  /// Backstop only; Netty's own connect deadline should be the one that fires.
+  private static final long PROBE_AWAIT_TIMEOUT_MS = PROBE_CONNECT_TIMEOUT_MS + 1_000L;
 
   // TSerializer currently is not thread safe, must be put into a ThreadLocal.
   private static final ThreadLocal<TSerializer> THREAD_LOCAL_T_SERIALIZER = ThreadLocal.withInitial(() -> {
@@ -149,9 +156,42 @@ public class ServerChannels {
     return _serverToChannelMap.containsKey(serverRoutingInstance);
   }
 
-  public void connect(ServerRoutingInstance serverRoutingInstance)
-      throws InterruptedException, TimeoutException {
-    _serverToChannelMap.computeIfAbsent(serverRoutingInstance, ServerChannel::new).connect();
+  /// Tests whether the server still accepts connections, by establishing a **fresh** TCP connection and closing it
+  /// again.
+  ///
+  /// The freshness is the point. The pooled channel stays established long after a server stops serving, because
+  /// nothing closes it when the peer's node disappears without a FIN or an RST, so reusing it reports every
+  /// wedged-but-connected server as healthy. The throwaway channel also uses a bare pipeline, so the probe neither
+  /// takes the pooled channel's lock nor fires `channelInactive` on [DataTableHandler] (which would mark the
+  /// server down).
+  public boolean probeConnection(ServerRoutingInstance serverRoutingInstance) {
+    ChannelFuture future = newBootstrap(serverRoutingInstance)
+        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) PROBE_CONNECT_TIMEOUT_MS)
+        .handler(new ChannelInitializer<SocketChannel>() {
+          @Override
+          protected void initChannel(SocketChannel ch) {
+          }
+        }).connect();
+    // Close on every outcome. Netty makes the connect promise uncancellable, so cancel() cannot release the channel,
+    // and leaking one would leave a file descriptor registered on the query event loop.
+    future.addListener(ChannelFutureListener.CLOSE);
+    try {
+      if (future.await(PROBE_AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS) && future.isSuccess()) {
+        return true;
+      }
+      LOGGER.debug("Failed to probe server: {}", serverRoutingInstance, future.cause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOGGER.debug("Interrupted while probing server: {}", serverRoutingInstance);
+    }
+    return false;
+  }
+
+  /// Bootstraps a connection to the given server with the transport this instance selected. Callers add the
+  /// pipeline and any options of their own.
+  private Bootstrap newBootstrap(ServerRoutingInstance serverRoutingInstance) {
+    return new Bootstrap().remoteAddress(serverRoutingInstance.getHostname(), serverRoutingInstance.getPort())
+        .group(_eventLoopGroup).channel(_channelClass);
   }
 
   public void shutDown() {
@@ -174,8 +214,7 @@ public class ServerChannels {
 
     ServerChannel(ServerRoutingInstance serverRoutingInstance) {
       _serverRoutingInstance = serverRoutingInstance;
-      _bootstrap = new Bootstrap().remoteAddress(serverRoutingInstance.getHostname(), serverRoutingInstance.getPort())
-          .option(ChannelOption.ALLOCATOR, _bufAllocatorWithLimits).group(_eventLoopGroup).channel(_channelClass)
+      _bootstrap = newBootstrap(serverRoutingInstance).option(ChannelOption.ALLOCATOR, _bufAllocatorWithLimits)
           .option(ChannelOption.SO_KEEPALIVE, true).handler(new ChannelInitializer<SocketChannel>() {
             @Override
             protected void initChannel(SocketChannel ch) {
@@ -265,19 +304,6 @@ public class ServerChannels {
       });
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.NETTY_CONNECTION_REQUESTS_SENT, 1);
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.NETTY_CONNECTION_BYTES_SENT, requestBytes.length);
-    }
-
-    void connect()
-        throws InterruptedException, TimeoutException {
-      if (_channelLock.tryLock(TRY_CONNECT_CHANNEL_LOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
-        try {
-          connectWithoutLocking();
-        } finally {
-          _channelLock.unlock();
-        }
-      } else {
-        throw new TimeoutException(CHANNEL_LOCK_TIMEOUT_MSG);
-      }
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
@@ -236,6 +236,12 @@ public class QueryRoutingTest {
     assertEquals(serverResponse.getDeserializationTimeMs(), 0);
     // Query should time out
     assertTrue(System.currentTimeMillis() - startTimeMs >= 1000);
+    // A request left unanswered until the deadline produces a timeout and nothing else: the send succeeded and the
+    // channel was never torn down, so no failed server is reported. This is why the broker's failure detector cannot
+    // rely on getFailedServer() alone -- see FailureDetector#notifyServerNotResponded.
+    assertEquals(asyncQueryResponse.getStatus(), QueryResponse.Status.TIMED_OUT);
+    assertNull(asyncQueryResponse.getException());
+    assertNull(asyncQueryResponse.getFailedServer());
     _requestCount += 2;
     waitForStatsUpdate(_requestCount);
     assertEquals(_serverRoutingStatsManager.fetchNumInFlightRequestsForServer(serverId).intValue(), 0);

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryServerTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryServerTestUtils.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.transport;
+
+import java.net.InetSocketAddress;
+import org.apache.pinot.core.query.scheduler.QueryScheduler;
+import org.apache.pinot.server.access.AccessControl;
+import org.apache.pinot.spi.accounting.ThreadAccountantUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+/// Helpers for standing up a real Netty [QueryServer] in a test.
+///
+/// Lives in `org.apache.pinot.core.transport` because [QueryServer#getChannel] and the `host`/`port`
+/// [ServerInstance] constructor are package-private; pinot-broker consumes this through the pinot-core test jar.
+public class QueryServerTestUtils {
+  private QueryServerTestUtils() {
+  }
+
+  /// Builds an unstarted query server whose scheduler answers every submission with `submitAnswer`.
+  public static QueryServer newQueryServer(Answer<?> submitAnswer) {
+    QueryScheduler queryScheduler = mock(QueryScheduler.class);
+    when(queryScheduler.submit(any())).thenAnswer(submitAnswer);
+    InstanceRequestHandler handler =
+        new InstanceRequestHandler("testServer", new PinotConfiguration(), queryScheduler, mock(AccessControl.class),
+            ThreadAccountantUtils.getNoOpAccountant());
+    return new QueryServer(0, null, handler);
+  }
+
+  /// Starts the server and returns the port it bound to.
+  ///
+  /// Binds on port 0 and reads the port back, rather than picking a free port up front, which would leave a window
+  /// for another process on the machine to take it. [QueryServer#start] blocks on `bind().sync()`, so the server is
+  /// accepting connections when this returns.
+  public static int startAndGetPort(QueryServer server) {
+    server.start();
+    return ((InetSocketAddress) server.getChannel().localAddress()).getPort();
+  }
+
+  public static ServerInstance serverInstance(String hostname, int port) {
+    return new ServerInstance(hostname, port);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/ServerChannelsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/ServerChannelsTest.java
@@ -34,6 +34,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -44,8 +45,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
 
 public class ServerChannelsTest {
@@ -79,7 +82,7 @@ public class ServerChannelsTest {
           new ServerRoutingInstance("localhost", dummyServer.getAddress().getPort(), TableType.REALTIME);
       ServerChannels serverChannels =
           new ServerChannels(queryRouter, nettyConfig, null, ThreadAccountantUtils.getNoOpAccountant());
-      serverChannels.connect(serverRoutingInstance);
+      assertTrue(serverChannels.probeConnection(serverRoutingInstance));
 
       final long requestId = System.currentTimeMillis();
 
@@ -92,6 +95,29 @@ public class ServerChannelsTest {
       serverChannels.shutDown();
     } finally {
       dummyServer.stop(0);
+    }
+  }
+
+  /// The probe must ignore the pooled channel. A server whose node disappears without sending a FIN or an RST
+  /// leaves that channel `isActive()` forever, so a probe that consulted it would call every wedged server healthy —
+  /// which is exactly how the broker kept routing queries to a dead server for minutes.
+  @Test
+  public void testProbeIgnoresAnActivePooledChannel()
+      throws Exception {
+    ServerChannels serverChannels =
+        new ServerChannels(mock(QueryRouter.class), null, null, ThreadAccountantUtils.getNoOpAccountant());
+    try {
+      // Nothing is listening on this port, so any real connection attempt must fail.
+      ServerRoutingInstance serverRoutingInstance =
+          new ServerRoutingInstance("localhost", NetUtils.findOpenPort(), TableType.OFFLINE);
+      Channel activeChannel = mock(Channel.class);
+      when(activeChannel.isActive()).thenReturn(true);
+      serverChannels.getOrCreateServerChannel(serverRoutingInstance).setChannel(activeChannel);
+
+      assertFalse(serverChannels.probeConnection(serverRoutingInstance),
+          "A pooled channel reporting isActive() must not make the probe succeed");
+    } finally {
+      serverChannels.shutDown();
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1172,7 +1172,8 @@ public class CommonConstants {
         // Do not detect any failure
         NO_OP,
 
-        // Detect connection failures
+        // Detect connection failures, and servers that leave consecutive requests unanswered while staying
+        // connected (see CONFIG_OF_CONSECUTIVE_TIMEOUT_THRESHOLD; set it to <= 0 for connection failures only)
         CONNECTION,
 
         // Use the custom failure detector of the configured class name
@@ -1191,6 +1192,14 @@ public class CommonConstants {
       public static final double DEFAULT_RETRY_DELAY_FACTOR = 2.0;
       public static final String CONFIG_OF_MAX_RETRIES = "pinot.broker.failure.detector.max.retries";
       public static final int DEFAULT_MAX_RETRIES = 10;
+
+      /// Number of consecutive requests a server must leave unanswered before it is marked unhealthy. This is the
+      /// only way to detect a server that keeps its connection open but stops serving, since that raises no
+      /// connection failure. Any response resets the count, so only a server answering nothing at all reaches the
+      /// threshold. Set to `<= 0` to detect connection failures only.
+      public static final String CONFIG_OF_CONSECUTIVE_TIMEOUT_THRESHOLD =
+          "pinot.broker.failure.detector.consecutive.timeout.threshold";
+      public static final int DEFAULT_CONSECUTIVE_TIMEOUT_THRESHOLD = 5;
     }
 
     // Configs related to AdaptiveServerSelection.


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Detect wedged servers by tracking sole non\-responders and marking unhealthy after consecutive timeouts\.

```mermaid
flowchart TD
  N0["Scatter#58; collect responding and non#45;responding servers #40;F1#41;"]:::stModified
  N1["Check if timed out and sole non#45;responding server exists #40;F1#41;"]:::stModified
  N2["Report responding servers to failure detector #40;F1#41;"]:::stModified
  N3["Report sole non#45;responder to failure detector #40;F1#41;"]:::stModified
  N4["Failure detector#58; clear timeout count on response #40;F2#41;"]:::stModified
  N5["Failure detector#58; update timeout count on non#45;response #40;F2#41;"]:::stModified
  N6["Failure detector#58; mark server unhealthy if threshold reached #40;F2#41;"]:::stModified
  N0 --> N1
  N0 --> N2
  N1 --> N3
  N2 --> N4
  N3 --> N5
  N5 --> N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler\.java — [before](https://github.com/apache/pinot/blob/ca71554fc9d7a6012e5f6cf6c55c9dcd320c8526/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java) · [after](https://github.com/apache/pinot/blob/32604b567678c3711b489c668c54e62996a829ee/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java)
- F2: pinot\-common/src/main/java/org/apache/pinot/common/failuredetector/BaseExponentialBackoffRetryFailureDetector\.java — [before](https://github.com/apache/pinot/blob/ca71554fc9d7a6012e5f6cf6c55c9dcd320c8526/pinot-common/src/main/java/org/apache/pinot/common/failuredetector/BaseExponentialBackoffRetryFailureDetector.java) · [after](https://github.com/apache/pinot/blob/32604b567678c3711b489c668c54e62996a829ee/pinot-common/src/main/java/org/apache/pinot/common/failuredetector/BaseExponentialBackoffRetryFailureDetector.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImNhNzE1NTRmYzlkN2E2MDEyZTVmNmNmNmM1NWM5ZGNkMzIwYzg1MjYiLCJjb250ZXh0X2hhc2giOiJiMGE3MzJjMzM4NjBiM2QzYjEzOTFiZDNlYjBkMTAyNDFlNDU3YWExMjE0Yjc4NTA4MDJkMDBhNTg1ZGYzMGUxIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NTM2OTIwLCJoZWFkX3NoYSI6IjMyNjA0YjU2NzY3OGMzNzExYjQ4OWM2NjhjNTRlNjI5OTZhODI5ZWUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIxY2NjNzA4ZWExYzY3NWE1OTlhMmM5M2JmYTg3NTUzYWRmZmQwZGEzIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 7a1aaa09e00a03973215be5106ebed77aecbf4736f091f2e5d5210ae1b1b2819 -->
<!-- pinot-pr-flow:end -->

## Problem

A server that stops answering queries but keeps its TCP connection open is invisible to the broker's failure detector.

`ConnectionFailureDetector` only acts on `AsyncQueryResponse.getFailedServer()`, which is set by a send exception or a channel teardown. A wedged node, a blackholed network path or a disk-stalled JVM produces neither. Writing into an open socket buffer succeeds even when the peer is gone, so the request is sent, the reply never comes, and the query just times out.

The broker keeps selecting that server for every subsequent query while healthy replicas sit idle, until Helix eventually notices — which is driven by a ZooKeeper heartbeat the wedged server may keep answering.

We hit this in production: **4 minutes 16 seconds of query failures** on a table with three healthy replica groups (`strictReplicaGroup`, `replicasPerPartition: 3`). Over that window:

- `brokerResponsesWithTimeouts` — ~12
- `REQUEST_SEND_EXCEPTIONS` — 0
- `"Excluding server"` log lines — 0
- `pinot_broker_unhealthyServers` — 0 on all brokers

The detector ran the whole time with nothing to act on.

## Reproduction

Added first, before the fix. A Netty query server that accepts the connection and the request and never writes a response — a `SettableFuture` that is never completed. Note this must **not** be simulated by stopping the server: that closes the socket and takes the already-working `markServerDown` path.

`SingleConnectionBrokerRequestHandlerFailureDetectorTest#testRepeatedTimeoutsAgainstWedgedServerMarkItUnhealthy` failed on master with:

```
A server that repeatedly leaves requests unanswered while its connection stays open must be
marked unhealthy. If this set is empty the broker keeps routing queries to the dead server
until Helix notices minutes later, while healthy replicas sit idle.
```

## Change

**1. `doScatter` reports per-server outcomes to the failure detector.** The list of servers that did not respond is already built there — it is what the `427 SERVER_NOT_RESPONDING` error is made from. It was simply never fed to the detector.

**2. The detector ejects a server after N consecutive unanswered requests** (`pinot.broker.failure.detector.consecutive.timeout.threshold`, default 5). Any response clears the count.

**3. The recovery probe now opens a fresh TCP connection.** `QueryRouter.connect()` reused the pooled channel, which stays `isActive()` forever when a peer vanishes without a FIN or an RST — so it reported every wedged server as healthy and would have re-admitted it every 5 seconds.

## Why this cannot be solved anywhere else

Worth stating, because the obvious alternatives were tried on paper first:

- **ZooKeeper / Helix liveness** only proves the JVM can reach ZooKeeper. A server with a jammed query pool or a stalled disk keeps its session alive indefinitely. The correlation with query-path liveness is weak in both directions.
- **A liveness endpoint on the server** answers the wrong question. `/health` runs on a separate listener and returns 200 for a wedged query executor. It also cannot separate "wedged" from "busy", which is the distinction that matters.
- **Kubernetes probes** are not in the query path at all. Brokers read server hostnames from ZooKeeper and connect directly to the pod; no Service is involved.

Queries going unanswered is the only signal that observes the thing we care about.

## Guarding against false positives

Ejecting a live-but-busy server is worse than the bug it fixes, so the change is deliberately reluctant. Three independent guards:

| Guard | What it stops |
|---|---|
| **Sole non-responder only.** A timeout is attributed to a server only when it is the only one in its query that failed. | Shared causes — the broker, the query, the network, an overloaded fleet. Those make servers fail *together*, so nobody is ever the sole non-responder. |
| **Consecutive, with a 5-minute expiry.** Any response resets the count; a stale count restarts. | A busy server always answers *something*. Only a server answering nothing at all reaches the threshold. And a count cannot survive a rolling restart and eject a server on its first miss back. |
| **Fresh-connection recovery probe.** | A busy server still completes a TCP handshake (Netty's acceptor pool is separate from the query pool), so it is re-included on the first retry. |

Note what the first guard also buys: this feature **structurally cannot empty a routing table**. If every server is wedged, every query fails wholly, nothing is a sole non-responder, and nothing is ejected. That is why there is no cap on how many servers may be held out at once — several servers each going silent while their peers keep serving is exactly the case that should shed all of them, and a fleet-wide fault accuses nobody.

Deliberate consequences, all pinned by tests:

- Two servers wedged **in the same query** are not detected. That is the status quo, and a shared cause is the likelier explanation.
- A hybrid server that answers one half of a query and stalls the other is not ejected. It is producing results, so it is serving.
- A wedged server that still accepts connections **is** re-admitted by the retrier. This is the fail-safe direction: never strand a server that has recovered.

## The default is the main thing to review

`DEFAULT_CONSECUTIVE_TIMEOUT_THRESHOLD = 5`, so this is **on** for anyone already running `failure.detector.type=CONNECTION`. `NO_OP` is untouched and remains the shipped default detector.

The argument for on: `CONNECTION` is opt-in, and choosing it means wanting unhealthy servers out of routing. Shipped off, it would likely never get turned on.

The argument for off: Pinot's convention is that behaviour-changing features default to disabled, and this changes what `UNHEALTHY_SERVERS` means for existing alerts.

Happy to flip it to `0` if reviewers prefer a release of soak time first — it is a one-line change, and `<= 0` is the documented escape hatch either way.

## Known gaps

- Only the single-stage Netty path reports timeouts. `GrpcBrokerRequestHandler` and the multi-stage `QueryDispatcher` still report connection failures only — neither currently knows *which* servers failed to answer, so wiring them up needs changes in `StreamingReduceService` / `processResults`. Noted on `ConnectionFailureDetector`; follow-up.
- Does not cover a server whose kernel is alive but whose JVM is wedged *and* still accepting connections. The probe calls that server healthy. Setting `TCP_USER_TIMEOUT` on the broker channel would cover the complementary case (node gone) through the existing `markServerDown` path — separate change.
- `reportScatterOutcomeToFailureDetector` is called from both scatter sites in the handler. The deeper seam is `AsyncQueryResponse#getFinalResponses`, which already partitions responded/not-responded and already fans out to a per-server observer — but a per-response hook cannot express the MV-split path's merged view across two responses. Left as a follow-up.

### One note for reviewers

An earlier revision had an `isEmpty()` fast path in front of the per-responder reset. It is gone, and should stay gone on two counts: it raced with the concurrent counter update, and it is also *slower* — `ConcurrentHashMap.isEmpty()` sums `counterCells`, whereas a miss on `remove()` short-circuits on a single null-table read.

## Testing

| Suite | Result |
|---|---|
| `SingleConnectionBrokerRequestHandlerFailureDetectorTest` (new, real sockets) | 8 |
| `ConnectionFailureDetectorTest` | 9 |
| `QueryRoutingTest` | 12 |
| `ServerChannelsTest` | 6 |
| Other broker request-handler tests | 39 |
| `MultiNodesOfflineClusterIntegrationTest` | 139 |

`ServerChannelsTest#testProbeIgnoresAnActivePooledChannel` pins the part that actually changed: a pooled channel reporting `isActive()` must not make the probe succeed.
