### PR TITLE
Fix lease extender loss on same-name table recreate race

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.util.concurrent.Striped;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.File;
 import java.io.IOException;
@@ -87,6 +88,9 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(HelixInstanceDataManager.class);
 
   private final Map<String, TableDataManager> _tableDataManagerMap = new ConcurrentHashMap<>();
+  // Serialize table creation with the previous owner's entire shutdown, including table-scoped resource cleanup.
+  // Acquire it before changing the manager map, and release it before calling the table's segment-add methods.
+  private final Striped<Lock> _tableLifecycleLocks = Striped.lock(1024);
 
   // Logical table metadata cache to cache logical table configs, schemas, and offline/realtime table configs.
   private final LogicalTableMetadataCache _logicalTableMetadataCache = new LogicalTableMetadataCache();
@@ -308,37 +312,54 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   @Override
   public void deleteTable(String tableNameWithType, long deletionTimeMs)
       throws Exception {
-    AtomicReference<TableDataManager> tableDataManagerRef = new AtomicReference<>();
-    _tableDataManagerMap.computeIfPresent(tableNameWithType, (k, v) -> {
-      _recentlyDeletedTables.put(k, deletionTimeMs);
-      tableDataManagerRef.set(v);
-      return null;
-    });
-    TableDataManager tableDataManager = tableDataManagerRef.get();
-    if (tableDataManager == null) {
-      LOGGER.warn("Failed to find table data manager for table: {}, skip deleting the table", tableNameWithType);
-      return;
+    Lock lifecycleLock = _tableLifecycleLocks.get(tableNameWithType);
+    lifecycleLock.lock();
+    try {
+      AtomicReference<TableDataManager> tableDataManagerRef = new AtomicReference<>();
+      _tableDataManagerMap.computeIfPresent(tableNameWithType, (k, v) -> {
+        _recentlyDeletedTables.put(k, deletionTimeMs);
+        tableDataManagerRef.set(v);
+        return null;
+      });
+      TableDataManager tableDataManager = tableDataManagerRef.get();
+      if (tableDataManager == null) {
+        LOGGER.warn("Failed to find table data manager for table: {}, skip deleting the table", tableNameWithType);
+        return;
+      }
+      // Shutdown can wait for segment callbacks, so do not run it inside a map computation.
+      LOGGER.info("Shutting down table data manager for table: {}", tableNameWithType);
+      tableDataManager.setDeleted(true);
+      tableDataManager.shutDown();
+      LOGGER.info("Finished shutting down table data manager for table: {}", tableNameWithType);
+    } finally {
+      lifecycleLock.unlock();
     }
-    LOGGER.info("Shutting down table data manager for table: {}", tableNameWithType);
-    tableDataManager.setDeleted(true);
-    tableDataManager.shutDown();
-    LOGGER.info("Finished shutting down table data manager for table: {}", tableNameWithType);
   }
 
   @Override
   public void addOnlineSegment(String tableNameWithType, String segmentName)
       throws Exception {
-    _tableDataManagerMap.computeIfAbsent(tableNameWithType, this::createTableDataManager).addOnlineSegment(segmentName);
+    getOrCreateTableDataManager(tableNameWithType).addOnlineSegment(segmentName);
   }
 
   @Override
   public void addConsumingSegment(String realtimeTableName, String segmentName)
       throws Exception {
-    _tableDataManagerMap.computeIfAbsent(realtimeTableName, this::createTableDataManager)
-        .addConsumingSegment(segmentName);
+    getOrCreateTableDataManager(realtimeTableName).addConsumingSegment(segmentName);
   }
 
-  private TableDataManager createTableDataManager(String tableNameWithType) {
+  private TableDataManager getOrCreateTableDataManager(String tableNameWithType) {
+    Lock lifecycleLock = _tableLifecycleLocks.get(tableNameWithType);
+    lifecycleLock.lock();
+    try {
+      return _tableDataManagerMap.computeIfAbsent(tableNameWithType, this::createTableDataManager);
+    } finally {
+      lifecycleLock.unlock();
+    }
+  }
+
+  @VisibleForTesting
+  TableDataManager createTableDataManager(String tableNameWithType) {
     LOGGER.info("Creating table data manager for table: {}", tableNameWithType);
     TableConfig tableConfig;
     Long tableDeleteTimeMs = _recentlyDeletedTables.getIfPresent(tableNameWithType);

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerLifecycleTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerLifecycleTest.java
@@ -1,0 +1,292 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.starter.helix;
+
+import com.google.common.cache.CacheBuilder;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.apache.pinot.core.data.manager.realtime.SegmentBuildTimeLeaseExtender;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+/// Exercises table lifecycle ordering with controlled shutdown and segment callbacks, without starting a server.
+public class HelixInstanceDataManagerLifecycleTest {
+  private static final long TIMEOUT_SECONDS = 10;
+
+  @DataProvider
+  public Object[][] segmentTypes() {
+    return new Object[][]{{false}, {true}};
+  }
+
+  @Test(dataProvider = "segmentTypes")
+  public void testRecreationWaitsForOldLeaseShutdown(boolean consuming)
+      throws Exception {
+    String table = "lifecycle_" + consuming + "_REALTIME";
+    TableDataManager oldManager = mock(TableDataManager.class);
+    TableDataManager replacement = mock(TableDataManager.class);
+    CountDownLatch shutdownEntered = new CountDownLatch(1);
+    CountDownLatch finishShutdown = new CountDownLatch(1);
+    CountDownLatch shutdownFinished = new CountDownLatch(1);
+    AtomicInteger creations = new AtomicInteger();
+    AtomicReference<SegmentBuildTimeLeaseExtender> replacementLease = new AtomicReference<>();
+    SegmentBuildTimeLeaseExtender oldLease = SegmentBuildTimeLeaseExtender.getOrCreate("server", null, table);
+    TestInstanceDataManager instance = new TestInstanceDataManager(name -> {
+      if (creations.getAndIncrement() == 0) {
+        return oldManager;
+      }
+      assertTrue(shutdownFinished.getCount() == 0, "Replacement initialized before old lease shutdown completed");
+      replacementLease.set(SegmentBuildTimeLeaseExtender.getOrCreate("server", null, name));
+      return replacement;
+    });
+    doAnswer(invocation -> {
+      shutdownEntered.countDown();
+      await(finishShutdown);
+      oldLease.shutDown();
+      shutdownFinished.countDown();
+      return null;
+    }).when(oldManager).shutDown();
+    addSegment(instance, table, "old", consuming);
+    FutureTask<Void> deletion = new FutureTask<>(() -> {
+      instance.deleteTable(table, 1L);
+      return null;
+    });
+    Thread deletionThread = new Thread(deletion, "delete-table");
+    FutureTask<Void> recreation = new FutureTask<>(() -> {
+      addSegment(instance, table, "new", consuming);
+      return null;
+    });
+    Thread recreationThread = new Thread(recreation, "recreate-table");
+    try {
+      deletionThread.start();
+      await(shutdownEntered);
+      recreationThread.start();
+      // Wait for the competing operation to reach the lock, or expose an incorrectly completed creation.
+      long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS);
+      while (recreationThread.getState() != Thread.State.WAITING && !recreation.isDone()
+          && System.nanoTime() < deadline) {
+        Thread.sleep(10L);
+      }
+      assertFalse(recreation.isDone(), "Recreation must wait for the old table's shutdown");
+      assertSame(recreationThread.getState(), Thread.State.WAITING, "Recreation did not reach the lifecycle lock");
+      finishShutdown.countDown();
+      deletion.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      recreation.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      assertNotSame(replacementLease.get(), oldLease);
+      assertSame(SegmentBuildTimeLeaseExtender.getLeaseExtender(table), replacementLease.get());
+      assertSame(instance.getTableDataManager(table), replacement);
+    } finally {
+      finishShutdown.countDown();
+      join(deletionThread);
+      join(recreationThread);
+      SegmentBuildTimeLeaseExtender lease = SegmentBuildTimeLeaseExtender.getLeaseExtender(table);
+      if (lease != null) {
+        lease.shutDown();
+      }
+    }
+  }
+
+  @Test
+  public void testOtherTableCanInitializeDuringShutdown()
+      throws Exception {
+    TableDataManager oldManager = mock(TableDataManager.class);
+    TableDataManager otherManager = mock(TableDataManager.class);
+    CountDownLatch shutdownEntered = new CountDownLatch(1);
+    CountDownLatch finishShutdown = new CountDownLatch(1);
+    TestInstanceDataManager instance = new TestInstanceDataManager(name -> name.equals("old_REALTIME")
+        ? oldManager : otherManager);
+    doAnswer(invocation -> {
+      shutdownEntered.countDown();
+      await(finishShutdown);
+      return null;
+    }).when(oldManager).shutDown();
+    instance.addConsumingSegment("old_REALTIME", "old");
+    FutureTask<Void> deletion = new FutureTask<>(() -> {
+      instance.deleteTable("old_REALTIME", 1L);
+      return null;
+    });
+    Thread deletionThread = new Thread(deletion, "delete-other-table");
+    FutureTask<Void> creation = new FutureTask<>(() -> {
+      instance.addConsumingSegment("other_REALTIME", "other");
+      return null;
+    });
+    Thread creationThread = new Thread(creation, "create-other-table");
+    try {
+      deletionThread.start();
+      await(shutdownEntered);
+      creationThread.start();
+      creation.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      verify(otherManager).addConsumingSegment("other");
+    } finally {
+      finishShutdown.countDown();
+      join(deletionThread);
+      join(creationThread);
+    }
+    deletion.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+  }
+
+  @Test(dataProvider = "segmentTypes")
+  public void testSegmentCallbackDoesNotHoldLifecycleLock(boolean consuming)
+      throws Exception {
+    TableDataManager manager = mock(TableDataManager.class);
+    CountDownLatch addEntered = new CountDownLatch(1);
+    CountDownLatch finishAdd = new CountDownLatch(1);
+    if (consuming) {
+      doAnswer(invocation -> {
+        addEntered.countDown();
+        await(finishAdd);
+        return null;
+      }).when(manager).addConsumingSegment(anyString());
+    } else {
+      doAnswer(invocation -> {
+        addEntered.countDown();
+        await(finishAdd);
+        return null;
+      }).when(manager).addOnlineSegment(anyString());
+    }
+    TestInstanceDataManager instance = new TestInstanceDataManager(name -> manager);
+    FutureTask<Void> add = new FutureTask<>(() -> {
+      addSegment(instance, "callback_REALTIME", "segment", consuming);
+      return null;
+    });
+    Thread addThread = new Thread(add, "add-segment");
+    FutureTask<Void> deletion = new FutureTask<>(() -> {
+      instance.deleteTable("callback_REALTIME", 1L);
+      return null;
+    });
+    Thread deletionThread = new Thread(deletion, "delete-during-add");
+    try {
+      addThread.start();
+      await(addEntered);
+      deletionThread.start();
+      deletion.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      verify(manager).shutDown();
+    } finally {
+      finishAdd.countDown();
+      join(addThread);
+      join(deletionThread);
+    }
+    add.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void testShutdownFailureReleasesLifecycleLock()
+      throws Exception {
+    TableDataManager oldManager = mock(TableDataManager.class);
+    TableDataManager replacement = mock(TableDataManager.class);
+    RuntimeException failure = new IllegalStateException("shutdown failure");
+    doThrow(failure).when(oldManager).shutDown();
+    AtomicInteger creations = new AtomicInteger();
+    TestInstanceDataManager instance = new TestInstanceDataManager(name ->
+        creations.getAndIncrement() == 0 ? oldManager : replacement);
+    instance.addConsumingSegment("failure_REALTIME", "old");
+    assertThrows(IllegalStateException.class, () -> instance.deleteTable("failure_REALTIME", 1L));
+    assertNull(instance.getTableDataManager("failure_REALTIME"));
+    FutureTask<Void> creation = new FutureTask<>(() -> {
+      instance.addConsumingSegment("failure_REALTIME", "new");
+      return null;
+    });
+    Thread creationThread = new Thread(creation, "create-after-shutdown-failure");
+    try {
+      creationThread.start();
+      creation.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      verify(replacement).addConsumingSegment("new");
+    } finally {
+      join(creationThread);
+    }
+  }
+
+  @Test
+  public void testCreationFailureReleasesLifecycleLock()
+      throws Exception {
+    TableDataManager manager = mock(TableDataManager.class);
+    AtomicInteger creations = new AtomicInteger();
+    TestInstanceDataManager instance = new TestInstanceDataManager(name -> {
+      if (creations.getAndIncrement() == 0) {
+        throw new IllegalStateException("creation failure");
+      }
+      return manager;
+    });
+    assertThrows(IllegalStateException.class, () -> instance.addOnlineSegment("failure_REALTIME", "first"));
+    FutureTask<Void> creation = new FutureTask<>(() -> {
+      instance.addOnlineSegment("failure_REALTIME", "second");
+      return null;
+    });
+    Thread creationThread = new Thread(creation, "retry-creation");
+    try {
+      creationThread.start();
+      creation.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      verify(manager).addOnlineSegment("second");
+    } finally {
+      join(creationThread);
+    }
+  }
+
+  private static void addSegment(HelixInstanceDataManager instance, String table, String segment, boolean consuming)
+      throws Exception {
+    if (consuming) {
+      instance.addConsumingSegment(table, segment);
+    } else {
+      instance.addOnlineSegment(table, segment);
+    }
+  }
+
+  private static void await(CountDownLatch latch)
+      throws InterruptedException {
+    assertTrue(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS), "Timed out waiting for controlled lifecycle operation");
+  }
+
+  private static void join(Thread thread)
+      throws InterruptedException {
+    thread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+    assertFalse(thread.isAlive(), "Lifecycle worker did not terminate");
+  }
+
+  /// Supplies controlled table instances while exercising the real instance manager's map and lifecycle operations.
+  private static class TestInstanceDataManager extends HelixInstanceDataManager {
+    private final Function<String, TableDataManager> _factory;
+
+    TestInstanceDataManager(Function<String, TableDataManager> factory) {
+      _factory = factory;
+      _recentlyDeletedTables = CacheBuilder.newBuilder().build();
+    }
+
+    @Override
+    TableDataManager createTableDataManager(String tableNameWithType) {
+      return _factory.apply(tableNameWithType);
+    }
+  }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Serialize table deletion and creation with a per\-table lock to prevent lease extender races during recreation\.

```mermaid
flowchart TD
  N0["lock acquired in deleteTable #40;F1#41;"]:::stModified
  N1["manager removed from map in deleteTable #40;F1#41;"]:::stModified
  N2["manager shut down in deleteTable #40;F1#41;"]:::stModified
  N3["lock released in deleteTable #40;F1#41;"]:::stModified
  N4["lock acquired in getOrCreateTableDataManager #40;F1#41;"]:::stAdded
  N5["manager created#47;retrieved from map in getOrCreateTableDataManager #40;F1#41;"]:::stAdded
  N6["lock released in getOrCreateTableDataManager #40;F1#41;"]:::stAdded
  N7["segment add method called on manager #40;F1#41;"]:::stModified
  N0 -->|"sequential"| N1
  N1 -->|"sequential"| N2
  N2 -->|"sequential"| N3
  N4 -->|"sequential"| N5
  N5 -->|"sequential"| N6
  N6 -->|"sequential"| N7
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java) · [after](https://github.com/apache/pinot/blob/a202d87dd616598e6ab990f8a26f7e824057ad57/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImU2Nzg3ZTE3ODY0NWZkM2M1YTg4N2UyYWJhN2UwZGU4MzQzY2Q1MjQiLCJjb250ZXh0X2hhc2giOiI1YjA2Y2ZkNjExNmRkMTkyMzRiMDNkMTA0YTI5ZmVlMTQ2ZDM0YTc1ODE5YzdiYTdiYWIxZmFlODliNTFiNzhmIiwiZ2VuZXJhdGVkX2F0IjoxNzkwMDQzMTUyLCJoZWFkX3NoYSI6ImEyMDJkODdkZDYxNjU5OGU2YWI5OTBmOGEyNmY3ZTgyNDA1N2FkNTciLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJlNjc4N2UxNzg2NDVmZDNjNWE4ODdlMmFiYTdlMGRlODM0M2NkNTI0IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 6ed46498008e7da00c449e5512199e92188aafc6fbd76270a26eebcd09b5c904 -->
<!-- pinot-pr-flow:end -->

## What this fixes

A **delete-then-recreate of the same-named table** on a server can corrupt the recreated realtime table's segment-build lease extender, leaving later consuming-segment commits with a dead/`null` lease extender.

This is a genuine concurrency bug in the server table lifecycle, not a test-only issue. The added tests exist to *prove* the race — both recreation regressions fail deterministically against the old runtime ordering.

## The race (before this PR)

`HelixInstanceDataManager` removes a table's manager from the map and then shuts it down **outside** the map computation, while segment transitions concurrently (re)create the manager for the same table name:

1. `deleteTable(t)` removes the manager from `_tableDataManagerMap` (`computeIfPresent` → `null`), then — no longer holding any per-table guard — calls `oldMgr.shutDown()`.
2. Concurrently, `addConsumingSegment(t)` / `addOnlineSegment(t)` runs `computeIfAbsent` → `createTableDataManager(t)`, constructing a **new** `RealtimeTableDataManager`. Its setup calls `SegmentBuildTimeLeaseExtender.getOrCreate(t)`, which reuses the still-present entry in the static `TABLE_TO_LEASE_EXTENDER` map — so the new manager adopts the **old** manager's lease extender.
3. The old manager's still-running `shutDown()` reaches `_leaseExtender.shutDown()`, which does `TABLE_TO_LEASE_EXTENDER.remove(t)` — ripping the extender out from under the live new manager.
4. A later consuming segment on the new manager commits and finds a `null`/cancelled lease extender.

The root cause is that manager removal and the old owner's **table-scoped resource cleanup** (lease extender + segments) were not serialized against recreation. The window is the duration of `oldMgr.shutDown()`.

## The fix

Serialize creation and deletion of a given table with a striped lifecycle lock (`Striped.lock(1024)`, keyed by `tableNameWithType`):

- `deleteTable` acquires the table's lock and holds it across map removal **and** the full `shutDown()` (including lease-extender cleanup), then releases it. Shutdown stays **outside** the map computation, so it can't block other tables' map operations.
- `addOnlineSegment` / `addConsumingSegment` go through a new `getOrCreateTableDataManager`, which holds the same lock across `computeIfAbsent` (manager construction, incl. `getOrCreate` of the lease extender) and **releases it before** invoking the segment-add callback — so segment ingestion is not serialized, only manager lifecycle is.

With this, a recreate for table `t` cannot begin constructing a new manager until the previous manager's shutdown — and its lease-extender removal — has fully completed, closing the window in step 2/3 above.

Striping bounds memory and lets unrelated tables proceed fully in parallel; colliding table names (same stripe) simply wait. In-flight segment additions and exceptional shutdown cleanup keep their existing behavior.

## Scope / when this matters

- **Trigger:** delete + same-name recreate of a (realtime) table while segment transitions are in flight — e.g. rebuild/replace flows and automation that recreates tables. Steady-state operation is unaffected.
- **Not touched:** the normal add-segment hot path (lock is released before the segment-add call), other tables (independent stripes), and server shutdown ordering.

## Validation

- 13 focused unit cases pass (`HelixInstanceDataManagerLifecycleTest`, `HelixInstanceDataManagerTest`), zero failures/skips. Both recreation regressions fail against the old runtime ordering and pass with the lock.
- Spotless, Checkstyle, license checks, and warning-enabled compilation pass; reported deprecations are pre-existing.
