### PR TITLE
Add an InstancePlanMakerImplV2 extension point for the combine plan node

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -225,7 +226,7 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
       }
     }
 
-    CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, queryContext, executorService, null);
+    CombinePlanNode combinePlanNode = createCombinePlanNode(planNodes, queryContext, executorService, null);
     return new GlobalPlanImplV0(
         new InstanceResponsePlanNode(combinePlanNode, segmentContexts, fetchContexts, queryContext));
   }
@@ -395,7 +396,7 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
       }
     }
 
-    CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, queryContext, executorService, streamer);
+    CombinePlanNode combinePlanNode = createCombinePlanNode(planNodes, queryContext, executorService, streamer);
     return new GlobalPlanImplV0(
         new StreamingInstanceResponsePlanNode(combinePlanNode, segmentContexts, fetchContexts, queryContext, streamer));
   }
@@ -409,6 +410,16 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     } else {
       return makeSegmentPlanNode(segmentContext, queryContext);
     }
+  }
+
+  /// Returns the combine plan node placed above the segment plan nodes, for both the streaming and the
+  /// non-streaming instance plan. `streamer` is null for a non-streaming query.
+  ///
+  /// Which combine operator that node builds is decided inside [CombinePlanNode] itself, per query type, so an
+  /// implementation substituting one query type does not have to reproduce the dispatch for the others.
+  protected CombinePlanNode createCombinePlanNode(List<PlanNode> planNodes, QueryContext queryContext,
+      ExecutorService executorService, @Nullable ResultsBlockStreamer streamer) {
+    return new CombinePlanNode(planNodes, queryContext, executorService, streamer);
   }
 
   /// In-place rewrite QueryContext based on the information from local IndexSegment.


### PR DESCRIPTION
## Motivation

`CombinePlanNode` exposes a protected method per combine operator, so an implementation can substitute the operator for one query type and leave the rest to the existing dispatch. Nothing outside `org.apache.pinot.core.plan.maker` can construct a subclass that uses them, though.

`makeInstancePlan` and `makeStreamingInstancePlan` both construct `CombinePlanNode` directly, so substituting means overriding one of those. Both open with `applyQueryOptions`, which is package-private and reads private server-level fields — `_maxExecutionThreads`, `_defaultExecutionThreads`, `_numGroupsLimit`, `_numGroupsWarningLimit`, and the trim/capacity settings — that `init()` populates from the server configuration and no accessor exposes. Nothing else calls it. So an override outside this package can neither invoke it nor reproduce it: a copy would compute the wrong execution-thread count and trim sizes.

## Change

Extract the construction into a protected `createCombinePlanNode()` used by both entry points.

```java
protected CombinePlanNode createCombinePlanNode(List<PlanNode> planNodes, QueryContext queryContext,
    ExecutorService executorService, @Nullable ResultsBlockStreamer streamer) {
  return new CombinePlanNode(planNodes, queryContext, executorService, streamer);
}
```

One method rather than one per entry point. The streaming/non-streaming distinction is already expressed inside `CombinePlanNode`, which picks the combine operator per query type; expressing it here as well would state the same choice twice, and a subclass substituting one query type still overrides only that one method.

The objects constructed, the conditions and their ordering are unchanged.

## Testing

56 existing tests pass across `CombinePlanNodeTest` (6), `InstancePlanMakerImplV2Test` (5), `SelectionCombineOperatorTest` (7), `SortedGroupByCombineOperatorsTest` (12), `StreamingGroupByCombineOperatorTest` (9) and `StreamingDistinctCombineOperatorTest` (17) — the construction moved, nothing about what gets constructed changed.
