### PR TITLE
Stop a lingering receiving mailbox from pinning the receive operator

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
@@ -73,7 +73,7 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
       for (String mailboxId : _mailboxIds) {
         ReceivingMailbox receivingMailbox = _mailboxService.getReceivingMailbox(mailboxId);
         receivingMailbox.registerReceiveOperatorThreadContext(QueryThreadContext.getIfAvailable());
-        ReadMailboxAsyncStream asyncStream = new ReadMailboxAsyncStream(receivingMailbox, this);
+        ReadMailboxAsyncStream asyncStream = new ReadMailboxAsyncStream(receivingMailbox, _mailboxService);
         asyncStreams.add(asyncStream);
         _receivingStats.add(asyncStream._mailbox.getStatMap());
       }
@@ -164,13 +164,20 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
     _statMap.merge(StatKey.UPSTREAM_WAIT_MS, from.getLong(ReceivingMailbox.StatKey.WAIT_CPU_TIME_MS));
   }
 
+  /// Adapts a [ReceivingMailbox] to the [AsyncStream] the [BlockingMultiStreamConsumer] reads from.
+  ///
+  /// Deliberately holds the [MailboxService] and not the operator. The mailbox keeps this stream reachable through
+  /// the reader callback registered on it, and after a failed query the mailbox itself stays in the service's cache
+  /// until it expires (see [#poll()] for why it is not released earlier). A reference back to the operator from here
+  /// would keep the operator, its [OpChainExecutionContext] and everything reachable from them alive for that whole
+  /// time.
   private static class ReadMailboxAsyncStream implements AsyncStream<ReceivingMailbox.MseBlockWithStats> {
     final ReceivingMailbox _mailbox;
-    final BaseMailboxReceiveOperator _operator;
+    final MailboxService _mailboxService;
 
-    ReadMailboxAsyncStream(ReceivingMailbox mailbox, BaseMailboxReceiveOperator operator) {
+    ReadMailboxAsyncStream(ReceivingMailbox mailbox, MailboxService mailboxService) {
       _mailbox = mailbox;
-      _operator = operator;
+      _mailboxService = mailboxService;
     }
 
     @Override
@@ -186,9 +193,11 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
       if (blockWithStats != null) {
         MseBlock block = blockWithStats.getBlock();
 
-        // TODO: Check if we should also release mailbox on not successful EOS.
+        // Only a successful EOS releases the mailbox from the service's cache. After an error the senders may still
+        // be running, and they have to find the cancelled mailbox rather than recreate a fresh one that nobody reads.
+        // The cache expiry takes care of it, and this stream holds nothing that makes that wait expensive.
         if (block.isSuccess()) {
-          _operator._mailboxService.releaseReceivingMailbox(_mailbox);
+          _mailboxService.releaseReceivingMailbox(_mailbox);
         }
       }
       return blockWithStats;

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.query.runtime.operator;
 
 import java.io.IOException;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -242,6 +244,45 @@ public class MailboxReceiveOperatorTest {
       assertTrue(block.isError());
       assertTrue(((ErrorMseBlock) block).getErrorMessages().get(QueryErrorCode.UNKNOWN).contains(errorMessage));
     }
+  }
+
+  /// After an error the mailbox stays in the service's cache until it expires, and the reader callback it holds keeps
+  /// the stream that adapts it reachable. That stream must not point back at the operator, or every failed query
+  /// would pin its operator tree and execution context for as long as the mailbox lingers.
+  @Test
+  public void shouldNotStayReachableFromTheMailboxAfterAnError()
+      throws InterruptedException {
+    ReceivingMailbox mailbox = new ReceivingMailbox(MAILBOX_ID_1);
+    when(_mailboxService.getReceivingMailbox(eq(MAILBOX_ID_1))).thenReturn(mailbox);
+    MailboxReceiveOperator operator = getOperator(_stageMetadata1, RelDistribution.Type.SINGLETON);
+    mailbox.offer(ErrorMseBlock.fromException(new RuntimeException("TEST ERROR")), List.of(), 1000L);
+    assertTrue(operator.nextBlock().isError());
+    operator.cancel(new RuntimeException("TEST ERROR"));
+    operator.close();
+
+    ReferenceQueue<MailboxReceiveOperator> queue = new ReferenceQueue<>();
+    WeakReference<MailboxReceiveOperator> operatorRef = new WeakReference<>(operator, queue);
+    operator = null;
+    assertTrue(awaitCleared(operatorRef, queue), "the mailbox must not keep the closed operator reachable");
+    // The mailbox is the retention path under test, so it has to stay strongly reachable until this point.
+    assertEquals(mailbox.getId(), MAILBOX_ID_1);
+  }
+
+  /// Waits for `ref` to be cleared, prompting collection as it goes. The reference queue does the waiting rather than a
+  /// sleep loop over [WeakReference#get()], so the expected case costs one collection instead of a fixed delay, and the
+  /// failing case still gives the collector several attempts before giving up.
+  private static boolean awaitCleared(WeakReference<?> ref, ReferenceQueue<?> queue)
+      throws InterruptedException {
+    long deadlineMs = System.currentTimeMillis() + 5_000L;
+    do {
+      System.gc();
+      if (queue.remove(200L) != null) {
+        return true;
+      }
+    } while (System.currentTimeMillis() < deadlineMs);
+    // The collector clears the reference before enqueueing it, so check directly rather than call a late enqueue a
+    // failure.
+    return ref.get() == null;
   }
 
   @Test


### PR DESCRIPTION
## The bug

A `ReceivingMailbox` outlives the query that used it, and until now it kept the receive operator alive with it.

`MailboxService` caches receiving mailboxes with a 5 minute `expireAfterAccess`. A mailbox is invalidated earlier only on a **successful** EOS (`ReadMailboxAsyncStream#poll`), so after an error or a cancellation it stays in that cache until it expires. The mailbox holds the reader callback registered on it, which reaches the `BlockingMultiStreamConsumer`, which holds the `ReadMailboxAsyncStream` — and that stream held a reference back to the `BaseMailboxReceiveOperator`.

So every failed query pinned its receive operator, its `OpChainExecutionContext`, and the `PipelineBreakerResult` blocks hanging off that context, for up to five minutes after the query was already gone. With stream-stats reporting enabled the context also maps every operator in the chain (`OpChainExecutionContext#_operatorToPlanNodes`), so a single retained receive operator pins the **whole operator tree** — every buffered row and hash table in the stage.

The retention chain, before this change:

```
MailboxService._receivingMailboxCache   (expireAfterAccess 5 min)
  └─ ReceivingMailbox._blocks._reader   (never cleared)
       └─ BlockingMultiStreamConsumer::onData
            └─ _mailboxes → ReadMailboxAsyncStream._operator   ← the link this PR removes
                 └─ BaseMailboxReceiveOperator._context
                      └─ (stream-stats mode) every operator in the stage
```

## The fix

`ReadMailboxAsyncStream` held the operator for exactly one reason: to reach `_operator._mailboxService` in `poll()`. It now holds the `MailboxService` directly, so the chain above stops at the stream.

The mailbox itself is still released only on a successful EOS, which is deliberate rather than an oversight — the `TODO` that asked the question is replaced with the answer. After an error the senders may still be running, and they have to find the cancelled mailbox rather than recreate a fresh one that nobody will ever read. Letting the cache expiry handle it is correct; what was wrong is how much it dragged along while it waited.

## Testing

`shouldNotStayReachableFromTheMailboxAfterAnError` drives a real `ReceivingMailbox` (not a mock) to an error block, closes the operator, drops the last strong reference to it, and waits on a `ReferenceQueue` for a `WeakReference` to clear — while keeping the mailbox strongly reachable, since it is the retention path under test.

It fails on master and passes with this change.

Full `pinot-query-runtime` suite: 4601 tests, 0 failures, 0 errors. `spotless`, `checkstyle` and `license` clean.

## Notes

Found while reviewing #19462, which fixes the neighbouring problem — operators that keep their buffers after a failed query. That one is about what an operator holds; this is about what holds the operator. They are independent, so this goes on its own.

## Labels

`bug`, `multi-stage`
