### PR TITLE
Log a query on a single line

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.RateLimiter;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.broker.requesthandler.BaseSingleStageBrokerRequestHandler.ServerStats;
@@ -48,6 +49,14 @@ public class QueryLogger {
 
   private static final String FINGERPRINT_FAILED_QUERY_REDACTED = "FINGERPRINT_FAILED_QUERY_REDACTED";
   private static final String FULLY_REDACTED = "REDACTED";
+
+  /// Runs of CR/LF in a query are collapsed to a single space before it is logged, so that one
+  /// logged query occupies one physical log line. Clients routinely submit pretty-printed SQL, and
+  /// logging it verbatim turns a single log event into one line per line of SQL as soon as anything
+  /// downstream splits on newlines -- a container runtime, a log shipper, a file tailer. Those
+  /// continuation lines carry no logger name or level, so they cannot be filtered, sampled or
+  /// attributed, and a multiline log collector will attach them to whatever record preceded them.
+  private static final Pattern QUERY_NEWLINES = Pattern.compile("[\\r\\n]+");
 
   public enum SqlRedactionMode {
     // Log the full SQL query text as-is.
@@ -201,8 +210,16 @@ public class QueryLogger {
         return queryFingerprint != null ? queryFingerprint.getFingerprint() : FINGERPRINT_FAILED_QUERY_REDACTED;
       case NONE:
       default:
-        return query;
+        return toSingleLine(query);
     }
+  }
+
+  /// Collapses CR/LF runs so the query occupies a single log line. Only line breaks are touched:
+  /// indentation and spacing within a line are left alone, so the logged text stays as close to
+  /// what the client sent as a single-line rendering allows.
+  @Nullable
+  private static String toSingleLine(@Nullable String query) {
+    return query == null ? null : QUERY_NEWLINES.matcher(query).replaceAll(" ");
   }
 
   private boolean shouldForceLog(@Nullable QueryLogParams params) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
@@ -22,7 +22,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.RateLimiter;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.broker.requesthandler.BaseSingleStageBrokerRequestHandler.ServerStats;
@@ -50,13 +49,19 @@ public class QueryLogger {
   private static final String FINGERPRINT_FAILED_QUERY_REDACTED = "FINGERPRINT_FAILED_QUERY_REDACTED";
   private static final String FULLY_REDACTED = "REDACTED";
 
-  /// Runs of CR/LF in a query are collapsed to a single space before it is logged, so that one
-  /// logged query occupies one physical log line. Clients routinely submit pretty-printed SQL, and
-  /// logging it verbatim turns a single log event into one line per line of SQL as soon as anything
-  /// downstream splits on newlines -- a container runtime, a log shipper, a file tailer. Those
-  /// continuation lines carry no logger name or level, so they cannot be filtered, sampled or
-  /// attributed, and a multiline log collector will attach them to whatever record preceded them.
-  private static final Pattern QUERY_NEWLINES = Pattern.compile("[\\r\\n]+");
+  /// Line breaks in a query are escaped before it is logged, so that one logged query occupies one
+  /// physical log line. Clients routinely submit pretty-printed SQL, and logging it verbatim turns a
+  /// single log event into one line per line of SQL as soon as anything downstream splits on
+  /// newlines -- a container runtime, a log shipper, a file tailer. Those continuation lines carry no
+  /// logger name or level, so they cannot be filtered, sampled or attributed, and a multiline log
+  /// collector will attach them to whatever record preceded them.
+  ///
+  /// They are escaped rather than replaced with a space because a newline can be syntactically
+  /// significant: it terminates a `--` or `//` line comment. Replacing it with a space would pull
+  /// the remainder of the statement into the comment, so
+  ///     SELECT a -- note\n FROM t
+  /// would be logged as a query that no longer parses, and worse, no longer means what was run.
+  /// Escaping keeps the record on one line without changing what it says.
 
   public enum SqlRedactionMode {
     // Log the full SQL query text as-is.
@@ -214,12 +219,15 @@ public class QueryLogger {
     }
   }
 
-  /// Collapses CR/LF runs so the query occupies a single log line. Only line breaks are touched:
-  /// indentation and spacing within a line are left alone, so the logged text stays as close to
-  /// what the client sent as a single-line rendering allows.
+  /// Escapes line breaks so the query occupies a single log line. Only CR and LF are touched:
+  /// indentation and spacing within a line are left alone, and no character is removed, so the
+  /// logged text still says exactly what was run.
   @Nullable
   private static String toSingleLine(@Nullable String query) {
-    return query == null ? null : QUERY_NEWLINES.matcher(query).replaceAll(" ");
+    if (query == null || (query.indexOf('\n') < 0 && query.indexOf('\r') < 0)) {
+      return query;
+    }
+    return query.replace("\r", "\\r").replace("\n", "\\n");
   }
 
   private boolean shouldForceLog(@Nullable QueryLogParams params) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
@@ -49,22 +49,8 @@ public class QueryLogger {
   private static final String FINGERPRINT_FAILED_QUERY_REDACTED = "FINGERPRINT_FAILED_QUERY_REDACTED";
   private static final String FULLY_REDACTED = "REDACTED";
 
-  /// Line breaks in a query are escaped before it is logged, so that one logged query occupies one
-  /// physical log line. Clients routinely submit pretty-printed SQL, and logging it verbatim turns a
-  /// single log event into one line per line of SQL as soon as anything downstream splits on
-  /// newlines -- a container runtime, a log shipper, a file tailer. Those continuation lines carry no
-  /// logger name or level, so they cannot be filtered, sampled or attributed, and a multiline log
-  /// collector will attach them to whatever record preceded them.
-  ///
-  /// They are escaped rather than replaced with a space because a newline can be syntactically
-  /// significant: it terminates a `--` or `//` line comment. Replacing it with a space would pull
-  /// the remainder of the statement into the comment, so
-  ///     SELECT a -- note\n FROM t
-  /// would be logged as a query that no longer parses, and worse, no longer means what was run.
-  /// Escaping keeps the record on one line without changing what it says.
-
   public enum SqlRedactionMode {
-    // Log the full SQL query text as-is.
+    // Log the full SQL query text with backslashes and line endings escaped.
     // e.g. "SELECT name FROM users WHERE id = 42 AND status = 'active'"
     NONE,
     // Replace literal values with placeholders using the query fingerprint, preserving query structure.
@@ -219,15 +205,16 @@ public class QueryLogger {
     }
   }
 
-  /// Escapes line breaks so the query occupies a single log line. Only CR and LF are touched:
-  /// indentation and spacing within a line are left alone, and no character is removed, so the
-  /// logged text still says exactly what was run.
+  /// Escapes backslashes, CR and LF as `\\`, `\r` and `\n` so the query occupies a single log line.
+  /// A line ending can terminate a `--` or `//` comment, so replacing it with a space changes SQL semantics.
+  /// Escaping existing backslashes distinguishes literal escape sequences from encoded line endings.
+  /// Decode these three escape sequences in a single pass before replaying untruncated logged SQL.
   @Nullable
   private static String toSingleLine(@Nullable String query) {
-    if (query == null || (query.indexOf('\n') < 0 && query.indexOf('\r') < 0)) {
+    if (query == null || (query.indexOf('\\') < 0 && query.indexOf('\n') < 0 && query.indexOf('\r') < 0)) {
       return query;
     }
-    return query.replace("\r", "\\r").replace("\n", "\\n");
+    return query.replace("\\", "\\\\").replace("\r", "\\r").replace("\n", "\\n");
   }
 
   private boolean shouldForceLog(@Nullable QueryLogParams params) {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/querylog/QueryLoggerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/querylog/QueryLoggerTest.java
@@ -226,6 +226,47 @@ public class QueryLoggerTest {
   }
 
   @Test
+  public void shouldLogMultiLineQueryOnASingleLine() {
+    // Given: a client that submits pretty-printed SQL, as JDBC/BI tools routinely do
+    Mockito.when(_logRateLimiter.tryAcquire()).thenReturn(true);
+    QueryLogger queryLogger = new QueryLogger(_logRateLimiter, 10_000, true, true,
+        SqlRedactionMode.NONE, _logger, _droppedRateLimiter);
+    String prettyPrinted = "SELECT id, name\nFROM users\r\nWHERE id = 42\n    AND status = 'active'\nLIMIT 10";
+
+    // When:
+    queryLogger.logQueryReceived(123L, prettyPrinted, null);
+
+    // Then: one log record, and it occupies one physical line
+    Assert.assertEquals(_infoLog.size(), 1);
+    String logged = _infoLog.get(0);
+    Assert.assertFalse(logged.contains("\n"), "logged query must not contain a line feed: " + logged);
+    Assert.assertFalse(logged.contains("\r"), "logged query must not contain a carriage return: " + logged);
+    // and the query is still readable / replayable
+    Assert.assertTrue(logged.contains("SELECT id, name FROM users WHERE id = 42     AND status = 'active' LIMIT 10"),
+        logged);
+  }
+
+  @Test
+  public void shouldLogMultiLineQueryOnASingleLineOnCompletion() {
+    // Given: the completion log carries the query too, so it needs the same treatment
+    Mockito.when(_logRateLimiter.tryAcquire()).thenReturn(true);
+    QueryLogger queryLogger = new QueryLogger(_logRateLimiter, 10_000, true, false,
+        SqlRedactionMode.NONE, _logger, _droppedRateLimiter);
+
+    QueryLogger.QueryLogParams params =
+        generateParams(false, false, 0, 456, null, "SELECT id\nFROM users\nLIMIT 1");
+
+    // When:
+    queryLogger.logQueryCompleted(params, true);
+
+    // Then:
+    Assert.assertEquals(_infoLog.size(), 1);
+    String logged = _infoLog.get(0);
+    Assert.assertFalse(logged.contains("\n"), logged);
+    Assert.assertTrue(logged.contains("query=SELECT id FROM users LIMIT 1"), logged);
+  }
+
+  @Test
   public void shouldNotLogQueryReceivedWhenRateLimited() {
     // Given: rate limiter denies
     Mockito.when(_logRateLimiter.tryAcquire()).thenReturn(false);
@@ -476,9 +517,15 @@ public class QueryLoggerTest {
 
   private QueryLogger.QueryLogParams generateParams(boolean numGroupsLimitReached, boolean numGroupsWarningLimitReached,
       int numExceptions, long timeUsedMs, QueryFingerprint queryFingerprint) {
+    return generateParams(numGroupsLimitReached, numGroupsWarningLimitReached, numExceptions, timeUsedMs,
+        queryFingerprint, "SELECT * FROM foo");
+  }
+
+  private QueryLogger.QueryLogParams generateParams(boolean numGroupsLimitReached, boolean numGroupsWarningLimitReached,
+      int numExceptions, long timeUsedMs, QueryFingerprint queryFingerprint, String query) {
     RequestContext requestContext = new DefaultRequestContext();
     requestContext.setRequestId(123);
-    requestContext.setQuery("SELECT * FROM foo");
+    requestContext.setQuery(query);
     requestContext.setNumUnavailableSegments(21);
 
     if (queryFingerprint != null) {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/querylog/QueryLoggerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/querylog/QueryLoggerTest.java
@@ -231,28 +231,62 @@ public class QueryLoggerTest {
     Mockito.when(_logRateLimiter.tryAcquire()).thenReturn(true);
     QueryLogger queryLogger = new QueryLogger(_logRateLimiter, 10_000, true, true,
         SqlRedactionMode.NONE, _logger, _droppedRateLimiter);
-    String prettyPrinted = "SELECT id, name\nFROM users\r\nWHERE id = 42\n    AND status = 'active'\nLIMIT 10";
+    String prettyPrinted = "SELECT id, name\nFROM users\r\nWHERE id = 42\nLIMIT 10";
 
     // When:
     queryLogger.logQueryReceived(123L, prettyPrinted, null);
 
-    // Then: one log record, and it occupies one physical line
+    // Then: one record, on one physical line
     Assert.assertEquals(_infoLog.size(), 1);
     String logged = _infoLog.get(0);
     Assert.assertFalse(logged.contains("\n"), "logged query must not contain a line feed: " + logged);
     Assert.assertFalse(logged.contains("\r"), "logged query must not contain a carriage return: " + logged);
-    // and the query is still readable / replayable
-    Assert.assertTrue(logged.contains("SELECT id, name FROM users WHERE id = 42     AND status = 'active' LIMIT 10"),
-        logged);
+    // and the breaks are escaped, not discarded, so nothing is lost
+    Assert.assertTrue(logged.contains("SELECT id, name\\nFROM users\\r\\nWHERE id = 42\\nLIMIT 10"), logged);
+  }
+
+  @Test
+  public void shouldNotBreakLineCommentsWhenLoggingOnASingleLine() {
+    // Given: a query whose line comment is terminated by the newline. Pinot's grammar accepts both
+    // "--" and "//" line comments (SINGLE_LINE_COMMENT in Parser.jj), so replacing the break with a
+    // space would pull "FROM t" into the comment and change what the logged query means.
+    Mockito.when(_logRateLimiter.tryAcquire()).thenReturn(true);
+    QueryLogger queryLogger = new QueryLogger(_logRateLimiter, 10_000, true, true,
+        SqlRedactionMode.NONE, _logger, _droppedRateLimiter);
+
+    // When:
+    queryLogger.logQueryReceived(123L, "SELECT a -- note\nFROM t", null);
+
+    // Then:
+    Assert.assertEquals(_infoLog.size(), 1);
+    String logged = _infoLog.get(0);
+    Assert.assertFalse(logged.contains("\n"), logged);
+    Assert.assertTrue(logged.contains("SELECT a -- note\\nFROM t"), logged);
+    Assert.assertFalse(logged.contains("-- note FROM t"),
+        "the comment must not swallow the rest of the statement: " + logged);
+  }
+
+  @Test
+  public void shouldLeaveASingleLineQueryUntouched() {
+    // Given:
+    Mockito.when(_logRateLimiter.tryAcquire()).thenReturn(true);
+    QueryLogger queryLogger = new QueryLogger(_logRateLimiter, 10_000, true, true,
+        SqlRedactionMode.NONE, _logger, _droppedRateLimiter);
+
+    // When:
+    queryLogger.logQueryReceived(123L, "SELECT a FROM t WHERE s = 'x'", null);
+
+    // Then: no escaping applied to a query that was already on one line
+    Assert.assertEquals(_infoLog.size(), 1);
+    Assert.assertTrue(_infoLog.get(0).contains("SELECT a FROM t WHERE s = 'x'"), _infoLog.get(0));
   }
 
   @Test
   public void shouldLogMultiLineQueryOnASingleLineOnCompletion() {
-    // Given: the completion log carries the query too, so it needs the same treatment
+    // Given: the completion record carries the query too, so it needs the same treatment
     Mockito.when(_logRateLimiter.tryAcquire()).thenReturn(true);
     QueryLogger queryLogger = new QueryLogger(_logRateLimiter, 10_000, true, false,
         SqlRedactionMode.NONE, _logger, _droppedRateLimiter);
-
     QueryLogger.QueryLogParams params =
         generateParams(false, false, 0, 456, null, "SELECT id\nFROM users\nLIMIT 1");
 
@@ -263,7 +297,7 @@ public class QueryLoggerTest {
     Assert.assertEquals(_infoLog.size(), 1);
     String logged = _infoLog.get(0);
     Assert.assertFalse(logged.contains("\n"), logged);
-    Assert.assertTrue(logged.contains("query=SELECT id FROM users LIMIT 1"), logged);
+    Assert.assertTrue(logged.contains("query=SELECT id\\nFROM users\\nLIMIT 1"), logged);
   }
 
   @Test

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/querylog/QueryLoggerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/querylog/QueryLoggerTest.java
@@ -41,10 +41,15 @@ import org.slf4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.broker.querylog.QueryLogger.SqlRedactionMode;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 
 @SuppressWarnings("UnstableApiUsage")
@@ -228,7 +233,7 @@ public class QueryLoggerTest {
   @Test
   public void shouldLogMultiLineQueryOnASingleLine() {
     // Given: a client that submits pretty-printed SQL, as JDBC/BI tools routinely do
-    Mockito.when(_logRateLimiter.tryAcquire()).thenReturn(true);
+    when(_logRateLimiter.tryAcquire()).thenReturn(true);
     QueryLogger queryLogger = new QueryLogger(_logRateLimiter, 10_000, true, true,
         SqlRedactionMode.NONE, _logger, _droppedRateLimiter);
     String prettyPrinted = "SELECT id, name\nFROM users\r\nWHERE id = 42\nLIMIT 10";
@@ -237,39 +242,46 @@ public class QueryLoggerTest {
     queryLogger.logQueryReceived(123L, prettyPrinted, null);
 
     // Then: one record, on one physical line
-    Assert.assertEquals(_infoLog.size(), 1);
+    assertEquals(_infoLog.size(), 1);
     String logged = _infoLog.get(0);
-    Assert.assertFalse(logged.contains("\n"), "logged query must not contain a line feed: " + logged);
-    Assert.assertFalse(logged.contains("\r"), "logged query must not contain a carriage return: " + logged);
+    assertFalse(logged.contains("\n"), "logged query must not contain a line feed: " + logged);
+    assertFalse(logged.contains("\r"), "logged query must not contain a carriage return: " + logged);
     // and the breaks are escaped, not discarded, so nothing is lost
-    Assert.assertTrue(logged.contains("SELECT id, name\\nFROM users\\r\\nWHERE id = 42\\nLIMIT 10"), logged);
+    assertTrue(logged.contains("SELECT id, name\\nFROM users\\r\\nWHERE id = 42\\nLIMIT 10"), logged);
   }
 
-  @Test
-  public void shouldNotBreakLineCommentsWhenLoggingOnASingleLine() {
+  @DataProvider(name = "lineComments")
+  public Object[][] lineComments() {
+    return new Object[][]{{"--"}, {"//"}};
+  }
+
+  @Test(dataProvider = "lineComments")
+  public void shouldNotBreakLineCommentsWhenLoggingOnASingleLine(String commentPrefix) {
     // Given: a query whose line comment is terminated by the newline. Pinot's grammar accepts both
     // "--" and "//" line comments (SINGLE_LINE_COMMENT in Parser.jj), so replacing the break with a
     // space would pull "FROM t" into the comment and change what the logged query means.
-    Mockito.when(_logRateLimiter.tryAcquire()).thenReturn(true);
+    when(_logRateLimiter.tryAcquire()).thenReturn(true);
     QueryLogger queryLogger = new QueryLogger(_logRateLimiter, 10_000, true, true,
         SqlRedactionMode.NONE, _logger, _droppedRateLimiter);
 
     // When:
-    queryLogger.logQueryReceived(123L, "SELECT a -- note\nFROM t", null);
+    String query = "SELECT a " + commentPrefix + " note\nFROM t";
+    queryLogger.logQueryReceived(123L, query, null);
 
     // Then:
-    Assert.assertEquals(_infoLog.size(), 1);
+    assertEquals(_infoLog.size(), 1);
     String logged = _infoLog.get(0);
-    Assert.assertFalse(logged.contains("\n"), logged);
-    Assert.assertTrue(logged.contains("SELECT a -- note\\nFROM t"), logged);
-    Assert.assertFalse(logged.contains("-- note FROM t"),
+    assertFalse(logged.contains("\n"), logged);
+    assertEquals(logged, "SQL query for request 123: SELECT a " + commentPrefix + " note\\nFROM t");
+    assertEquals(logged.substring("SQL query for request 123: ".length()).translateEscapes(), query);
+    assertFalse(logged.contains(commentPrefix + " note FROM t"),
         "the comment must not swallow the rest of the statement: " + logged);
   }
 
   @Test
   public void shouldLeaveASingleLineQueryUntouched() {
     // Given:
-    Mockito.when(_logRateLimiter.tryAcquire()).thenReturn(true);
+    when(_logRateLimiter.tryAcquire()).thenReturn(true);
     QueryLogger queryLogger = new QueryLogger(_logRateLimiter, 10_000, true, true,
         SqlRedactionMode.NONE, _logger, _droppedRateLimiter);
 
@@ -277,14 +289,14 @@ public class QueryLoggerTest {
     queryLogger.logQueryReceived(123L, "SELECT a FROM t WHERE s = 'x'", null);
 
     // Then: no escaping applied to a query that was already on one line
-    Assert.assertEquals(_infoLog.size(), 1);
-    Assert.assertTrue(_infoLog.get(0).contains("SELECT a FROM t WHERE s = 'x'"), _infoLog.get(0));
+    assertEquals(_infoLog.size(), 1);
+    assertTrue(_infoLog.get(0).contains("SELECT a FROM t WHERE s = 'x'"), _infoLog.get(0));
   }
 
   @Test
   public void shouldLogMultiLineQueryOnASingleLineOnCompletion() {
     // Given: the completion record carries the query too, so it needs the same treatment
-    Mockito.when(_logRateLimiter.tryAcquire()).thenReturn(true);
+    when(_logRateLimiter.tryAcquire()).thenReturn(true);
     QueryLogger queryLogger = new QueryLogger(_logRateLimiter, 10_000, true, false,
         SqlRedactionMode.NONE, _logger, _droppedRateLimiter);
     QueryLogger.QueryLogParams params =
@@ -294,10 +306,48 @@ public class QueryLoggerTest {
     queryLogger.logQueryCompleted(params, true);
 
     // Then:
-    Assert.assertEquals(_infoLog.size(), 1);
+    assertEquals(_infoLog.size(), 1);
     String logged = _infoLog.get(0);
-    Assert.assertFalse(logged.contains("\n"), logged);
-    Assert.assertTrue(logged.contains("query=SELECT id\\nFROM users\\nLIMIT 1"), logged);
+    assertFalse(logged.contains("\n"), logged);
+    assertTrue(logged.contains("query=SELECT id\\nFROM users\\nLIMIT 1"), logged);
+  }
+
+  @DataProvider(name = "queriesWithEscapedCharacters")
+  public Object[][] queriesWithEscapedCharacters() {
+    return new Object[][]{
+        {"SELECT 'a\nb' FROM t", "SELECT 'a\\nb' FROM t"},
+        {"SELECT 'a\\nb' FROM t", "SELECT 'a\\\\nb' FROM t"},
+        {"SELECT 'a\rb' FROM t", "SELECT 'a\\rb' FROM t"},
+        {"SELECT 'a\\rb' FROM t", "SELECT 'a\\\\rb' FROM t"},
+        {"SELECT 'a\\\nb' FROM t", "SELECT 'a\\\\\\nb' FROM t"},
+        {"SELECT 'a\n\\b' FROM t", "SELECT 'a\\n\\\\b' FROM t"},
+        {"SELECT 'a\\\r\nb' FROM t", "SELECT 'a\\\\\\r\\nb' FROM t"},
+        {"SELECT 'a\\\\b' FROM t", "SELECT 'a\\\\\\\\b' FROM t"},
+        {"SELECT '\\d+\\s+\\w+' FROM t", "SELECT '\\\\d+\\\\s+\\\\w+' FROM t"},
+        {"SELECT '\\t\\b\\f\\141' FROM t", "SELECT '\\\\t\\\\b\\\\f\\\\141' FROM t"},
+        {"SELECT\t'a\tb' FROM t", "SELECT\t'a\tb' FROM t"}
+    };
+  }
+
+  @Test(dataProvider = "queriesWithEscapedCharacters")
+  public void shouldLogQueryWithReversibleEscaping(String query, String expected) {
+    when(_logRateLimiter.tryAcquire()).thenReturn(true);
+    QueryLogger queryLogger = new QueryLogger(_logRateLimiter, 10_000, true, true,
+        SqlRedactionMode.NONE, _logger, _droppedRateLimiter);
+
+    queryLogger.logQueryReceived(123L, query, null);
+    queryLogger.logQueryCompleted(generateParams(false, false, 0, 456, null, query), true);
+
+    assertEquals(_infoLog.size(), 2);
+    String receivedQuery = _infoLog.get(0).substring("SQL query for request 123: ".length());
+    String completedLog = _infoLog.get(1);
+    String completedQuery = completedLog.substring(completedLog.indexOf(",query=") + ",query=".length());
+    for (String loggedQuery : List.of(receivedQuery, completedQuery)) {
+      assertEquals(loggedQuery, expected);
+      assertFalse(loggedQuery.contains("\n"));
+      assertFalse(loggedQuery.contains("\r"));
+      assertEquals(loggedQuery.translateEscapes(), query);
+    }
   }
 
   @Test


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

The NONE redaction mode now calls toSingleLine to escape backslashes, CR, and LF, logging each query on one line\.

```mermaid
flowchart TD
  N0["redactQuery NONE branch #40;F1#41;"]:::stModified
  N1["toSingleLine method #40;F1#41;"]:::stAdded
  N0 -->|"calls"| N1
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger\.java — [before](https://github.com/apache/pinot/blob/ca71554fc9d7a6012e5f6cf6c55c9dcd320c8526/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java) · [after](https://github.com/apache/pinot/blob/2788b3302f5c6238ff2bad2b8ed9fce147793e72/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImNhNzE1NTRmYzlkN2E2MDEyZTVmNmNmNmM1NWM5ZGNkMzIwYzg1MjYiLCJjb250ZXh0X2hhc2giOiJjYjczN2RkYTUyYjlmZDM0YWViMmM1Y2Q2NzM2YzFiZTdhMGJmNWY0MzFjYmE2M2MyYjI4NGI5NzJjZTk0ZGNmIiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTA3NDkwLCJoZWFkX3NoYSI6IjI3ODhiMzMwMmY1YzYyMzhmZjJiYWQyYjhlZDlmY2UxNDc3OTNlNzIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJjYTcxNTU0ZmM5ZDdhNjAxMmU1ZjZjZjZjNTVjOWRjZDMyMGM4NTI2IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 849b94cfcc6226c7fa65aacc0f74593f6fbd3c519203b0539122d62c353dabdf -->
<!-- pinot-pr-flow:end -->

## Summary

Escape backslashes, carriage returns and line feeds in logged SQL so each query occupies one physical log line and its original text can be recovered from an untruncated log value.

## Motivation

Clients routinely submit pretty-printed SQL — JDBC and BI tools do so by default — and the broker logs the query verbatim. A single log *event* then renders as one physical *line per line of SQL* when a container runtime, log shipper or file tailer splits on newlines.

Measured on one production broker, 60s window, 3,995 queries:

| | lines | per query |
|---|---|---|
| `SQL query for request <id>:` headers | 3,995 | 1 |
| continuation lines after them | 30,975 | 7.8 |
| completion stats lines | 3,994 | 1 |
| continuation lines after those | 30,969 | 7.8 |
| **total continuation lines** | **61,944** | **79.4% of that broker's entire log volume** |

Escaping line breaks removes those 61,944 continuation lines while retaining both log records and their fields. Continuation lines carry no timestamp, level or logger name, so downstream tools cannot independently filter, sample or attribute them. A multiline collector can also attach SQL fragments to an unrelated preceding record; we observed exactly that on this broker.

## Implementation and compatibility

Apply the rendering inside `redactQuery` for `SqlRedactionMode.NONE`, covering query receipt, completion and broker error/cancellation logging paths. Escape each backslash as `\\`, each CR as `\r` and each LF as `\n`. Escaping existing backslashes also applies to single-line SQL and distinguishes literal backslash sequences from encoded line breaks.

The executable SQL is unchanged. Comments, quoted identifiers, string contents and indentation are preserved by this encoding. Log consumers must decode the three escapes before replaying SQL; logged SQL containing these characters is no longer directly copy-pasteable. Existing configured query truncation still applies, so a truncated value cannot be fully recovered.

No config or API changes. `SqlRedactionMode.FULL` and `LITERAL_VALUES` are unchanged. Queries without backslashes, CR or LF pass through unchanged.

## Validation

- Maven QueryLoggerTest with dependent modules on JDK 25: 35 tests passed, no failures or skips.
- Regression coverage checks exact encoded output and decoding for both received/completed logs, including literal backslash sequences, LF/CR/CRLF, adjacent/repeated backslashes, regex patterns, tabs, and both line-comment forms. Eight regression cases fail against the original escaping implementation.
- Spotless, Checkstyle, license formatting and license validation passed for pinot-broker.
- An additional compiler-warning build stops in unchanged ZstandardDecompressor.java:51 because org.jetbrains.annotations.NotNull is unavailable. The standard Maven test build passes.

## Related

Companion draft adds a `QUERY_RECEIVED` marker so the two per-query records become separately routable. Independent of this change — that one affects addressability, this one affects rendering.
