### PR TITLE
Extract task-type table filter into overridable PinotTaskManager method

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -504,15 +504,7 @@ public class PinotTableRestletResource {
                       : _pinotHelixResourceManager.getAllOfflineTables(database));
 
       if (StringUtils.isNotBlank(taskType)) {
-        Set<String> tableNamesForTaskType = new HashSet<>();
-        for (String tableNameWithType : tableNamesWithType) {
-          TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
-          if (tableConfig != null && tableConfig.getTaskConfig() != null && tableConfig.getTaskConfig()
-              .isTaskTypeEnabled(taskType)) {
-            tableNamesForTaskType.add(tableNameWithType);
-          }
-        }
-        tableNamesWithType.retainAll(tableNamesForTaskType);
+        tableNamesWithType.retainAll(_pinotTaskManager.getTablesForTaskType(taskType, tableNamesWithType));
       }
 
       List<String> tableNames;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -726,6 +726,19 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
     return _taskGeneratorRegistry;
   }
 
+  /// Return the subset of [candidateTables] that have [taskType] enabled.
+  public Set<String> getTablesForTaskType(String taskType, Collection<String> candidateTables) {
+    Set<String> tables = new HashSet<>();
+    for (String tableNameWithType : candidateTables) {
+      TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+      if (tableConfig != null && tableConfig.getTaskConfig() != null
+          && tableConfig.getTaskConfig().isTaskTypeEnabled(taskType)) {
+        tables.add(tableNameWithType);
+      }
+    }
+    return tables;
+  }
+
   /// Registers a task generator.
   ///
   /// This method can be used to plug in custom task generators.


### PR DESCRIPTION
## Summary
- Move the inline scan in `PinotTableRestletResource#listTables` that filters tables by `taskType` into a new public method `PinotTaskManager#getTablesForTaskType(taskType, candidateTables)`.
- Default implementation is behavior-identical to the previous inline scan.
- Distributions can override the method to include tables enabled via other mechanisms (e.g. implicit / default-scheduled task types).