### PR TITLE
Release MSE operator buffers on error and cancel, not only on end of stream

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -205,12 +205,21 @@ public class AggregateOperator extends MultiStageOperator {
     _eosBlock = finalBlock;
 
     if (finalBlock.isError()) {
+      // The upstream failed, so no result will ever be produced from what we accumulated: drop it right away instead
+      // of waiting for close()/cancel().
+      releaseBuffers();
       return finalBlock;
     }
     MseBlock mseBlock = produceAggregatedBlock();
+    releaseBuffers();
+    return mseBlock;
+  }
+
+  /// Drops the executors, and with them the group-by hash maps and the aggregate result holders they own.
+  @Override
+  protected void releaseBuffers() {
     _aggregationExecutor = null;
     _groupByExecutor = null;
-    return mseBlock;
   }
 
   private MseBlock produceAggregatedBlock() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -50,6 +50,7 @@ import org.apache.pinot.query.planner.plannode.AggregateNode;
 import org.apache.pinot.query.planner.plannode.PlanNode;
 import org.apache.pinot.query.runtime.blocks.MseBlock;
 import org.apache.pinot.query.runtime.blocks.RowHeapDataBlock;
+import org.apache.pinot.query.runtime.blocks.SuccessMseBlock;
 import org.apache.pinot.query.runtime.operator.utils.SortUtils;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.spi.exception.QueryErrorCode;
@@ -71,6 +72,9 @@ public class AggregateOperator extends MultiStageOperator {
   private final MultiStageOperator _input;
   private final DataSchema _resultSchema;
   private final AggregationFunction<?, ?>[] _aggFunctions;
+  /// Whether this operator groups. Decides which of the two executors below is in use; kept separate from them so
+  /// that releasing an executor cannot change the mode.
+  private final boolean _isGroupBy;
   @Nullable
   private MultistageAggregationExecutor _aggregationExecutor;
   @Nullable
@@ -136,7 +140,8 @@ public class AggregateOperator extends MultiStageOperator {
     AggregateNode.AggType aggType = node.getAggType();
     // TODO: Allow leaf return final result for non-group-by queries
     boolean leafReturnFinalResult = node.isLeafReturnFinalResult();
-    if (groupKeys.isEmpty()) {
+    _isGroupBy = !groupKeys.isEmpty();
+    if (!_isGroupBy) {
       _aggregationExecutor =
           new MultistageAggregationExecutor(_aggFunctions, filterArgIds, maxFilterArgId, aggType, _resultSchema);
       _groupByExecutor = null;
@@ -201,7 +206,7 @@ public class AggregateOperator extends MultiStageOperator {
     if (_eosBlock != null) {
       return _eosBlock;
     }
-    MseBlock.Eos finalBlock = _aggregationExecutor != null ? consumeAggregation() : consumeGroupBy();
+    MseBlock.Eos finalBlock = _isGroupBy ? consumeGroupBy() : consumeAggregation();
     _eosBlock = finalBlock;
 
     if (finalBlock.isError()) {
@@ -215,15 +220,26 @@ public class AggregateOperator extends MultiStageOperator {
     return mseBlock;
   }
 
-  /// Drops the executors, and with them the group-by hash maps and the aggregate result holders they own.
+  /// Drops the executors, and with them the group-by hash maps and the aggregate result holders they own. Marks the
+  /// operator finished at the same time, so that a later [#getNextBlock()] returns the cached end of stream instead
+  /// of trying to consume the input again with a dropped executor.
   @Override
   protected void releaseBuffers() {
     _aggregationExecutor = null;
     _groupByExecutor = null;
+    if (_eosBlock == null) {
+      _eosBlock = SuccessMseBlock.INSTANCE;
+    }
+  }
+
+  @Override
+  protected boolean hasBufferedState() {
+    return _aggregationExecutor != null || _groupByExecutor != null;
   }
 
   private MseBlock produceAggregatedBlock() {
-    if (_aggregationExecutor != null) {
+    if (!_isGroupBy) {
+      assert _aggregationExecutor != null;
       return new RowHeapDataBlock(_aggregationExecutor.getResult(), _resultSchema, _aggFunctions);
     } else {
       assert _groupByExecutor != null;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AsofJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AsofJoinOperator.java
@@ -91,7 +91,7 @@ public class AsofJoinOperator extends BaseJoinOperator {
   }
 
   @Override
-  protected void onEosProduced() {
+  protected void releaseBuffers() {
     _rightTable = null; // Release memory in case we keep the operator around for a while
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AsofJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AsofJoinOperator.java
@@ -96,6 +96,11 @@ public class AsofJoinOperator extends BaseJoinOperator {
   }
 
   @Override
+  protected boolean hasBufferedState() {
+    return _rightTable != null;
+  }
+
+  @Override
   protected List<Object[]> buildJoinedRows(MseBlock.Data leftBlock) {
     assert _rightTable != null : "Right table should not be null when building joined rows";
     List<Object[]> rows = new ArrayList<>();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseJoinOperator.java
@@ -191,17 +191,11 @@ public abstract class BaseJoinOperator extends MultiStageOperator {
     LOGGER.trace("Returning {} for join operator", mseBlock);
     if (mseBlock.isEos()) {
       _eos = (MseBlock.Eos) mseBlock;
-      onEosProduced();
+      // The right table is dead weight from here on, whether this is a successful end of stream or an error block
+      // propagated from the left input. Release it now rather than waiting for close()/cancel() to do it.
+      releaseBuffers();
     }
     return mseBlock;
-  }
-
-  /// Called once this operator has produced its end-of-stream block, i.e. on the successful termination path.
-  ///
-  /// Releases the buffered right table as early as possible. [#releaseBuffers()] runs again from `close()` and
-  /// `cancel()`, which is what covers the error and cancellation paths.
-  protected void onEosProduced() {
-    releaseBuffers();
   }
 
   protected void buildRightTable() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseJoinOperator.java
@@ -196,7 +196,13 @@ public abstract class BaseJoinOperator extends MultiStageOperator {
     return mseBlock;
   }
 
-  protected abstract void onEosProduced();
+  /// Called once this operator has produced its end-of-stream block, i.e. on the successful termination path.
+  ///
+  /// Releases the buffered right table as early as possible. [#releaseBuffers()] runs again from `close()` and
+  /// `cancel()`, which is what covers the error and cancellation paths.
+  protected void onEosProduced() {
+    releaseBuffers();
+  }
 
   protected void buildRightTable() {
     LOGGER.trace("Building right table for join operator");

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -164,6 +164,11 @@ public class HashJoinOperator extends BaseJoinOperator {
   }
 
   @Override
+  protected boolean hasBufferedState() {
+    return _rightTable != null || _matchedRightRows != null || _nullKeyRightRows != null;
+  }
+
+  @Override
   protected List<Object[]> buildJoinedRows(MseBlock.Data leftBlock) {
     assert _rightTable != null : "Right table should not be null when building joined rows";
     switch (_joinType) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -157,7 +157,7 @@ public class HashJoinOperator extends BaseJoinOperator {
   }
 
   @Override
-  protected void onEosProduced() {
+  protected void releaseBuffers() {
     _rightTable = null;
     _matchedRightRows = null;
     _nullKeyRightRows = null;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java
@@ -320,16 +320,17 @@ public class LeafOperator extends MultiStageOperator {
     cancelSseTasks();
   }
 
+  /// Stops the single-stage tasks feeding this operator and drains the blocks they have already queued. Routed
+  /// through the release hook rather than through separate `close()`/`cancel()` overrides so that it runs on every
+  /// termination path by construction, and so a failure here cannot abort the rest of the teardown.
   @Override
-  public void cancel(Throwable e) {
-    super.cancel(e);
+  protected void releaseBuffers() {
     cancelSseTasks();
   }
 
   @Override
-  public void close() {
-    super.close();
-    cancelSseTasks();
+  protected boolean hasBufferedState() {
+    return !_blockingQueue.isEmpty();
   }
 
   @VisibleForTesting

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java
@@ -322,11 +322,13 @@ public class LeafOperator extends MultiStageOperator {
 
   @Override
   public void cancel(Throwable e) {
+    super.cancel(e);
     cancelSseTasks();
   }
 
   @Override
   public void close() {
+    super.close();
     cancelSseTasks();
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -238,6 +238,21 @@ public abstract class MultiStageOperator implements Operator<MseBlock>, AutoClos
   /// the stat map the operator keeps.
   public abstract StatMap<?> copyStatMaps();
 
+  /// Drops the row and hash buffers this operator accumulated while running, so that they become collectable even
+  /// while the operator itself stays reachable.
+  ///
+  /// Both [#close()] and [#cancel(Throwable)] call this, so the buffers are released on *every* termination path:
+  /// end of stream, error and cancellation alike. Operators that can release earlier (when they produce their
+  /// end-of-stream block, say) should keep doing that as well — this is the backstop, not the prompt path.
+  ///
+  /// Implementations must be idempotent: this can run twice, and it runs after [#cancel(Throwable)] on the error
+  /// path. They must not touch anything [#calculateStats()] and [#copyStatMaps()] read, since stats are collected
+  /// after termination. They must also not `clear()` a collection whose identity was handed downstream — a block
+  /// sitting in a local mailbox still points at it, and emptying it silently drops rows. Drop the reference (set
+  /// the field to `null`) in that case.
+  protected void releaseBuffers() {
+  }
+
   // TODO: Ideally close() call should finish within request deadline.
   // TODO: Consider passing deadline as part of the API.
   @Override
@@ -250,6 +265,7 @@ public abstract class MultiStageOperator implements Operator<MseBlock>, AutoClos
         // Continue processing because even one operator failed to be close, we should still close the rest.
       }
     }
+    releaseBuffersSafely();
   }
 
   public void cancel(Throwable e) {
@@ -260,6 +276,16 @@ public abstract class MultiStageOperator implements Operator<MseBlock>, AutoClos
         logger().error("Failed to cancel operator:" + op + "with error:" + e + " with exception:" + e2);
         // Continue processing because even one operator failed to be cancelled, we should still cancel the rest.
       }
+    }
+    releaseBuffersSafely();
+  }
+
+  private void releaseBuffersSafely() {
+    try {
+      releaseBuffers();
+    } catch (Exception e) {
+      // Releasing buffers is best-effort cleanup; never let it break the rest of the teardown.
+      logger().error("Failed to release buffers of operator: " + this + " with exception:" + e);
     }
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
@@ -238,19 +239,50 @@ public abstract class MultiStageOperator implements Operator<MseBlock>, AutoClos
   /// the stat map the operator keeps.
   public abstract StatMap<?> copyStatMaps();
 
-  /// Drops the row and hash buffers this operator accumulated while running, so that they become collectable even
-  /// while the operator itself stays reachable.
+  /// Drops the per-query row and hash state this operator is holding — whatever it accumulated while running, plus
+  /// any input it is still pointing at — so that it becomes collectable even while the operator itself stays
+  /// reachable.
   ///
-  /// Both [#close()] and [#cancel(Throwable)] call this, so the buffers are released on *every* termination path:
-  /// end of stream, error and cancellation alike. Operators that can release earlier (when they produce their
+  /// Both [#close()] and [#cancel(Throwable)] call this, so the state is released on *every* termination path: end
+  /// of stream, error and cancellation alike. Operators that can release earlier (when they produce their
   /// end-of-stream block, say) should keep doing that as well — this is the backstop, not the prompt path.
   ///
-  /// Implementations must be idempotent: this can run twice, and it runs after [#cancel(Throwable)] on the error
-  /// path. They must not touch anything [#calculateStats()] and [#copyStatMaps()] read, since stats are collected
-  /// after termination. They must also not `clear()` a collection whose identity was handed downstream — a block
-  /// sitting in a local mailbox still points at it, and emptying it silently drops rows. Drop the reference (set
-  /// the field to `null`) in that case.
+  /// **Threading.** Like the rest of teardown, this runs on the thread that executes the op chain (see [OpChain]) —
+  /// either the worker thread itself, via the scheduler's direct-executor callback, or a thread holding a chain that
+  /// never started. It is therefore safe to touch operator state without synchronization, and callers must not
+  /// invoke [#close()] or [#cancel(Throwable)] from anywhere else: nulling a field that a concurrently running
+  /// `getNextBlock()` is dereferencing would be a use-after-free, not a missed release.
+  ///
+  /// Rules for implementations:
+  ///
+  ///  1. **Be idempotent.** This can run more than once, and it runs after [#cancel(Throwable)] on the error path.
+  ///  2. **Leave the stats alone.** [#calculateStats()] and [#copyStatMaps()] are called after termination.
+  ///  3. **Never mutate something whose identity left the operator.** A block sitting in a local mailbox still
+  ///     points at the list it was built from, and emptying that list silently drops rows rather than failing.
+  ///     Drop or replace the reference; do not `clear()` in place. The same goes for state an external consumer
+  ///     reads after termination — see [org.apache.pinot.query.runtime.plan.pipeline.PipelineBreakerOperator], whose
+  ///     buffer is its output and which therefore releases nothing.
+  ///  4. **Prefer replacing to clearing.** `clear()` drops the elements but keeps the backing table at whatever
+  ///     capacity it grew to — `HashMap`, `ObjectOpenHashSet`, `ArrayList` and `PriorityQueue` all behave this way,
+  ///     which for a large buffer leaves tens of megabytes of empty slots reachable. Assign a fresh, empty instance
+  ///     (or `null`) instead.
+  ///  5. **Do not let a released field double as control flow.** After release the operator is done, so a field that
+  ///     also serves as a mode discriminator or a "have I read the input yet" marker must not be the one being
+  ///     dropped. Keep the discriminator in a separate final field.
+  ///
+  /// An operator that overrides [#close()] or [#cancel(Throwable)] must chain to `super`, or its state is never
+  /// released — that is not a compile error, so it is on the implementer.
   protected void releaseBuffers() {
+  }
+
+  /// Whether this operator is currently holding any of the state that [#releaseBuffers()] drops.
+  ///
+  /// The two are a pair: an operator that overrides one must override the other, and
+  /// `releaseBuffers(); assert !hasBufferedState();` must hold. It exists so the release invariant can be asserted
+  /// without reflecting into private fields; nothing in production reads it.
+  @VisibleForTesting
+  protected boolean hasBufferedState() {
+    return false;
   }
 
   // TODO: Ideally close() call should finish within request deadline.
@@ -283,9 +315,11 @@ public abstract class MultiStageOperator implements Operator<MseBlock>, AutoClos
   private void releaseBuffersSafely() {
     try {
       releaseBuffers();
-    } catch (Exception e) {
-      // Releasing buffers is best-effort cleanup; never let it break the rest of the teardown.
-      logger().error("Failed to release buffers of operator: " + this + " with exception:" + e);
+    } catch (Throwable t) {
+      // Releasing buffers is best-effort cleanup; never let it break the rest of the teardown. Throwable rather than
+      // Exception so that an AssertionError from an implementation (tests run with -ea) cannot abort a parent's
+      // close loop and leave its siblings unclosed.
+      logger().error("Failed to release the buffers of operator: {}", this, t);
     }
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/NonEquiJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/NonEquiJoinOperator.java
@@ -69,8 +69,11 @@ public class NonEquiJoinOperator extends BaseJoinOperator {
     }
   }
 
+  /// Clears rather than drops `_rightTable`: its rows are only ever copied into the emitted rows by `joinRow`, so no
+  /// downstream block aliases the list itself.
   @Override
-  protected void onEosProduced() {
+  protected void releaseBuffers() {
+    _rightTable.clear();
     _matchedRightRows = null;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/NonEquiJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/NonEquiJoinOperator.java
@@ -37,7 +37,7 @@ public class NonEquiJoinOperator extends BaseJoinOperator {
   private static final String BUILD_JOINED_ROWS_SCOPE = "NonEquiJoinOperator#buildJoinedRows";
   private static final String BUILD_NON_MATCH_RIGHT_ROWS_SCOPE = "NonEquiJoinOperator#buildNonMatchRightRows";
 
-  private final List<Object[]> _rightTable;
+  private List<Object[]> _rightTable;
   // Track matched right rows for right join and full join to output non-matched right rows.
   // TODO: Revisit whether we should use IntList or RoaringBitmap for smaller memory footprint.
   @Nullable
@@ -69,12 +69,18 @@ public class NonEquiJoinOperator extends BaseJoinOperator {
     }
   }
 
-  /// Clears rather than drops `_rightTable`: its rows are only ever copied into the emitted rows by `joinRow`, so no
-  /// downstream block aliases the list itself.
+  /// Replaces `_rightTable` with a fresh, empty list rather than clearing it: `clear()` would keep the element array
+  /// it grew to. A new `ArrayList` rather than `List.of()` because the field is read — and, if the operator were ever
+  /// re-entered, written — unconditionally, so it must stay both non-null and mutable.
   @Override
   protected void releaseBuffers() {
-    _rightTable.clear();
+    _rightTable = new ArrayList<>();
     _matchedRightRows = null;
+  }
+
+  @Override
+  protected boolean hasBufferedState() {
+    return !_rightTable.isEmpty() || _matchedRightRows != null;
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/RepeatOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/RepeatOperator.java
@@ -25,6 +25,7 @@ import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.runtime.blocks.MseBlock;
 import org.apache.pinot.query.runtime.blocks.RowHeapDataBlock;
+import org.apache.pinot.query.runtime.blocks.SuccessMseBlock;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,6 +71,10 @@ public class RepeatOperator extends MultiStageOperator {
   /// Rows of the input block currently being expanded, or null when the next input block must be pulled.
   @Nullable
   private List<Object[]> _currentRows;
+  /// Set once the input is exhausted (or the operator is terminated), and returned from every later call. Without
+  /// it, a null [#_currentRows] would send us back to a spent — after [#releaseBuffers()], closed — input.
+  @Nullable
+  private MseBlock.Eos _eosBlock;
   /// The grouping set (ordinal) the next getNextBlock() call will expand the current input block for.
   private int _currentSet;
 
@@ -124,9 +129,13 @@ public class RepeatOperator extends MultiStageOperator {
 
   @Override
   protected MseBlock getNextBlock() {
+    if (_eosBlock != null) {
+      return _eosBlock;
+    }
     if (_currentRows == null) {
       MseBlock block = _input.nextBlock();
       if (block.isEos()) {
+        _eosBlock = (MseBlock.Eos) block;
         return block;
       }
       _currentRows = ((MseBlock.Data) block).asRowHeap().getRows();
@@ -166,12 +175,21 @@ public class RepeatOperator extends MultiStageOperator {
     return new StatMap<>(_statMap);
   }
 
-  /// Drops the input block being expanded. The rows belong to the input block, not to this operator, and the emitted
-  /// rows are freshly allocated, so dropping the reference is enough — and clearing would corrupt a block another
-  /// operator may still be holding.
+  /// Drops the input block being expanded. The rows belong to that block, not to this operator, and the emitted rows
+  /// are freshly allocated, so dropping the reference is enough — clearing would corrupt a block another operator may
+  /// still be holding. Marks the operator finished at the same time, because a null [#_currentRows] otherwise means
+  /// "pull the next input block".
   @Override
   protected void releaseBuffers() {
     _currentRows = null;
+    if (_eosBlock == null) {
+      _eosBlock = SuccessMseBlock.INSTANCE;
+    }
+  }
+
+  @Override
+  protected boolean hasBufferedState() {
+    return _currentRows != null;
   }
 
   public enum StatKey implements StatMap.Key {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/RepeatOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/RepeatOperator.java
@@ -166,6 +166,14 @@ public class RepeatOperator extends MultiStageOperator {
     return new StatMap<>(_statMap);
   }
 
+  /// Drops the input block being expanded. The rows belong to the input block, not to this operator, and the emitted
+  /// rows are freshly allocated, so dropping the reference is enough — and clearing would corrupt a block another
+  /// operator may still be holding.
+  @Override
+  protected void releaseBuffers() {
+    _currentRows = null;
+  }
+
   public enum StatKey implements StatMap.Key {
     EXECUTION_TIME_MS(StatMap.Type.LONG) {
       @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -47,13 +47,16 @@ public class SortOperator extends MultiStageOperator {
   private final DataSchema _dataSchema;
   private final int _offset;
   private final int _numRowsToKeep;
+  /// Whether this operator has to sort, or is a plain limit/offset over an already-sorted input. Decides which of
+  /// the two buffers below is in use. Kept separate from them so that releasing a buffer cannot change the mode.
+  private final boolean _requiresSort;
+  /// The rows-to-keep heap, used when [#_requiresSort]. Never handed downstream — [#produceSortedBlock()] drains it
+  /// into a fresh array — so releasing replaces it outright rather than clearing it, which would keep the backing
+  /// array alive.
   @Nullable
-  private final PriorityQueue<Object[]> _priorityQueue;
-  /// The buffered rows, when this operator is a plain limit/offset over an already-sorted input. Handed downstream
-  /// as a sublist view of itself, so [#releaseBuffers()] drops the reference instead of clearing it.
-  ///
-  /// `null` once released, and whenever [#_priorityQueue] is the buffer in use — but note that the discriminator
-  /// between the two modes is `_priorityQueue == null`, not this field.
+  private PriorityQueue<Object[]> _priorityQueue;
+  /// The buffered rows, used when not [#_requiresSort]. Handed downstream as a sublist view of itself, so releasing
+  /// must drop the reference rather than empty the list.
   @Nullable
   private ArrayList<Object[]> _rows;
   private final StatMap<StatKey> _statMap = new StatMap<>(StatKey.class);
@@ -81,7 +84,8 @@ public class SortOperator extends MultiStageOperator {
     // - There is no collation
     // - Input is already sorted
     List<RelFieldCollation> collations = node.getCollations();
-    if (collations.isEmpty() || input instanceof SortedMailboxReceiveOperator) {
+    _requiresSort = !(collations.isEmpty() || input instanceof SortedMailboxReceiveOperator);
+    if (!_requiresSort) {
       _priorityQueue = null;
       _rows = new ArrayList<>(Math.min(defaultHolderCapacity, _numRowsToKeep));
     } else {
@@ -116,14 +120,15 @@ public class SortOperator extends MultiStageOperator {
     return List.of(_input);
   }
 
-  /// Releases the buffered rows. The priority queue is cleared rather than dropped because `_priorityQueue == null`
-  /// is what tells the two buffering modes apart; nothing outside this operator ever sees the queue itself.
   @Override
   protected void releaseBuffers() {
-    if (_priorityQueue != null) {
-      _priorityQueue.clear();
-    }
+    _priorityQueue = null;
     _rows = null;
+  }
+
+  @Override
+  protected boolean hasBufferedState() {
+    return _priorityQueue != null || _rows != null;
   }
 
   @Override
@@ -139,7 +144,7 @@ public class SortOperator extends MultiStageOperator {
     }
     _eosBlock = consumeInputBlocks();
     // returning upstream error block if finalBlock contains error.
-    _statMap.merge(StatKey.REQUIRE_SORT, _priorityQueue != null);
+    _statMap.merge(StatKey.REQUIRE_SORT, _requiresSort);
     if (_eosBlock.isError()) {
       return _eosBlock;
     }
@@ -153,7 +158,7 @@ public class SortOperator extends MultiStageOperator {
 
   private MseBlock produceSortedBlock() {
     _hasConstructedSortedBlock = true;
-    if (_priorityQueue == null) {
+    if (!_requiresSort) {
       assert _rows != null : "Rows should not be null when producing the sorted block";
       if (_rows.size() > _offset) {
         List<Object[]> row = _rows.subList(_offset, _rows.size());
@@ -162,6 +167,7 @@ public class SortOperator extends MultiStageOperator {
         return _eosBlock;
       }
     } else {
+      assert _priorityQueue != null : "Priority queue should not be null when producing the sorted block";
       int resultSize = _priorityQueue.size() - _offset;
       if (resultSize <= 0) {
         return _eosBlock;
@@ -179,7 +185,7 @@ public class SortOperator extends MultiStageOperator {
     MseBlock block = _input.nextBlock();
     while (block.isData()) {
       List<Object[]> container = ((MseBlock.Data) block).asRowHeap().getRows();
-      if (_priorityQueue == null) {
+      if (!_requiresSort) {
         assert _rows != null : "Rows should not be null when consuming input blocks";
         // TODO: when push-down properly, we shouldn't get more than _numRowsToKeep
         int numRows = _rows.size();
@@ -200,6 +206,7 @@ public class SortOperator extends MultiStageOperator {
           }
         }
       } else {
+        assert _priorityQueue != null : "Priority queue should not be null when consuming input blocks";
         for (Object[] row : container) {
           SelectionOperatorUtils.addToPriorityQueue(row, _priorityQueue, _numRowsToKeep);
         }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.PriorityQueue;
+import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.utils.DataSchema;
@@ -46,8 +47,15 @@ public class SortOperator extends MultiStageOperator {
   private final DataSchema _dataSchema;
   private final int _offset;
   private final int _numRowsToKeep;
+  @Nullable
   private final PriorityQueue<Object[]> _priorityQueue;
-  private final ArrayList<Object[]> _rows;
+  /// The buffered rows, when this operator is a plain limit/offset over an already-sorted input. Handed downstream
+  /// as a sublist view of itself, so [#releaseBuffers()] drops the reference instead of clearing it.
+  ///
+  /// `null` once released, and whenever [#_priorityQueue] is the buffer in use — but note that the discriminator
+  /// between the two modes is `_priorityQueue == null`, not this field.
+  @Nullable
+  private ArrayList<Object[]> _rows;
   private final StatMap<StatKey> _statMap = new StatMap<>(StatKey.class);
 
   private boolean _hasConstructedSortedBlock;
@@ -108,8 +116,14 @@ public class SortOperator extends MultiStageOperator {
     return List.of(_input);
   }
 
+  /// Releases the buffered rows. The priority queue is cleared rather than dropped because `_priorityQueue == null`
+  /// is what tells the two buffering modes apart; nothing outside this operator ever sees the queue itself.
   @Override
-  public void cancel(Throwable e) {
+  protected void releaseBuffers() {
+    if (_priorityQueue != null) {
+      _priorityQueue.clear();
+    }
+    _rows = null;
   }
 
   @Override
@@ -140,6 +154,7 @@ public class SortOperator extends MultiStageOperator {
   private MseBlock produceSortedBlock() {
     _hasConstructedSortedBlock = true;
     if (_priorityQueue == null) {
+      assert _rows != null : "Rows should not be null when producing the sorted block";
       if (_rows.size() > _offset) {
         List<Object[]> row = _rows.subList(_offset, _rows.size());
         return new RowHeapDataBlock(row, _dataSchema);
@@ -165,6 +180,7 @@ public class SortOperator extends MultiStageOperator {
     while (block.isData()) {
       List<Object[]> container = ((MseBlock.Data) block).asRowHeap().getRows();
       if (_priorityQueue == null) {
+        assert _rows != null : "Rows should not be null when consuming input blocks";
         // TODO: when push-down properly, we shouldn't get more than _numRowsToKeep
         int numRows = _rows.size();
         if (numRows < _numRowsToKeep) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperator.java
@@ -21,6 +21,7 @@ package org.apache.pinot.query.runtime.operator;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.pinot.common.utils.DataSchema;
@@ -46,7 +47,11 @@ public class SortedMailboxReceiveOperator extends BaseMailboxReceiveOperator {
 
   private final DataSchema _dataSchema;
   private final List<RelFieldCollation> _collations;
-  private final List<Object[]> _rows = new ArrayList<>();
+  /// The rows collected from the mailboxes. Sorted in place and handed downstream as-is, so [#releaseBuffers()]
+  /// drops the reference instead of clearing it: a local mailbox may still be holding the block that wraps this very
+  /// list, and emptying it would silently drop those rows.
+  @Nullable
+  private List<Object[]> _rows = new ArrayList<>();
 
   private MseBlock _eosBlock;
 
@@ -77,20 +82,24 @@ public class SortedMailboxReceiveOperator extends BaseMailboxReceiveOperator {
     while (true) {
       MseBlock block = _multiConsumer.readMseBlockBlocking();
       if (block.isData()) {
+        assert _rows != null : "Rows should not be null while collecting mailbox blocks";
         _rows.addAll(((MseBlock.Data) block).asRowHeap().getRows());
         continue;
       }
       MseBlock.Eos eosBlock = (MseBlock.Eos) block;
       onEos();
       _eosBlock = eosBlock;
+      List<Object[]> rows = _rows;
+      assert rows != null : "Rows should not be null when the end of stream is reached";
+      releaseBuffers();
       if (eosBlock.isError()) {
         return eosBlock;
       } else {
-        if (!_rows.isEmpty()) {
+        if (!rows.isEmpty()) {
           // TODO: This might not be efficient because we are sorting all the received rows. We should use a k-way merge
           //       when sender side is sorted.
-          _rows.sort(new SortUtils.SortComparator(_collations, false));
-          return new RowHeapDataBlock(_rows, _dataSchema);
+          rows.sort(new SortUtils.SortComparator(_collations, false));
+          return new RowHeapDataBlock(rows, _dataSchema);
         } else {
           return block;
         }
@@ -99,14 +108,7 @@ public class SortedMailboxReceiveOperator extends BaseMailboxReceiveOperator {
   }
 
   @Override
-  public void close() {
-    super.close();
-    _rows.clear();
-  }
-
-  @Override
-  public void cancel(Throwable t) {
-    super.cancel(t);
-    _rows.clear();
+  protected void releaseBuffers() {
+    _rows = null;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperator.java
@@ -111,4 +111,9 @@ public class SortedMailboxReceiveOperator extends BaseMailboxReceiveOperator {
   protected void releaseBuffers() {
     _rows = null;
   }
+
+  @Override
+  protected boolean hasBufferedState() {
+    return _rows != null;
+  }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/set/BinarySetOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/set/BinarySetOperator.java
@@ -105,6 +105,7 @@ public abstract class BinarySetOperator extends SetOperator {
         return mseBlock;
       } else if (mseBlock.isError()) {
         _eos = (MseBlock.Eos) mseBlock;
+        releaseBuffers();
         return _eos;
       } else if (mseBlock.isSuccess()) {
         // If it's a regular EOS block, we continue to process the left child operator.
@@ -115,10 +116,18 @@ public abstract class BinarySetOperator extends SetOperator {
     MseBlock mseBlock = processLeftOperator();
     if (mseBlock.isEos()) {
       _eos = (MseBlock.Eos) mseBlock;
+      releaseBuffers();
       return _eos;
     } else {
       return mseBlock;
     }
+  }
+
+  /// Clears rather than drops `_rightRowSet`: the emitted rows all come from the left child, so no downstream block
+  /// aliases this multiset.
+  @Override
+  protected void releaseBuffers() {
+    _rightRowSet.clear();
   }
 
   /// Returns true if the row matches the criteria defined by the set operation.

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/set/BinarySetOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/set/BinarySetOperator.java
@@ -36,7 +36,7 @@ public abstract class BinarySetOperator extends SetOperator {
 
   protected final MultiStageOperator _leftChildOperator;
   protected final MultiStageOperator _rightChildOperator;
-  protected final Multiset<Record> _rightRowSet;
+  protected Multiset<Record> _rightRowSet;
   private MseBlock.Eos _eos;
   private boolean _isRightChildOperatorProcessed;
 
@@ -123,11 +123,19 @@ public abstract class BinarySetOperator extends SetOperator {
     }
   }
 
-  /// Clears rather than drops `_rightRowSet`: the emitted rows all come from the left child, so no downstream block
-  /// aliases this multiset.
+  /// Replaces `_rightRowSet` with a fresh, empty multiset rather than clearing it: `HashMultiset.clear()` walks every
+  /// entry and still leaves the backing table at the capacity it grew to, which for a wide INTERSECT / EXCEPT is the
+  /// bulk of what we are trying to release. Safe to swap because [#handleRowMatched(Object[])] is only reached from
+  /// [#processLeftOperator()], which [#getNextBlock()] stops calling once `_eos` is set — and `_eos` is set before
+  /// every release.
   @Override
   protected void releaseBuffers() {
-    _rightRowSet.clear();
+    _rightRowSet = HashMultiset.create();
+  }
+
+  @Override
+  protected boolean hasBufferedState() {
+    return !_rightRowSet.isEmpty();
   }
 
   /// Returns true if the row matches the criteria defined by the set operation.

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/set/UnionOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/set/UnionOperator.java
@@ -41,7 +41,7 @@ public class UnionOperator extends SetOperator {
 
   private MseBlock _eosBlock = null;
   private int _currentOperatorIndex = 0;
-  private final Set<Record> _seenRecords = new ObjectOpenHashSet<>();
+  private Set<Record> _seenRecords = new ObjectOpenHashSet<>();
 
   public UnionOperator(OpChainExecutionContext opChainExecutionContext,
       List<MultiStageOperator> inputOperators, DataSchema dataSchema) {
@@ -106,10 +106,17 @@ public class UnionOperator extends SetOperator {
     return EXPLAIN_NAME;
   }
 
-  /// Clears rather than drops `_seenRecords`: it holds [Record] wrappers, while the emitted blocks reference the row
-  /// arrays directly, so emptying the set does not touch anything downstream.
+  /// Replaces `_seenRecords` with a fresh, empty set rather than clearing it: `ObjectOpenHashSet.clear()` nulls the
+  /// entries but deliberately keeps the key table at the capacity it grew to, and for a de-duplicating UNION that
+  /// table is sized by the full distinct cardinality of every input. Safe to swap because [#getNextBlock()] returns
+  /// the cached `_eosBlock` without touching the set once it is set, and it is set before every release.
   @Override
   protected void releaseBuffers() {
-    _seenRecords.clear();
+    _seenRecords = new ObjectOpenHashSet<>();
+  }
+
+  @Override
+  protected boolean hasBufferedState() {
+    return !_seenRecords.isEmpty();
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/set/UnionOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/set/UnionOperator.java
@@ -60,11 +60,13 @@ public class UnionOperator extends SetOperator {
       MseBlock block = currentOperator.nextBlock();
       if (block.isError()) {
         _eosBlock = block;
+        releaseBuffers();
         return block;
       } else if (block.isSuccess()) {
         _currentOperatorIndex++;
         if (_currentOperatorIndex == _inputOperators.size()) {
           _eosBlock = block;
+          releaseBuffers();
           return block;
         }
       } else if (block.isData()) {
@@ -102,5 +104,12 @@ public class UnionOperator extends SetOperator {
   @Override
   public String toExplainString() {
     return EXPLAIN_NAME;
+  }
+
+  /// Clears rather than drops `_seenRecords`: it holds [Record] wrappers, while the emitted blocks reference the row
+  /// arrays directly, so emptying the set does not touch anything downstream.
+  @Override
+  protected void releaseBuffers() {
+    _seenRecords.clear();
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerOperator.java
@@ -71,6 +71,16 @@ public class PipelineBreakerOperator extends MultiStageOperator {
     _statMap.merge(StatKey.EMITTED_ROWS, numRows);
   }
 
+  /// Deliberately releases nothing, unlike every other operator.
+  ///
+  /// `_resultMap` is this operator's *output*, not scratch space: [PipelineBreakerExecutor] reads it through
+  /// [#getResultMap()] after the op chain has finished, and `OpChain#close()` fires the callback that unblocks that
+  /// read only after `close()` has already run. Dropping the map here would hand the main op chain empty
+  /// pipeline-breaker results, which `nextBlock()` would then surface as an unexplained error block.
+  @Override
+  protected void releaseBuffers() {
+  }
+
   @Override
   public List<MultiStageOperator> getChildOperators() {
     return _childOperators;

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorBufferReleaseTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorBufferReleaseTest.java
@@ -18,15 +18,14 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
+import java.util.function.Supplier;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelFieldCollation.Direction;
 import org.apache.calcite.rel.RelFieldCollation.NullDirection;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
@@ -38,42 +37,52 @@ import org.apache.pinot.query.planner.plannode.SortNode;
 import org.apache.pinot.query.runtime.blocks.ErrorMseBlock;
 import org.apache.pinot.query.runtime.blocks.MseBlock;
 import org.apache.pinot.query.runtime.blocks.SuccessMseBlock;
-import org.apache.pinot.query.runtime.operator.set.IntersectOperator;
-import org.apache.pinot.query.runtime.operator.set.UnionOperator;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.mockito.Mock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.BOOLEAN;
 import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.INT;
+import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.LONG;
 import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.STRING;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
-/// Asserts the invariant that a [MultiStageOperator] releases the row and hash buffers it accumulated on *every*
+/// Asserts the invariant that a [MultiStageOperator] releases the row and hash state it is holding on *every*
 /// termination path — not only when it produces its end-of-stream block, but also when the query errors out and when
 /// it is cancelled.
 ///
-/// While an operator stays reachable its un-released buffers are live references, so no GC can reclaim them. Under
-/// heap pressure that turns a single failing stage into a self-reinforcing cascade, which is why the release has to
-/// happen in the operator rather than depend on nothing else holding the operator tree.
+/// While an operator stays reachable its un-released buffers are live references, so no GC can reclaim them. That is
+/// why the release has to happen in the operator itself rather than depend on nothing else holding the operator tree.
 ///
-/// The buffers are private state, so these tests read them reflectively rather than widening the production API.
+/// This is deliberately one cross-operator suite rather than a case bolted onto each operator's own test class: the
+/// invariant is a property of [MultiStageOperator], the interesting failure is one operator quietly not having it,
+/// and [#shouldReleaseByEitherPathForEveryOperator()] can only be written in one place. Each case drives an operator
+/// to the point where it holds state, asserts [MultiStageOperator#hasBufferedState] so the scenario cannot go
+/// vacuous, terminates it, and asserts the state is gone.
+///
+/// Set operators live in their own package and are covered by
+/// [org.apache.pinot.query.runtime.operator.set.SetOperatorBufferReleaseTest].
 public class OperatorBufferReleaseTest {
   private static final DataSchema SCHEMA =
       new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{INT, STRING});
   private static final DataSchema JOIN_RESULT_SCHEMA =
       new DataSchema(new String[]{"int_col1", "string_col1", "int_col2", "string_col2"},
           new ColumnDataType[]{INT, STRING, INT, STRING});
+  private static final RuntimeException ERROR = new RuntimeException("boom");
 
   private AutoCloseable _mocks;
   @Mock
@@ -94,53 +103,115 @@ public class OperatorBufferReleaseTest {
     _mocks.close();
   }
 
+  // ---------------------------------------------------------------------------------------------------------------
+  // The base-class contract
+  // ---------------------------------------------------------------------------------------------------------------
+
   @Test
-  public void sortOperatorReleasesPriorityQueueOnError() {
-    when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{2, "b"}, new Object[]{1, "a"}))
-        .thenReturn(ErrorMseBlock.fromException(new RuntimeException("boom")));
+  public void shouldReleaseFromBothCloseAndCancel() {
+    RecordingOperator closed = new RecordingOperator();
+    closed.close();
+    assertEquals(closed._releaseCount, 1, "close() must release");
+
+    RecordingOperator cancelled = new RecordingOperator();
+    cancelled.cancel(ERROR);
+    assertEquals(cancelled._releaseCount, 1, "cancel() must release");
+  }
+
+  /// close() may run more than once, and it runs after cancel() on the error path, so releasing has to be idempotent.
+  @Test
+  public void shouldTolerateRepeatedTermination() {
+    RecordingOperator operator = new RecordingOperator();
+    operator.cancel(ERROR);
+    operator.close();
+    operator.close();
+    assertEquals(operator._releaseCount, 3);
+  }
+
+  /// Children are torn down first, so an operator may still reach into its inputs while releasing.
+  @Test
+  public void shouldReleaseAfterClosingChildren() {
+    RecordingOperator operator = new RecordingOperator(_input);
+    operator.close();
+    verify(_input, times(1)).close();
+    assertTrue(operator._childrenWereClosedFirst);
+  }
+
+  /// Releasing is best-effort cleanup: a throwing implementation must not abort the rest of the teardown. An
+  /// `AssertionError` is the interesting case, since tests run with assertions enabled.
+  @Test
+  public void shouldSurviveAThrowingRelease() {
+    MultiStageOperator throwsException = new RecordingOperator(_input) {
+      @Override
+      protected void releaseBuffers() {
+        throw new RuntimeException("release failed");
+      }
+    };
+    throwsException.close();
+    throwsException.cancel(ERROR);
+
+    MultiStageOperator throwsAssertionError = new RecordingOperator(_leftInput) {
+      @Override
+      protected void releaseBuffers() {
+        throw new AssertionError("release failed");
+      }
+    };
+    throwsAssertionError.close();
+    throwsAssertionError.cancel(ERROR);
+
+    verify(_input, times(1)).close();
+    verify(_input, times(1)).cancel(any());
+    verify(_leftInput, times(1)).close();
+    verify(_leftInput, times(1)).cancel(any());
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // SortOperator
+  // ---------------------------------------------------------------------------------------------------------------
+
+  @Test
+  public void shouldReleaseSortPriorityQueueOnError() {
+    givenInputProducesThenFails();
     SortOperator operator = sortOperator(_input);
 
     assertTrue(operator.nextBlock().isError());
-    assertFalse(isEmpty(field(operator, "_priorityQueue")), "rows should still be buffered before termination");
+    assertTrue(operator.hasBufferedState(), "the sort is still holding its heap when the error propagates");
 
-    operator.cancel(new RuntimeException("boom"));
+    operator.cancel(ERROR);
 
-    assertTrue(isEmpty(field(operator, "_priorityQueue")), "priority queue should be released on cancel");
-    assertNull(field(operator, "_rows"));
+    assertFalse(operator.hasBufferedState());
   }
 
   @Test
-  public void sortOperatorReleasesRowsOnError() {
+  public void shouldReleaseSortRowsOnError() {
     // No collations => the operator buffers into _rows instead of the priority queue.
-    when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{2, "b"}, new Object[]{1, "a"}))
-        .thenReturn(ErrorMseBlock.fromException(new RuntimeException("boom")));
+    givenInputProducesThenFails();
     SortOperator operator = sortOperator(_input, List.of());
 
     assertTrue(operator.nextBlock().isError());
-    assertNotNull(field(operator, "_rows"), "rows should still be buffered before termination");
+    assertTrue(operator.hasBufferedState(), "the sort is still holding its rows when the error propagates");
 
     operator.close();
 
-    assertNull(field(operator, "_rows"), "buffered rows should be released on close");
+    assertFalse(operator.hasBufferedState());
   }
 
   /// [SortOperator] used to override `cancel()` with an empty body, so a cancel never reached the operators feeding
   /// it. Releasing state must not come at the cost of that recursion.
   @Test
-  public void sortOperatorCancelReachesChildren() {
+  public void shouldPropagateSortCancelToChildren() {
     when(_input.nextBlock()).thenReturn(SuccessMseBlock.INSTANCE);
     SortOperator operator = sortOperator(_input);
-    RuntimeException error = new RuntimeException("boom");
 
-    operator.cancel(error);
+    operator.cancel(ERROR);
 
-    verify(_input, times(1)).cancel(error);
+    verify(_input, times(1)).cancel(ERROR);
   }
 
   /// The block [SortOperator] emits is a sublist view of `_rows`, and a block handed to a local mailbox can still be
   /// read after this op chain has been closed. Releasing must therefore drop the reference, never empty the list.
   @Test
-  public void sortOperatorCloseDoesNotEmptyTheEmittedBlock() {
+  public void shouldNotEmptyTheBlockEmittedBySort() {
     when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{2, "b"}, new Object[]{1, "a"}))
         .thenReturn(SuccessMseBlock.INSTANCE);
     SortOperator operator = sortOperator(_input, List.of());
@@ -153,168 +224,303 @@ public class OperatorBufferReleaseTest {
     assertEquals(rows.get(0), new Object[]{2, "b"});
   }
 
+  // ---------------------------------------------------------------------------------------------------------------
+  // Joins
+  // ---------------------------------------------------------------------------------------------------------------
+
   /// The right side is materialized, the join starts emitting, and then the op chain is cancelled mid-flight — the
   /// case where nothing on the success path ever gets to run.
   @Test
-  public void hashJoinOperatorReleasesRightTableOnCancel() {
-    when(_rightInput.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}))
-        .thenReturn(SuccessMseBlock.INSTANCE);
-    when(_leftInput.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}));
+  public void shouldReleaseHashJoinRightTableOnCancel() {
+    givenRightBuiltThenLeftKeepsFlowing();
     HashJoinOperator operator = hashJoinOperator();
 
     assertTrue(operator.nextBlock().isData());
-    assertNotNull(field(operator, "_rightTable"), "the right table should still be held mid-join");
+    assertTrue(operator.hasBufferedState(), "the right table is still held mid-join");
 
-    operator.cancel(new RuntimeException("boom"));
+    operator.cancel(ERROR);
 
-    assertNull(field(operator, "_rightTable"));
-    assertNull(field(operator, "_matchedRightRows"));
-    assertNull(field(operator, "_nullKeyRightRows"));
+    assertFalse(operator.hasBufferedState());
   }
 
   /// When the right side itself fails, the partially built right table never reaches the success path.
   @Test
-  public void hashJoinOperatorReleasesPartialRightTableOnError() {
-    when(_rightInput.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}))
-        .thenReturn(ErrorMseBlock.fromException(new RuntimeException("boom")));
+  public void shouldReleaseHashJoinPartialRightTableOnError() {
+    givenRightSideFails();
     HashJoinOperator operator = hashJoinOperator();
 
     assertTrue(operator.nextBlock().isError());
-    assertNotNull(field(operator, "_rightTable"), "the partial right table is still held when the error propagates");
-
-    operator.cancel(new RuntimeException("boom"));
-
-    assertNull(field(operator, "_rightTable"));
-    assertNull(field(operator, "_matchedRightRows"));
-    assertNull(field(operator, "_nullKeyRightRows"));
-  }
-
-  @Test
-  public void nonEquiJoinOperatorReleasesRightTableOnCancel() {
-    when(_rightInput.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}))
-        .thenReturn(SuccessMseBlock.INSTANCE);
-    when(_leftInput.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{0, "z"}));
-    NonEquiJoinOperator operator = nonEquiJoinOperator();
-
-    assertTrue(operator.nextBlock().isData());
-    assertFalse(isEmpty(field(operator, "_rightTable")), "the right table should still be held mid-join");
-
-    operator.cancel(new RuntimeException("boom"));
-
-    assertTrue(isEmpty(field(operator, "_rightTable")));
-    assertNull(field(operator, "_matchedRightRows"));
-  }
-
-  @Test
-  public void nonEquiJoinOperatorReleasesPartialRightTableOnError() {
-    when(_rightInput.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}))
-        .thenReturn(ErrorMseBlock.fromException(new RuntimeException("boom")));
-    NonEquiJoinOperator operator = nonEquiJoinOperator();
-
-    assertTrue(operator.nextBlock().isError());
-    assertFalse(isEmpty(field(operator, "_rightTable")),
-        "the partial right table is still held when the error propagates");
+    assertTrue(operator.hasBufferedState(), "the partial right table is still held when the error propagates");
 
     operator.close();
 
-    assertTrue(isEmpty(field(operator, "_rightTable")));
+    assertFalse(operator.hasBufferedState());
   }
 
   @Test
-  public void aggregateOperatorReleasesGroupByExecutorOnError() {
-    when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}, new Object[]{2, "b"}))
-        .thenReturn(ErrorMseBlock.fromException(new RuntimeException("boom")));
-    AggregateOperator operator = aggregateOperator(List.of(0));
+  public void shouldReleaseNonEquiJoinRightTableOnCancel() {
+    givenRightBuiltThenLeftKeepsFlowing();
+    NonEquiJoinOperator operator = nonEquiJoinOperator();
 
-    assertNotNull(field(operator, "_groupByExecutor"));
+    assertTrue(operator.nextBlock().isData());
+    assertTrue(operator.hasBufferedState(), "the right table is still held mid-join");
+
+    operator.cancel(ERROR);
+
+    assertFalse(operator.hasBufferedState());
+  }
+
+  @Test
+  public void shouldReleaseNonEquiJoinPartialRightTableOnError() {
+    givenRightSideFails();
+    NonEquiJoinOperator operator = nonEquiJoinOperator();
+
+    assertTrue(operator.nextBlock().isError());
+    assertTrue(operator.hasBufferedState(), "the partial right table is still held when the error propagates");
+
+    operator.close();
+
+    assertFalse(operator.hasBufferedState());
+  }
+
+  /// The emitted rows are copies, so releasing the right table must not disturb a block already sent downstream.
+  @Test
+  public void shouldNotEmptyTheBlockEmittedByNonEquiJoin() {
+    when(_rightInput.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{5, "r"}))
+        .thenReturn(SuccessMseBlock.INSTANCE);
+    when(_leftInput.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "l"}))
+        .thenReturn(SuccessMseBlock.INSTANCE);
+    NonEquiJoinOperator operator = nonEquiJoinOperator();
+    List<Object[]> rows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+    assertEquals(rows.size(), 1);
+
+    operator.close();
+
+    assertEquals(rows.size(), 1, "the emitted block must survive the operator being closed");
+    assertEquals(rows.get(0), new Object[]{1, "l", 5, "r"});
+  }
+
+  @Test
+  public void shouldReleaseAsofJoinRightTableOnCancel() {
+    givenRightBuiltThenLeftKeepsFlowing();
+    AsofJoinOperator operator = asofJoinOperator();
+
+    assertTrue(operator.nextBlock().isData());
+    assertTrue(operator.hasBufferedState(), "the right table is still held mid-join");
+
+    operator.cancel(ERROR);
+
+    assertFalse(operator.hasBufferedState());
+  }
+
+  @Test
+  public void shouldReleaseAsofJoinPartialRightTableOnError() {
+    givenRightSideFails();
+    AsofJoinOperator operator = asofJoinOperator();
+
+    assertTrue(operator.nextBlock().isError());
+    assertTrue(operator.hasBufferedState(), "the partial right table is still held when the error propagates");
+
+    operator.close();
+
+    assertFalse(operator.hasBufferedState());
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // AggregateOperator and RepeatOperator
+  // ---------------------------------------------------------------------------------------------------------------
+
+  @Test
+  public void shouldReleaseGroupByExecutorOnError() {
+    givenInputProducesThenFails();
+    AggregateOperator operator = aggregateOperator(List.of(0));
+    assertTrue(operator.hasBufferedState());
 
     assertTrue(operator.nextBlock().isError());
 
     // The upstream failed, so the group-by hash maps are dead weight from the moment the error block is produced.
-    assertNull(field(operator, "_groupByExecutor"), "group-by executor should be released on the error path");
+    assertFalse(operator.hasBufferedState(), "the group-by executor should be released on the error path");
     operator.close();
-    assertNull(field(operator, "_groupByExecutor"));
+    assertFalse(operator.hasBufferedState());
   }
 
   @Test
-  public void aggregateOperatorReleasesAggregationExecutorOnError() {
-    when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}))
-        .thenReturn(ErrorMseBlock.fromException(new RuntimeException("boom")));
+  public void shouldReleaseAggregationExecutorOnError() {
+    givenInputProducesThenFails();
     AggregateOperator operator = aggregateOperator(List.of());
-
-    assertNotNull(field(operator, "_aggregationExecutor"));
+    assertTrue(operator.hasBufferedState());
 
     assertTrue(operator.nextBlock().isError());
 
-    assertNull(field(operator, "_aggregationExecutor"), "aggregation executor should be released on the error path");
+    assertFalse(operator.hasBufferedState(), "the aggregation executor should be released on the error path");
+    operator.cancel(ERROR);
+    assertFalse(operator.hasBufferedState());
+  }
+
+  /// Releasing the executors must not change which of the two the operator thinks it is: a group-by that has been
+  /// closed still has to behave like a group-by, not silently turn into a plain aggregation.
+  @Test
+  public void shouldKeepAggregateModeAfterRelease() {
+    givenInputProducesThenFails();
+    AggregateOperator groupBy = aggregateOperator(List.of(0));
+    groupBy.close();
+    assertTrue(groupBy.nextBlock().isEos(), "a released group-by must not be re-dispatched as an aggregation");
+
+    givenInputProducesThenFails();
+    AggregateOperator aggregation = aggregateOperator(List.of());
+    aggregation.close();
+    assertTrue(aggregation.nextBlock().isEos());
   }
 
   @Test
-  public void repeatOperatorReleasesCurrentRowsOnCancel() {
+  public void shouldReleaseRepeatCurrentRowsOnCancel() {
     when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}, new Object[]{2, "b"}));
-    // Two grouping sets, so the operator still holds the input block after emitting the first expansion.
-    RepeatOperator operator = new RepeatOperator(OperatorTestUtil.getTracingContext(), _input, new int[]{0},
-        List.of(List.of(0), List.of()), repeatResultSchema());
+    RepeatOperator operator = repeatOperator();
 
     assertTrue(operator.nextBlock().isData());
-    assertNotNull(field(operator, "_currentRows"), "the input block should still be held before termination");
+    assertTrue(operator.hasBufferedState(), "the input block is still held between grouping sets");
 
-    operator.cancel(new RuntimeException("boom"));
+    operator.cancel(ERROR);
 
-    assertNull(field(operator, "_currentRows"));
+    assertFalse(operator.hasBufferedState());
   }
 
+  /// `_currentRows == null` means "pull the next input block", so releasing it must also mark the operator finished —
+  /// otherwise a released operator would go back to an input that has already been closed.
   @Test
-  public void intersectOperatorReleasesRightRowSetOnCancel() {
-    MultiStageOperator right = mock(MultiStageOperator.class);
-    MultiStageOperator left = mock(MultiStageOperator.class);
-    // Two right rows, one of which the left side matches, so the set is still populated when the cancel lands.
-    when(right.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}, new Object[]{2, "b"}))
-        .thenReturn(SuccessMseBlock.INSTANCE);
-    when(left.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}));
-    IntersectOperator operator =
-        new IntersectOperator(OperatorTestUtil.getTracingContext(), List.of(left, right), SCHEMA);
-
+  public void shouldNotPullFromTheInputAfterRepeatIsReleased() {
+    when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}));
+    RepeatOperator operator = repeatOperator();
     assertTrue(operator.nextBlock().isData());
-    assertFalse(isEmpty(field(operator, "_rightRowSet")), "the right row set should still be held mid-intersect");
+    reset(_input);
 
-    operator.cancel(new RuntimeException("boom"));
+    operator.close();
 
-    assertTrue(isEmpty(field(operator, "_rightRowSet")));
+    assertTrue(operator.nextBlock().isEos(), "a released operator must report end of stream");
+    verify(_input, times(0)).nextBlock();
+    assertFalse(operator.hasBufferedState());
   }
 
+  // ---------------------------------------------------------------------------------------------------------------
+  // Cross-operator sweep
+  // ---------------------------------------------------------------------------------------------------------------
+
+  /// close() and cancel() must be interchangeable and repeatable for every operator that buffers: whichever one runs,
+  /// and however often, the operator ends up holding nothing. Guards against an operator that releases on only one
+  /// of the two paths, which is the exact defect this change set fixes.
   @Test
-  public void intersectOperatorReleasesRightRowSetOnError() {
-    MultiStageOperator right = mock(MultiStageOperator.class);
-    MultiStageOperator left = mock(MultiStageOperator.class);
-    when(right.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}))
-        .thenReturn(SuccessMseBlock.INSTANCE);
-    when(left.nextBlock()).thenReturn(ErrorMseBlock.fromException(new RuntimeException("boom")));
-    IntersectOperator operator =
-        new IntersectOperator(OperatorTestUtil.getTracingContext(), List.of(left, right), SCHEMA);
-
-    assertTrue(operator.nextBlock().isError());
-    operator.cancel(new RuntimeException("boom"));
-
-    assertTrue(isEmpty(field(operator, "_rightRowSet")));
+  public void shouldReleaseByEitherPathForEveryOperator() {
+    for (boolean cancelFirst : new boolean[]{true, false}) {
+      assertReleasedByEitherPath(cancelFirst, this::sortHoldingRows);
+      assertReleasedByEitherPath(cancelFirst, this::sortHoldingPriorityQueue);
+      assertReleasedByEitherPath(cancelFirst, this::hashJoinHoldingRightTable);
+      assertReleasedByEitherPath(cancelFirst, this::nonEquiJoinHoldingRightTable);
+      assertReleasedByEitherPath(cancelFirst, this::asofJoinHoldingRightTable);
+      assertReleasedByEitherPath(cancelFirst, this::aggregateHoldingGroupByExecutor);
+      assertReleasedByEitherPath(cancelFirst, this::repeatHoldingCurrentRows);
+    }
   }
 
-  @Test
-  public void unionOperatorReleasesSeenRecordsOnError() {
-    MultiStageOperator first = mock(MultiStageOperator.class);
-    MultiStageOperator second = mock(MultiStageOperator.class);
-    when(first.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}))
+  private void assertReleasedByEitherPath(boolean cancelFirst, Supplier<MultiStageOperator> factory) {
+    MultiStageOperator operator = factory.get();
+    String name = operator.getClass().getSimpleName();
+    assertTrue(operator.hasBufferedState(), name + " should be holding state before termination");
+
+    terminate(operator, cancelFirst);
+    assertFalse(operator.hasBufferedState(),
+        name + " should have released after " + (cancelFirst ? "cancel" : "close"));
+
+    // Terminating again, by the other path, must be safe and must leave it released.
+    terminate(operator, !cancelFirst);
+    assertFalse(operator.hasBufferedState(), name + " should stay released after a second termination");
+  }
+
+  private static void terminate(MultiStageOperator operator, boolean cancel) {
+    if (cancel) {
+      operator.cancel(ERROR);
+    } else {
+      operator.close();
+    }
+  }
+
+  private MultiStageOperator sortHoldingRows() {
+    resetMocks();
+    givenInputProducesThenFails();
+    SortOperator operator = sortOperator(_input, List.of());
+    operator.nextBlock();
+    return operator;
+  }
+
+  private MultiStageOperator sortHoldingPriorityQueue() {
+    resetMocks();
+    givenInputProducesThenFails();
+    SortOperator operator = sortOperator(_input);
+    operator.nextBlock();
+    return operator;
+  }
+
+  private MultiStageOperator hashJoinHoldingRightTable() {
+    resetMocks();
+    givenRightBuiltThenLeftKeepsFlowing();
+    HashJoinOperator operator = hashJoinOperator();
+    operator.nextBlock();
+    return operator;
+  }
+
+  private MultiStageOperator nonEquiJoinHoldingRightTable() {
+    resetMocks();
+    givenRightBuiltThenLeftKeepsFlowing();
+    NonEquiJoinOperator operator = nonEquiJoinOperator();
+    operator.nextBlock();
+    return operator;
+  }
+
+  private MultiStageOperator asofJoinHoldingRightTable() {
+    resetMocks();
+    givenRightBuiltThenLeftKeepsFlowing();
+    AsofJoinOperator operator = asofJoinOperator();
+    operator.nextBlock();
+    return operator;
+  }
+
+  private MultiStageOperator aggregateHoldingGroupByExecutor() {
+    resetMocks();
+    when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}));
+    return aggregateOperator(List.of(0));
+  }
+
+  private MultiStageOperator repeatHoldingCurrentRows() {
+    resetMocks();
+    when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}));
+    RepeatOperator operator = repeatOperator();
+    operator.nextBlock();
+    return operator;
+  }
+
+  private void resetMocks() {
+    reset(_input, _leftInput, _rightInput);
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Fixtures
+  // ---------------------------------------------------------------------------------------------------------------
+
+  private void givenInputProducesThenFails() {
+    when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{2, "b"}, new Object[]{1, "a"}))
+        .thenReturn(ErrorMseBlock.fromException(ERROR));
+  }
+
+  /// Right side completes, left side keeps producing, so the join is mid-flight when we terminate it.
+  private void givenRightBuiltThenLeftKeepsFlowing() {
+    when(_rightInput.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}))
         .thenReturn(SuccessMseBlock.INSTANCE);
-    when(second.nextBlock()).thenReturn(ErrorMseBlock.fromException(new RuntimeException("boom")));
-    UnionOperator operator = new UnionOperator(OperatorTestUtil.getTracingContext(), List.of(first, second), SCHEMA);
+    when(_leftInput.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{0, "z"}));
+  }
 
-    assertTrue(operator.nextBlock().isData());
-    assertFalse(isEmpty(field(operator, "_seenRecords")), "seen records should be tracked before termination");
-    assertTrue(operator.nextBlock().isError());
-
-    operator.cancel(new RuntimeException("boom"));
-
-    assertTrue(isEmpty(field(operator, "_seenRecords")));
+  /// Right side produces one block and then fails, so the right table is only partially built.
+  private void givenRightSideFails() {
+    when(_rightInput.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}))
+        .thenReturn(ErrorMseBlock.fromException(ERROR));
   }
 
   private HashJoinOperator hashJoinOperator() {
@@ -326,11 +532,20 @@ public class OperatorBufferReleaseTest {
   private NonEquiJoinOperator nonEquiJoinOperator() {
     // Condition: left.int_col < right.int_col
     List<RexExpression> nonEquiConditions = List.of(
-        new RexExpression.FunctionCall(ColumnDataType.BOOLEAN, SqlKind.LESS_THAN.name(),
+        new RexExpression.FunctionCall(BOOLEAN, SqlKind.LESS_THAN.name(),
             List.of(new RexExpression.InputRef(0), new RexExpression.InputRef(2))));
     return new NonEquiJoinOperator(OperatorTestUtil.getTracingContext(), _leftInput, SCHEMA, _rightInput,
         new JoinNode(-1, JOIN_RESULT_SCHEMA, PlanNode.NodeHint.EMPTY, List.of(), JoinRelType.FULL, List.of(),
             List.of(), nonEquiConditions, JoinNode.JoinStrategy.HASH));
+  }
+
+  private AsofJoinOperator asofJoinOperator() {
+    // Joined on int_col, MATCH_CONDITION on string_col.
+    RexExpression matchCondition = new RexExpression.FunctionCall(BOOLEAN, "LESS_THAN_OR_EQUAL",
+        List.of(new RexExpression.InputRef(1), new RexExpression.InputRef(3)));
+    return new AsofJoinOperator(OperatorTestUtil.getTracingContext(), _leftInput, SCHEMA, _rightInput,
+        new JoinNode(-1, JOIN_RESULT_SCHEMA, PlanNode.NodeHint.EMPTY, List.of(), JoinRelType.LEFT_ASOF, List.of(0),
+            List.of(0), List.of(), JoinNode.JoinStrategy.ASOF, matchCondition));
   }
 
   private SortOperator sortOperator(MultiStageOperator input) {
@@ -344,39 +559,82 @@ public class OperatorBufferReleaseTest {
 
   private AggregateOperator aggregateOperator(List<Integer> groupKeys) {
     RexExpression.FunctionCall countStar =
-        new RexExpression.FunctionCall(ColumnDataType.LONG, SqlKind.COUNT.name(), List.of());
+        new RexExpression.FunctionCall(LONG, SqlKind.COUNT.name(), List.of());
+    DataSchema resultSchema = groupKeys.isEmpty()
+        ? new DataSchema(new String[]{"count"}, new ColumnDataType[]{LONG})
+        : new DataSchema(new String[]{"int_col", "count"}, new ColumnDataType[]{INT, LONG});
     return new AggregateOperator(OperatorTestUtil.getTracingContext(), _input,
-        new AggregateNode(-1, aggregateResultSchema(groupKeys), PlanNode.NodeHint.EMPTY, List.of(), List.of(countStar),
-            List.of(-1), groupKeys, AggType.DIRECT, false, null, 0));
+        new AggregateNode(-1, resultSchema, PlanNode.NodeHint.EMPTY, List.of(), List.of(countStar), List.of(-1),
+            groupKeys, AggType.DIRECT, false, null, 0));
   }
 
-  private static DataSchema aggregateResultSchema(List<Integer> groupKeys) {
-    return groupKeys.isEmpty() ? new DataSchema(new String[]{"count"}, new ColumnDataType[]{ColumnDataType.LONG})
-        : new DataSchema(new String[]{"int_col", "count"}, new ColumnDataType[]{INT, ColumnDataType.LONG});
-  }
-
-  /// Input schema plus one group-key copy column plus the `$groupingId` discriminator.
-  private static DataSchema repeatResultSchema() {
-    return new DataSchema(new String[]{"int_col", "string_col", "int_col_key", "$groupingId"},
+  /// Two grouping sets, so the operator still holds the input block after emitting the first expansion.
+  private RepeatOperator repeatOperator() {
+    DataSchema resultSchema = new DataSchema(new String[]{"int_col", "string_col", "int_col_key", "$groupingId"},
         new ColumnDataType[]{INT, STRING, INT, INT});
+    return new RepeatOperator(OperatorTestUtil.getTracingContext(), _input, new int[]{0},
+        List.of(List.of(0), List.of()), resultSchema);
   }
 
-  private static Object field(Object operator, String name) {
-    try {
-      return FieldUtils.readField(operator, name, true);
-    } catch (IllegalAccessException e) {
-      throw new AssertionError("Cannot read field " + name + " of " + operator.getClass().getSimpleName(), e);
-    }
-  }
+  /// Minimal operator that records how the base class drove it.
+  private static class RecordingOperator extends MultiStageOperator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RecordingOperator.class);
 
-  private static boolean isEmpty(Object collection) {
-    assertNotNull(collection, "expected a collection, not null");
-    if (collection instanceof Collection) {
-      return ((Collection<?>) collection).isEmpty();
+    private final List<MultiStageOperator> _children;
+    private final StatMap<SortOperator.StatKey> _statMap = new StatMap<>(SortOperator.StatKey.class);
+    private int _releaseCount;
+    private boolean _childrenWereClosedFirst;
+
+    RecordingOperator(MultiStageOperator... children) {
+      this(OperatorTestUtil.getTracingContext(), children);
     }
-    if (collection instanceof Map) {
-      return ((Map<?, ?>) collection).isEmpty();
+
+    private RecordingOperator(OpChainExecutionContext context, MultiStageOperator... children) {
+      super(context);
+      _children = List.of(children);
     }
-    throw new AssertionError("Not a collection: " + collection.getClass());
+
+    @Override
+    protected void releaseBuffers() {
+      _releaseCount++;
+      for (MultiStageOperator child : _children) {
+        verify(child, atLeastOnce()).close();
+      }
+      _childrenWereClosedFirst = true;
+    }
+
+    @Override
+    public List<MultiStageOperator> getChildOperators() {
+      return _children;
+    }
+
+    @Override
+    protected MseBlock getNextBlock() {
+      return SuccessMseBlock.INSTANCE;
+    }
+
+    @Override
+    public void registerExecution(long time, int numRows, long memoryUsedBytes, long gcTimeMs) {
+    }
+
+    @Override
+    public Type getOperatorType() {
+      return Type.SORT_OR_LIMIT;
+    }
+
+    @Override
+    public StatMap<SortOperator.StatKey> copyStatMaps() {
+      return new StatMap<>(_statMap);
+    }
+
+    @Override
+    protected Logger logger() {
+      return LOGGER;
+    }
+
+    @Override
+    public String toExplainString() {
+      return "RECORDING";
+    }
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorBufferReleaseTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorBufferReleaseTest.java
@@ -1,0 +1,382 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelFieldCollation.Direction;
+import org.apache.calcite.rel.RelFieldCollation.NullDirection;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.query.planner.plannode.AggregateNode;
+import org.apache.pinot.query.planner.plannode.AggregateNode.AggType;
+import org.apache.pinot.query.planner.plannode.JoinNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.apache.pinot.query.planner.plannode.SortNode;
+import org.apache.pinot.query.runtime.blocks.ErrorMseBlock;
+import org.apache.pinot.query.runtime.blocks.MseBlock;
+import org.apache.pinot.query.runtime.blocks.SuccessMseBlock;
+import org.apache.pinot.query.runtime.operator.set.IntersectOperator;
+import org.apache.pinot.query.runtime.operator.set.UnionOperator;
+import org.mockito.Mock;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.INT;
+import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.STRING;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+/// Asserts the invariant that a [MultiStageOperator] releases the row and hash buffers it accumulated on *every*
+/// termination path — not only when it produces its end-of-stream block, but also when the query errors out and when
+/// it is cancelled.
+///
+/// While an operator stays reachable its un-released buffers are live references, so no GC can reclaim them. Under
+/// heap pressure that turns a single failing stage into a self-reinforcing cascade, which is why the release has to
+/// happen in the operator rather than depend on nothing else holding the operator tree.
+///
+/// The buffers are private state, so these tests read them reflectively rather than widening the production API.
+public class OperatorBufferReleaseTest {
+  private static final DataSchema SCHEMA =
+      new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{INT, STRING});
+  private static final DataSchema JOIN_RESULT_SCHEMA =
+      new DataSchema(new String[]{"int_col1", "string_col1", "int_col2", "string_col2"},
+          new ColumnDataType[]{INT, STRING, INT, STRING});
+
+  private AutoCloseable _mocks;
+  @Mock
+  private MultiStageOperator _input;
+  @Mock
+  private MultiStageOperator _leftInput;
+  @Mock
+  private MultiStageOperator _rightInput;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = openMocks(this);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void sortOperatorReleasesPriorityQueueOnError() {
+    when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{2, "b"}, new Object[]{1, "a"}))
+        .thenReturn(ErrorMseBlock.fromException(new RuntimeException("boom")));
+    SortOperator operator = sortOperator(_input);
+
+    assertTrue(operator.nextBlock().isError());
+    assertFalse(isEmpty(field(operator, "_priorityQueue")), "rows should still be buffered before termination");
+
+    operator.cancel(new RuntimeException("boom"));
+
+    assertTrue(isEmpty(field(operator, "_priorityQueue")), "priority queue should be released on cancel");
+    assertNull(field(operator, "_rows"));
+  }
+
+  @Test
+  public void sortOperatorReleasesRowsOnError() {
+    // No collations => the operator buffers into _rows instead of the priority queue.
+    when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{2, "b"}, new Object[]{1, "a"}))
+        .thenReturn(ErrorMseBlock.fromException(new RuntimeException("boom")));
+    SortOperator operator = sortOperator(_input, List.of());
+
+    assertTrue(operator.nextBlock().isError());
+    assertNotNull(field(operator, "_rows"), "rows should still be buffered before termination");
+
+    operator.close();
+
+    assertNull(field(operator, "_rows"), "buffered rows should be released on close");
+  }
+
+  /// [SortOperator] used to override `cancel()` with an empty body, so a cancel never reached the operators feeding
+  /// it. Releasing state must not come at the cost of that recursion.
+  @Test
+  public void sortOperatorCancelReachesChildren() {
+    when(_input.nextBlock()).thenReturn(SuccessMseBlock.INSTANCE);
+    SortOperator operator = sortOperator(_input);
+    RuntimeException error = new RuntimeException("boom");
+
+    operator.cancel(error);
+
+    verify(_input, times(1)).cancel(error);
+  }
+
+  /// The block [SortOperator] emits is a sublist view of `_rows`, and a block handed to a local mailbox can still be
+  /// read after this op chain has been closed. Releasing must therefore drop the reference, never empty the list.
+  @Test
+  public void sortOperatorCloseDoesNotEmptyTheEmittedBlock() {
+    when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{2, "b"}, new Object[]{1, "a"}))
+        .thenReturn(SuccessMseBlock.INSTANCE);
+    SortOperator operator = sortOperator(_input, List.of());
+    List<Object[]> rows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+    assertEquals(rows.size(), 2);
+
+    operator.close();
+
+    assertEquals(rows.size(), 2, "the emitted block must survive the operator being closed");
+    assertEquals(rows.get(0), new Object[]{2, "b"});
+  }
+
+  /// The right side is materialized, the join starts emitting, and then the op chain is cancelled mid-flight — the
+  /// case where nothing on the success path ever gets to run.
+  @Test
+  public void hashJoinOperatorReleasesRightTableOnCancel() {
+    when(_rightInput.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}))
+        .thenReturn(SuccessMseBlock.INSTANCE);
+    when(_leftInput.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}));
+    HashJoinOperator operator = hashJoinOperator();
+
+    assertTrue(operator.nextBlock().isData());
+    assertNotNull(field(operator, "_rightTable"), "the right table should still be held mid-join");
+
+    operator.cancel(new RuntimeException("boom"));
+
+    assertNull(field(operator, "_rightTable"));
+    assertNull(field(operator, "_matchedRightRows"));
+    assertNull(field(operator, "_nullKeyRightRows"));
+  }
+
+  /// When the right side itself fails, the partially built right table never reaches the success path.
+  @Test
+  public void hashJoinOperatorReleasesPartialRightTableOnError() {
+    when(_rightInput.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}))
+        .thenReturn(ErrorMseBlock.fromException(new RuntimeException("boom")));
+    HashJoinOperator operator = hashJoinOperator();
+
+    assertTrue(operator.nextBlock().isError());
+    assertNotNull(field(operator, "_rightTable"), "the partial right table is still held when the error propagates");
+
+    operator.cancel(new RuntimeException("boom"));
+
+    assertNull(field(operator, "_rightTable"));
+    assertNull(field(operator, "_matchedRightRows"));
+    assertNull(field(operator, "_nullKeyRightRows"));
+  }
+
+  @Test
+  public void nonEquiJoinOperatorReleasesRightTableOnCancel() {
+    when(_rightInput.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}))
+        .thenReturn(SuccessMseBlock.INSTANCE);
+    when(_leftInput.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{0, "z"}));
+    NonEquiJoinOperator operator = nonEquiJoinOperator();
+
+    assertTrue(operator.nextBlock().isData());
+    assertFalse(isEmpty(field(operator, "_rightTable")), "the right table should still be held mid-join");
+
+    operator.cancel(new RuntimeException("boom"));
+
+    assertTrue(isEmpty(field(operator, "_rightTable")));
+    assertNull(field(operator, "_matchedRightRows"));
+  }
+
+  @Test
+  public void nonEquiJoinOperatorReleasesPartialRightTableOnError() {
+    when(_rightInput.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}))
+        .thenReturn(ErrorMseBlock.fromException(new RuntimeException("boom")));
+    NonEquiJoinOperator operator = nonEquiJoinOperator();
+
+    assertTrue(operator.nextBlock().isError());
+    assertFalse(isEmpty(field(operator, "_rightTable")),
+        "the partial right table is still held when the error propagates");
+
+    operator.close();
+
+    assertTrue(isEmpty(field(operator, "_rightTable")));
+  }
+
+  @Test
+  public void aggregateOperatorReleasesGroupByExecutorOnError() {
+    when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}, new Object[]{2, "b"}))
+        .thenReturn(ErrorMseBlock.fromException(new RuntimeException("boom")));
+    AggregateOperator operator = aggregateOperator(List.of(0));
+
+    assertNotNull(field(operator, "_groupByExecutor"));
+
+    assertTrue(operator.nextBlock().isError());
+
+    // The upstream failed, so the group-by hash maps are dead weight from the moment the error block is produced.
+    assertNull(field(operator, "_groupByExecutor"), "group-by executor should be released on the error path");
+    operator.close();
+    assertNull(field(operator, "_groupByExecutor"));
+  }
+
+  @Test
+  public void aggregateOperatorReleasesAggregationExecutorOnError() {
+    when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}))
+        .thenReturn(ErrorMseBlock.fromException(new RuntimeException("boom")));
+    AggregateOperator operator = aggregateOperator(List.of());
+
+    assertNotNull(field(operator, "_aggregationExecutor"));
+
+    assertTrue(operator.nextBlock().isError());
+
+    assertNull(field(operator, "_aggregationExecutor"), "aggregation executor should be released on the error path");
+  }
+
+  @Test
+  public void repeatOperatorReleasesCurrentRowsOnCancel() {
+    when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}, new Object[]{2, "b"}));
+    // Two grouping sets, so the operator still holds the input block after emitting the first expansion.
+    RepeatOperator operator = new RepeatOperator(OperatorTestUtil.getTracingContext(), _input, new int[]{0},
+        List.of(List.of(0), List.of()), repeatResultSchema());
+
+    assertTrue(operator.nextBlock().isData());
+    assertNotNull(field(operator, "_currentRows"), "the input block should still be held before termination");
+
+    operator.cancel(new RuntimeException("boom"));
+
+    assertNull(field(operator, "_currentRows"));
+  }
+
+  @Test
+  public void intersectOperatorReleasesRightRowSetOnCancel() {
+    MultiStageOperator right = mock(MultiStageOperator.class);
+    MultiStageOperator left = mock(MultiStageOperator.class);
+    // Two right rows, one of which the left side matches, so the set is still populated when the cancel lands.
+    when(right.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}, new Object[]{2, "b"}))
+        .thenReturn(SuccessMseBlock.INSTANCE);
+    when(left.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}));
+    IntersectOperator operator =
+        new IntersectOperator(OperatorTestUtil.getTracingContext(), List.of(left, right), SCHEMA);
+
+    assertTrue(operator.nextBlock().isData());
+    assertFalse(isEmpty(field(operator, "_rightRowSet")), "the right row set should still be held mid-intersect");
+
+    operator.cancel(new RuntimeException("boom"));
+
+    assertTrue(isEmpty(field(operator, "_rightRowSet")));
+  }
+
+  @Test
+  public void intersectOperatorReleasesRightRowSetOnError() {
+    MultiStageOperator right = mock(MultiStageOperator.class);
+    MultiStageOperator left = mock(MultiStageOperator.class);
+    when(right.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}))
+        .thenReturn(SuccessMseBlock.INSTANCE);
+    when(left.nextBlock()).thenReturn(ErrorMseBlock.fromException(new RuntimeException("boom")));
+    IntersectOperator operator =
+        new IntersectOperator(OperatorTestUtil.getTracingContext(), List.of(left, right), SCHEMA);
+
+    assertTrue(operator.nextBlock().isError());
+    operator.cancel(new RuntimeException("boom"));
+
+    assertTrue(isEmpty(field(operator, "_rightRowSet")));
+  }
+
+  @Test
+  public void unionOperatorReleasesSeenRecordsOnError() {
+    MultiStageOperator first = mock(MultiStageOperator.class);
+    MultiStageOperator second = mock(MultiStageOperator.class);
+    when(first.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "a"}))
+        .thenReturn(SuccessMseBlock.INSTANCE);
+    when(second.nextBlock()).thenReturn(ErrorMseBlock.fromException(new RuntimeException("boom")));
+    UnionOperator operator = new UnionOperator(OperatorTestUtil.getTracingContext(), List.of(first, second), SCHEMA);
+
+    assertTrue(operator.nextBlock().isData());
+    assertFalse(isEmpty(field(operator, "_seenRecords")), "seen records should be tracked before termination");
+    assertTrue(operator.nextBlock().isError());
+
+    operator.cancel(new RuntimeException("boom"));
+
+    assertTrue(isEmpty(field(operator, "_seenRecords")));
+  }
+
+  private HashJoinOperator hashJoinOperator() {
+    return new HashJoinOperator(OperatorTestUtil.getTracingContext(), _leftInput, SCHEMA, _rightInput,
+        new JoinNode(-1, JOIN_RESULT_SCHEMA, PlanNode.NodeHint.EMPTY, List.of(), JoinRelType.FULL, List.of(0),
+            List.of(0), List.of(), JoinNode.JoinStrategy.HASH));
+  }
+
+  private NonEquiJoinOperator nonEquiJoinOperator() {
+    // Condition: left.int_col < right.int_col
+    List<RexExpression> nonEquiConditions = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.BOOLEAN, SqlKind.LESS_THAN.name(),
+            List.of(new RexExpression.InputRef(0), new RexExpression.InputRef(2))));
+    return new NonEquiJoinOperator(OperatorTestUtil.getTracingContext(), _leftInput, SCHEMA, _rightInput,
+        new JoinNode(-1, JOIN_RESULT_SCHEMA, PlanNode.NodeHint.EMPTY, List.of(), JoinRelType.FULL, List.of(),
+            List.of(), nonEquiConditions, JoinNode.JoinStrategy.HASH));
+  }
+
+  private SortOperator sortOperator(MultiStageOperator input) {
+    return sortOperator(input, List.of(new RelFieldCollation(0, Direction.ASCENDING, NullDirection.LAST)));
+  }
+
+  private SortOperator sortOperator(MultiStageOperator input, List<RelFieldCollation> collations) {
+    return new SortOperator(OperatorTestUtil.getTracingContext(), input,
+        new SortNode(-1, SCHEMA, PlanNode.NodeHint.EMPTY, List.of(), collations, 10, 0));
+  }
+
+  private AggregateOperator aggregateOperator(List<Integer> groupKeys) {
+    RexExpression.FunctionCall countStar =
+        new RexExpression.FunctionCall(ColumnDataType.LONG, SqlKind.COUNT.name(), List.of());
+    return new AggregateOperator(OperatorTestUtil.getTracingContext(), _input,
+        new AggregateNode(-1, aggregateResultSchema(groupKeys), PlanNode.NodeHint.EMPTY, List.of(), List.of(countStar),
+            List.of(-1), groupKeys, AggType.DIRECT, false, null, 0));
+  }
+
+  private static DataSchema aggregateResultSchema(List<Integer> groupKeys) {
+    return groupKeys.isEmpty() ? new DataSchema(new String[]{"count"}, new ColumnDataType[]{ColumnDataType.LONG})
+        : new DataSchema(new String[]{"int_col", "count"}, new ColumnDataType[]{INT, ColumnDataType.LONG});
+  }
+
+  /// Input schema plus one group-key copy column plus the `$groupingId` discriminator.
+  private static DataSchema repeatResultSchema() {
+    return new DataSchema(new String[]{"int_col", "string_col", "int_col_key", "$groupingId"},
+        new ColumnDataType[]{INT, STRING, INT, INT});
+  }
+
+  private static Object field(Object operator, String name) {
+    try {
+      return FieldUtils.readField(operator, name, true);
+    } catch (IllegalAccessException e) {
+      throw new AssertionError("Cannot read field " + name + " of " + operator.getClass().getSimpleName(), e);
+    }
+  }
+
+  private static boolean isEmpty(Object collection) {
+    assertNotNull(collection, "expected a collection, not null");
+    if (collection instanceof Collection) {
+      return ((Collection<?>) collection).isEmpty();
+    }
+    if (collection instanceof Map) {
+      return ((Map<?, ?>) collection).isEmpty();
+    }
+    throw new AssertionError("Not a collection: " + collection.getClass());
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperatorTest.java
@@ -22,12 +22,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelFieldCollation.Direction;
 import org.apache.calcite.rel.RelFieldCollation.NullDirection;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.mailbox.MailboxService;
@@ -56,7 +54,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 
@@ -285,16 +283,7 @@ public class SortedMailboxReceiveOperatorTest {
 
     operator.cancel(new RuntimeException("TEST ERROR"));
 
-    assertNull(readBufferedRows(operator));
-  }
-
-  @Nullable
-  private static Object readBufferedRows(SortedMailboxReceiveOperator operator) {
-    try {
-      return FieldUtils.readField(operator, "_rows", true);
-    } catch (IllegalAccessException e) {
-      throw new AssertionError("Cannot read the buffered rows", e);
-    }
+    assertFalse(operator.hasBufferedState());
   }
 
   private SortedMailboxReceiveOperator getOperator(StageMetadata stageMetadata, RelDistribution.Type distributionType,

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperatorTest.java
@@ -22,10 +22,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelFieldCollation.Direction;
 import org.apache.calcite.rel.RelFieldCollation.NullDirection;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.mailbox.MailboxService;
@@ -54,6 +56,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -249,6 +252,48 @@ public class SortedMailboxReceiveOperatorTest {
         dataSchema, collations, Long.MAX_VALUE)) {
       assertEquals(((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows(), List.of(row1, row2, row3, row5, row4));
       assertTrue(operator.nextBlock().isSuccess());
+    }
+  }
+
+  /// The block this operator emits wraps the very list it buffered the rows into, and a block handed to a local
+  /// mailbox can still be read after this op chain has been closed. Releasing the buffer must therefore drop the
+  /// reference, never empty the list.
+  @Test
+  public void shouldNotEmptyTheEmittedBlockOnClose() {
+    when(_mailboxService.getReceivingMailbox(eq(MAILBOX_ID_1))).thenReturn(_mailbox1);
+    Object[] row = new Object[]{1, 1};
+    when(_mailbox1.poll()).thenReturn(OperatorTestUtil.blockWithStats(DATA_SCHEMA, row),
+        OperatorTestUtil.eosWithEmptyStats());
+    SortedMailboxReceiveOperator operator = getOperator(_stageMetadata1, RelDistribution.Type.SINGLETON);
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+    assertEquals(resultRows.size(), 1);
+
+    operator.close();
+
+    assertEquals(resultRows.size(), 1, "the emitted block must survive the operator being closed");
+    assertEquals(resultRows.get(0), row);
+  }
+
+  /// The buffered rows must be gone on the error path too, not only once the sorted block has been produced.
+  @Test
+  public void shouldReleaseBufferedRowsOnError() {
+    when(_mailboxService.getReceivingMailbox(eq(MAILBOX_ID_1))).thenReturn(_mailbox1);
+    when(_mailbox1.poll()).thenReturn(OperatorTestUtil.blockWithStats(DATA_SCHEMA, new Object[]{1, 1}),
+        OperatorTestUtil.errorWithEmptyStats(new RuntimeException("TEST ERROR")));
+    SortedMailboxReceiveOperator operator = getOperator(_stageMetadata1, RelDistribution.Type.SINGLETON);
+    assertTrue(operator.nextBlock().isError());
+
+    operator.cancel(new RuntimeException("TEST ERROR"));
+
+    assertNull(readBufferedRows(operator));
+  }
+
+  @Nullable
+  private static Object readBufferedRows(SortedMailboxReceiveOperator operator) {
+    try {
+      return FieldUtils.readField(operator, "_rows", true);
+    } catch (IllegalAccessException e) {
+      throw new AssertionError("Cannot read the buffered rows", e);
     }
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/set/SetOperatorBufferReleaseTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/set/SetOperatorBufferReleaseTest.java
@@ -1,0 +1,228 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.set;
+
+import java.util.List;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.query.runtime.blocks.ErrorMseBlock;
+import org.apache.pinot.query.runtime.blocks.MseBlock;
+import org.apache.pinot.query.runtime.operator.BlockListMultiStageOperator;
+import org.apache.pinot.query.runtime.operator.MultiStageOperator;
+import org.apache.pinot.query.runtime.operator.OperatorTestUtil;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+/// The set-operator half of the release invariant asserted by
+/// [org.apache.pinot.query.runtime.operator.OperatorBufferReleaseTest]: every operator must drop the row state it is
+/// holding on end of stream, on error and on cancellation alike.
+///
+/// These live in their own class because `hasBufferedState()` is `protected` and the overrides that matter here are
+/// declared in this package.
+///
+/// The [BinarySetOperator] subclasses all buffer the whole right child in `_rightRowSet`, and [UnionOperator] buffers
+/// every distinct row it has seen — neither was released on any path before.
+public class SetOperatorBufferReleaseTest {
+  private static final DataSchema SCHEMA =
+      new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+          ColumnDataType.INT, ColumnDataType.STRING
+      });
+  private static final RuntimeException ERROR = new RuntimeException("boom");
+
+  @Test
+  public void shouldReleaseRightRowSetOnCancelForEveryBinarySetOperator() {
+    for (BinarySetOperatorFactory factory : binarySetOperators()) {
+      // The right child completes and the left child produces a block, so the operator is mid-flight.
+      MultiStageOperator right = twoRowOperator();
+      BinarySetOperator operator = factory.create(mixedLeftOperator(), right);
+      String name = operator.getClass().getSimpleName();
+
+      assertTrue(operator.nextBlock().isData(), name + " should emit a data block");
+      assertTrue(operator.hasBufferedState(), name + " should still hold the right row set mid-flight");
+
+      operator.cancel(ERROR);
+
+      assertFalse(operator.hasBufferedState(), name + " should release the right row set on cancel");
+    }
+  }
+
+  @Test
+  public void shouldReleaseRightRowSetOnCloseForEveryBinarySetOperator() {
+    for (BinarySetOperatorFactory factory : binarySetOperators()) {
+      MultiStageOperator right = twoRowOperator();
+      BinarySetOperator operator = factory.create(mixedLeftOperator(), right);
+      String name = operator.getClass().getSimpleName();
+
+      assertTrue(operator.nextBlock().isData());
+      assertTrue(operator.hasBufferedState());
+
+      operator.close();
+
+      assertFalse(operator.hasBufferedState(), name + " should release the right row set on close");
+      // Terminating twice, by the other path, must be safe.
+      operator.cancel(ERROR);
+      assertFalse(operator.hasBufferedState(), name + " should stay released after a second termination");
+    }
+  }
+
+  /// When the left child fails, the right row set is released in band with the error block rather than waiting for
+  /// teardown.
+  @Test
+  public void shouldReleaseRightRowSetWhenTheLeftChildFails() {
+    for (BinarySetOperatorFactory factory : binarySetOperators()) {
+      MultiStageOperator right = twoRowOperator();
+      MultiStageOperator left = mock(MultiStageOperator.class);
+      when(left.nextBlock()).thenReturn(ErrorMseBlock.fromException(ERROR));
+      BinarySetOperator operator = factory.create(left, right);
+      String name = operator.getClass().getSimpleName();
+
+      assertTrue(operator.nextBlock().isError(), name + " should propagate the error");
+
+      assertFalse(operator.hasBufferedState(), name + " should release the right row set on the error path");
+      operator.close();
+      assertFalse(operator.hasBufferedState());
+    }
+  }
+
+  /// The right child failing leaves the right row set partially built and no result will ever be produced from it.
+  @Test
+  public void shouldReleasePartialRightRowSetWhenTheRightChildFails() {
+    for (BinarySetOperatorFactory factory : binarySetOperators()) {
+      MultiStageOperator right = mock(MultiStageOperator.class);
+      when(right.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "AA"}))
+          .thenReturn(ErrorMseBlock.fromException(ERROR));
+      BinarySetOperator operator = factory.create(mixedLeftOperator(), right);
+      String name = operator.getClass().getSimpleName();
+
+      assertTrue(operator.nextBlock().isError(), name + " should propagate the error");
+
+      assertFalse(operator.hasBufferedState(), name + " should release the partial right row set");
+    }
+  }
+
+  /// The emitted rows come from the left child, so releasing the right row set must not disturb a block already
+  /// handed downstream.
+  @Test
+  public void shouldNotEmptyTheEmittedBlockOnClose() {
+    MultiStageOperator right = twoRowOperator();
+    MultiStageOperator left = new BlockListMultiStageOperator.Builder(SCHEMA).addRow(1, "AA").buildWithEos();
+    IntersectOperator operator =
+        new IntersectOperator(OperatorTestUtil.getTracingContext(), List.of(left, right), SCHEMA);
+    List<Object[]> rows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+    assertEquals(rows.size(), 1);
+
+    operator.close();
+
+    assertEquals(rows.size(), 1, "the emitted block must survive the operator being closed");
+    assertEquals(rows.get(0), new Object[]{1, "AA"});
+  }
+
+  @Test
+  public void shouldReleaseUnionSeenRecordsOnCancel() {
+    MultiStageOperator first = mock(MultiStageOperator.class);
+    when(first.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "AA"}));
+    MultiStageOperator second = mock(MultiStageOperator.class);
+    UnionOperator operator = new UnionOperator(OperatorTestUtil.getTracingContext(), List.of(first, second), SCHEMA);
+
+    assertTrue(operator.nextBlock().isData());
+    assertTrue(operator.hasBufferedState(), "the seen records should be tracked before termination");
+
+    operator.cancel(ERROR);
+
+    assertFalse(operator.hasBufferedState());
+  }
+
+  @Test
+  public void shouldReleaseUnionSeenRecordsOnError() {
+    MultiStageOperator first = mock(MultiStageOperator.class);
+    when(first.nextBlock()).thenReturn(OperatorTestUtil.block(SCHEMA, new Object[]{1, "AA"}))
+        .thenReturn(ErrorMseBlock.fromException(ERROR));
+    MultiStageOperator second = mock(MultiStageOperator.class);
+    UnionOperator operator = new UnionOperator(OperatorTestUtil.getTracingContext(), List.of(first, second), SCHEMA);
+
+    assertTrue(operator.nextBlock().isData());
+    assertTrue(operator.hasBufferedState());
+    assertTrue(operator.nextBlock().isError());
+
+    assertFalse(operator.hasBufferedState(), "the seen records should be released on the error path");
+    operator.close();
+    assertFalse(operator.hasBufferedState());
+  }
+
+  /// Draining every input successfully must release too — the success path is the common one.
+  @Test
+  public void shouldReleaseUnionSeenRecordsOnEndOfStream() {
+    MultiStageOperator first = new BlockListMultiStageOperator.Builder(SCHEMA).addRow(1, "AA").buildWithEos();
+    MultiStageOperator second = new BlockListMultiStageOperator.Builder(SCHEMA).addRow(2, "BB").buildWithEos();
+    UnionOperator operator = new UnionOperator(OperatorTestUtil.getTracingContext(), List.of(first, second), SCHEMA);
+
+    MseBlock block = operator.nextBlock();
+    while (block.isData()) {
+      block = operator.nextBlock();
+    }
+
+    assertTrue(block.isSuccess());
+    assertFalse(operator.hasBufferedState(), "the seen records should be released once every input is drained");
+  }
+
+  /// The emitted blocks reference the left rows directly, so releasing must not touch them.
+  @Test
+  public void shouldNotEmptyTheBlockEmittedByUnion() {
+    MultiStageOperator first = new BlockListMultiStageOperator.Builder(SCHEMA).addRow(1, "AA").buildWithEos();
+    MultiStageOperator second = new BlockListMultiStageOperator.Builder(SCHEMA).addRow(2, "BB").buildWithEos();
+    UnionOperator operator = new UnionOperator(OperatorTestUtil.getTracingContext(), List.of(first, second), SCHEMA);
+    List<Object[]> rows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+    assertEquals(rows.size(), 1);
+
+    operator.close();
+
+    assertEquals(rows.size(), 1, "the emitted block must survive the operator being closed");
+    assertEquals(rows.get(0), new Object[]{1, "AA"});
+  }
+
+  private static MultiStageOperator twoRowOperator() {
+    // Two rows so that the set is still non-empty after the left child has matched one of them.
+    return new BlockListMultiStageOperator.Builder(SCHEMA).addRow(1, "AA").addRow(2, "BB").buildWithEos();
+  }
+
+  /// One row the right child also has and one it does not, so that every flavour emits a data block: INTERSECT and
+  /// INTERSECT ALL keep the matching row, MINUS and MINUS ALL keep the other one.
+  private static MultiStageOperator mixedLeftOperator() {
+    return new BlockListMultiStageOperator.Builder(SCHEMA).addRow(1, "AA").addRow(3, "CC").buildWithEos();
+  }
+
+  private static List<BinarySetOperatorFactory> binarySetOperators() {
+    return List.of(
+        (left, right) -> new IntersectOperator(OperatorTestUtil.getTracingContext(), List.of(left, right), SCHEMA),
+        (left, right) -> new IntersectAllOperator(OperatorTestUtil.getTracingContext(), List.of(left, right), SCHEMA),
+        (left, right) -> new MinusOperator(OperatorTestUtil.getTracingContext(), List.of(left, right), SCHEMA),
+        (left, right) -> new MinusAllOperator(OperatorTestUtil.getTracingContext(), List.of(left, right), SCHEMA));
+  }
+
+  @FunctionalInterface
+  private interface BinarySetOperatorFactory {
+    BinarySetOperator create(MultiStageOperator left, MultiStageOperator right);
+  }
+}


### PR DESCRIPTION
## The invariant

A multi-stage operator should drop its buffered row and hash state on **every** termination path — end of stream, error, and cancellation alike.

Today most operators release only on the success path, via `onEosProduced()`. The base `MultiStageOperator.close()` and `cancel(Throwable)` recurse to child operators and release nothing themselves, so an operator that fails or is cancelled keeps its buffers for as long as anything holds the operator tree. Those buffers are live references, so no GC — not even a full one — can reclaim them.

`SortedMailboxReceiveOperator`, `BaseMailboxReceiveOperator` and `LeafOperator` already did the right thing; the rest did not.

## What this changes

Adds a `protected MultiStageOperator#releaseBuffers()` hook that both `close()` and `cancel()` invoke after recursing to children. An exception from it is logged and swallowed so it can never break the rest of the teardown. The default is a no-op, so operators that buffer nothing are unaffected.

Implemented where per-query state is buffered:

| Operator | State released | Was it released before? |
|---|---|---|
| `SortOperator` | `_priorityQueue`, `_rows` | Never, on any path |
| `BinarySetOperator` (INTERSECT / EXCEPT) | `_rightRowSet` | Never, on any path |
| `UnionOperator` | `_seenRecords` | Never, on any path |
| `NonEquiJoinOperator` | `_rightTable` — the whole right side | No; only the much smaller `_matchedRightRows` |
| `HashJoinOperator` | `_rightTable`, `_matchedRightRows`, `_nullKeyRightRows` | Success path only |
| `AsofJoinOperator` | `_rightTable` | Success path only |
| `AggregateOperator` | group-by / aggregation executors | Success path only — the error return sits two lines above where they were nulled |
| `RepeatOperator` | `_currentRows` | Never |

`BaseJoinOperator#onEosProduced()` is gone: all three of its overriders became `releaseBuffers()`, which would have left a one-line delegate that a future join subclass could override and get success-path-only release — the exact bug this PR fixes. `getNextBlock()` now calls `releaseBuffers()` directly, so the prompt success-path release stays and the hook is the backstop rather than a replacement. That also picks up a case `onEosProduced()` missed entirely: a RIGHT/FULL join whose last output is the non-matched right rows sets `_eos` inside `buildJoinedDataBlock()` and returns via the early `if (_eos != null)` branch, so the hook never ran.

### Design note

I went with one hook on the base class rather than a `close()`/`cancel()` pair in each operator. It keeps the per-operator diff to a single method, and it makes it impossible to add a release that forgets to `super`-recurse to children — which is exactly the bug `SortOperator` had (below). The trade-off is a new (no-op default) method on the shared base class.

`releaseBuffers()` is paired with a `@VisibleForTesting protected boolean hasBufferedState()`: whatever one drops, the other reports. That is what lets the tests assert the invariant without reflecting into private fields, and it gives the base-class javadoc something concrete to hang the contract on. Nothing in production reads it.

Three rules came out of writing the tests and are now spelled out on the hook:

- **Never mutate something whose identity left the operator.** After this PR no release calls `clear()` at all, so the hazard is retired rather than merely documented.
- **Prefer replacing to clearing.** `HashMultiset`, `ObjectOpenHashSet`, `ArrayList` and `PriorityQueue` all keep the backing table at the capacity it grew to, so `clear()` on a wide `INTERSECT` or de-duplicating `UNION` leaves 1.33–2.67 reference slots per distinct row reachable — most of what we were trying to release. Those four now assign a fresh empty instance.
- **Do not let a released field double as control flow.** `AggregateOperator` dispatched on `_aggregationExecutor != null` and `RepeatOperator` treated `_currentRows == null` as "pull the next input block" — both fields the release drops, so a released operator would silently change mode or go back to a closed input. Each now keeps the decision somewhere the release does not touch: a final `_isGroupBy`, and a cached EOS block. `SortOperator` got the same treatment with a final `_requiresSort`, which also lets it drop its priority queue outright.

`PipelineBreakerOperator` is the one operator that must *not* release: `_resultMap` is its output, read through `getResultMap()` after the op chain has closed. It carries an explicit empty override saying so, because the contract now invites an audit that would otherwise silently empty pipeline-breaker results.

`releaseBuffersSafely()` catches `Throwable`, not `Exception`, so an `AssertionError` from an implementation cannot abort a parent's close loop and leave its siblings unclosed.

## Two related fixes found on the way

**`SortOperator#cancel(Throwable)` was an empty override.** Not "released nothing" — it did not call `super`, so cancelling a sort never reached the operators feeding it. Removed, so the base implementation recurses again. Covered by `sortOperatorCancelReachesChildren`.

**`SortedMailboxReceiveOperator#close()` cleared a list it had already handed downstream.** It emits `new RowHeapDataBlock(_rows, …)` and then `close()` called `_rows.clear()`. `InMemorySendingMailbox` passes blocks to the receiving mailbox by reference, and the receiving op chain reads them after the sending one has been closed, so emptying that list could silently drop rows rather than fail loudly. It now drops the reference instead of mutating the list.

`SortOperator._rows` had the same shape (it is handed out as `_rows.subList(...)`, a view backed by the same list) and is likewise nulled rather than cleared. The `releaseBuffers()` javadoc states the rule: `clear()` only a collection whose identity never leaves the operator; otherwise drop the reference. Both are covered by regression tests asserting the emitted block survives `close()`.

`LeafOperator` releases through the hook instead of its own `close()`/`cancel()` overrides, so the teardown that stops its single-stage tasks now runs on every path by construction and inside the hook's try/catch.

## Deliberately not touched

- `WindowAggregateOperator` buffers into a local variable, so nothing is retained on the operator.
- `LookupJoinOperator#_rightTable` is a shared `DimensionTableDataManager`, not per-query state.
- `PipelineBreakerOperator#_resultMap` is handed to the main op chain through `getResultMap()` and must outlive the operator — releasing it would be a correctness bug.

## Testing

Every operator this PR touches is covered on both termination paths.

`OperatorBufferReleaseTest` (21 cases) covers the base-class contract — both paths release, releasing is idempotent, children are closed first, and a release that throws (including an `AssertionError`) cannot abort teardown — then `SortOperator` in both of its buffering modes, all three joins, `AggregateOperator` in both of its modes, and `RepeatOperator`. It closes with a sweep that drives every buffering operator in the package to a state-holding point and terminates it by `close()` and by `cancel()`, in both orders, so an operator that releases on only one path fails.

`SetOperatorBufferReleaseTest` (9 cases) is new and runs the same scenarios across all four `BinarySetOperator` flavours — `INTERSECT`, `INTERSECT ALL`, `MINUS`, `MINUS ALL` — plus `UnionOperator`.

`SortedMailboxReceiveOperatorTest` gained the block-emptying regression and an error-path release case.

Each case asserts `hasBufferedState()` *before* terminating, so a scenario that stops buffering can't quietly become vacuous, and there are dedicated tests that an emitted block survives `close()`.

Full `pinot-query-runtime` suite: 4632 tests, 0 failures, 0 errors.

## Labels

`bugfix`

