### PR TITLE
Clean up multipart tempfile on segment upload failure paths

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -406,6 +406,7 @@ public class LLCSegmentCompletionHandlers {
       return new SegmentMetadataImpl(tempIndexDir);
     } finally {
       FileUtils.deleteQuietly(tempIndexDir);
+      form.cleanup();
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
@@ -156,6 +156,10 @@ public class PinotIngestionRestletResource {
       asyncResponse.resume(new ControllerApplicationException(LOGGER,
           String.format("Caught exception when ingesting file into table: %s. %s", tableNameWithType, e.getMessage()),
           Response.Status.INTERNAL_SERVER_ERROR, e));
+    } finally {
+      if (fileUpload != null) {
+        fileUpload.cleanup();
+      }
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -463,6 +463,9 @@ public class PinotSegmentUploadDownloadRestletResource {
       FileUtils.deleteQuietly(tempEncryptedFile);
       FileUtils.deleteQuietly(tempDecryptedFile);
       FileUtils.deleteQuietly(tempSegmentDir);
+      if (multiPart != null) {
+        multiPart.cleanup();
+      }
     }
   }
 
@@ -555,6 +558,9 @@ public class PinotSegmentUploadDownloadRestletResource {
     } finally {
       FileUtils.deleteQuietly(tempTarFile);
       FileUtils.deleteQuietly(tempSegmentDir);
+      if (multiPart != null) {
+        multiPart.cleanup();
+      }
     }
   }
 
@@ -1260,7 +1266,9 @@ public class PinotSegmentUploadDownloadRestletResource {
 
   private static void createSegmentFileFromMultipart(FormDataMultiPart multiPart, File destFile)
       throws IOException {
-    // Read segment file or segment metadata file and directly use that information to update zk
+    // Read segment file or segment metadata file and directly use that information to update zk.
+    // NOTE: multiPart.cleanup() is intentionally NOT called here. The calling handler method owns the multipart
+    // lifecycle and cleans it up in its outer finally block.
     Map<String, List<FormDataBodyPart>> segmentMetadataMap = multiPart.getFields();
     if (!validateMultiPart(segmentMetadataMap, null)) {
       throw new ControllerApplicationException(LOGGER, "Invalid multi-part form for segment metadata",
@@ -1270,8 +1278,6 @@ public class PinotSegmentUploadDownloadRestletResource {
     try (InputStream inputStream = segmentMetadataBodyPart.getValueAs(InputStream.class);
         OutputStream outputStream = new FileOutputStream(destFile)) {
       IOUtils.copyLarge(inputStream, outputStream);
-    } finally {
-      multiPart.cleanup();
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
@@ -295,15 +295,15 @@ public class FileIngestionHelper {
     }
   }
 
-  /// Copy the file from the uploaded multipart to a local file
+  /// Copy the file from the uploaded multipart to a local file.
+  /// NOTE: multiPart.cleanup() is intentionally NOT called here. The calling REST endpoint owns the multipart
+  /// lifecycle and cleans it up in its outer finally block.
   public static void copyMultipartToLocal(FormDataMultiPart multiPart, File destFile)
       throws IOException {
     FormDataBodyPart formDataBodyPart = multiPart.getFields().values().iterator().next().get(0);
     try (InputStream inputStream = formDataBodyPart.getValueAs(InputStream.class);
         OutputStream outputStream = new FileOutputStream(destFile)) {
       IOUtils.copyLarge(inputStream, outputStream);
-    } finally {
-      multiPart.cleanup();
     }
   }
 


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds finally‑block cleanup for multipart uploads in handlers and removes it from helper methods to prevent temp‑file leaks\.

```mermaid
flowchart TD
  N0["uploadSegment #40;F4#41;"]:::stModified
  N1["finally multiPart#46;cleanup#40;#41; #40;F4#41;"]:::stAdded
  N2["uploadReingestedSegment #40;F4#41;"]:::stModified
  N3["finally multiPart#46;cleanup#40;#41; #40;F4#41;"]:::stAdded
  N4["extractSegmentMetadataFromForm #40;F2#41;"]:::stModified
  N5["finally form#46;cleanup#40;#41; #40;F2#41;"]:::stAdded
  N6["ingestFromFile #40;F3#41;"]:::stModified
  N7["finally fileUpload#46;cleanup#40;#41; #40;F3#41;"]:::stAdded
  N8["copyMultipartToLocal #40;F1#41;"]:::stModified
  N9["#40;no cleanup#41; #40;F1#41;"]:::stRemoved
  N10["createSegmentFileFromMultipart #40;F4#41;"]:::stModified
  N11["#40;no cleanup#41; #40;F4#41;"]:::stRemoved
  N0 -->|"calls cleanup"| N1
  N2 -->|"calls cleanup"| N3
  N4 -->|"calls cleanup"| N5
  N6 -->|"calls cleanup"| N7
  N8 -->|"no cleanup"| N9
  N10 -->|"no cleanup"| N11
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper\.java — [before](https://github.com/apache/pinot/blob/1ccc708ea1c675a599a2c93bfa87553adffd0da3/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java) · [after](https://github.com/apache/pinot/blob/42c225c73ead8d375de56c10ceb523f0fb378da5/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java)
- F2: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers\.java — [before](https://github.com/apache/pinot/blob/1ccc708ea1c675a599a2c93bfa87553adffd0da3/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java) · [after](https://github.com/apache/pinot/blob/42c225c73ead8d375de56c10ceb523f0fb378da5/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java)
- F3: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource\.java — [before](https://github.com/apache/pinot/blob/1ccc708ea1c675a599a2c93bfa87553adffd0da3/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java) · [after](https://github.com/apache/pinot/blob/42c225c73ead8d375de56c10ceb523f0fb378da5/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java)
- F4: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource\.java — [before](https://github.com/apache/pinot/blob/1ccc708ea1c675a599a2c93bfa87553adffd0da3/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java) · [after](https://github.com/apache/pinot/blob/42c225c73ead8d375de56c10ceb523f0fb378da5/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjFjY2M3MDhlYTFjNjc1YTU5OWEyYzkzYmZhODc1NTNhZGZmZDBkYTMiLCJjb250ZXh0X2hhc2giOiJkZjQwYjU2M2I1YmM2MTFiZGJmMDFkNjNhZTU4Mzk1YWIzNjNkMTM2ZDRiNmFhODE5MjRkNmNiMGY0MDQ5MzY2IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MzYzODE5LCJoZWFkX3NoYSI6IjQyYzIyNWM3M2VhZDhkMzc1ZGU1NmMxMGNlYjUyM2YwZmIzNzhkYTUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIxY2NjNzA4ZWExYzY3NWE1OTlhMmM5M2JmYTg3NTUzYWRmZmQwZGEzIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 166f87ed97affdef6bac271997d9f707ce89d09bd9b2693fe8448b7d164d1f25 -->
<!-- pinot-pr-flow:end -->

## Summary

Adds `multiPart.cleanup()` to the outer `finally` of `uploadSegment` and `uploadReingestedSegment` so Jersey/mimepull tempfiles (`MIME*.tmp` under the controller's `java.io.tmpdir`) don't leak when the handler exits before reaching `createSegmentFileFromMultipart`.

## Leak paths fixed

- `uploadSegment`: guard-clause throws for missing `DOWNLOAD_URI` (case SEGMENT and case METADATA), unexpected body in case URI, default case
- `uploadReingestedSegment`: pre-try guard throws (wrong `UPLOAD_TYPE` / missing `DOWNLOAD_URI` / `COPY_SEGMENT_TO_DEEP_STORE != true`) — moved inside the existing `try` so the new `finally` covers them

The existing `multiPart.cleanup()` inside `createSegmentFileFromMultipart` is kept for defense in depth. `MIMEPart.close()` is idempotent, so double-invocation on the success path is safe.

## Not covered

Leaks that no per-handler `finally` can catch — JVM death, `IOException` from mimepull during body spool, client disconnect — need a separate startup reaper for stale `MIME*.tmp`. Out of scope for this PR.