### PR TITLE
[query-runtime] Add hash aggregation disk spill

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -550,6 +550,29 @@ public class QueryOptionsUtils {
   }
 
   @Nullable
+  public static Integer getMSEAggregationSpillThreshold(Map<String, String> queryOptions) {
+    String value = queryOptions.get(QueryOptionKey.MSE_AGGREGATION_SPILL_THRESHOLD);
+    return checkedParseIntPositive(QueryOptionKey.MSE_AGGREGATION_SPILL_THRESHOLD, value);
+  }
+
+  public static boolean isMSEAggregationSpillEnabled(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.MSE_AGGREGATION_SPILL_ENABLED));
+  }
+
+  @Nullable
+  public static Integer getMSEAggregationSpillPartitions(Map<String, String> queryOptions) {
+    String value = queryOptions.get(QueryOptionKey.MSE_AGGREGATION_SPILL_PARTITIONS);
+    Integer partitions = uncheckedParseInt(QueryOptionKey.MSE_AGGREGATION_SPILL_PARTITIONS, value);
+    if (partitions != null
+        && (partitions < 1 || partitions > CommonConstants.Server.MAX_MSE_AGGREGATION_SPILL_PARTITIONS)) {
+      throw new IllegalArgumentException(
+          QueryOptionKey.MSE_AGGREGATION_SPILL_PARTITIONS + " must be a number between 1 and "
+              + CommonConstants.Server.MAX_MSE_AGGREGATION_SPILL_PARTITIONS + ", got: " + value);
+    }
+    return partitions;
+  }
+
+  @Nullable
   public static Integer getStreamingDistinctFlushThreshold(Map<String, String> queryOptions) {
     String value = queryOptions.get(QueryOptionKey.STREAMING_DISTINCT_FLUSH_THRESHOLD);
     return checkedParseIntNonNegative(QueryOptionKey.STREAMING_DISTINCT_FLUSH_THRESHOLD, value);

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/QueryOptionsUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/QueryOptionsUtilsTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey.*;
@@ -38,7 +39,7 @@ import static org.testng.Assert.fail;
 public class QueryOptionsUtilsTest {
   private static final List<String> POSITIVE_INT_KEYS =
       List.of(NUM_REPLICA_GROUPS_TO_QUERY, MAX_EXECUTION_THREADS, NUM_GROUPS_LIMIT, MAX_INITIAL_RESULT_HOLDER_CAPACITY,
-          MAX_STREAMING_PENDING_BLOCKS, MAX_ROWS_IN_JOIN, MAX_ROWS_IN_WINDOW);
+          MAX_STREAMING_PENDING_BLOCKS, MAX_ROWS_IN_JOIN, MAX_ROWS_IN_WINDOW, MSE_AGGREGATION_SPILL_THRESHOLD);
   private static final List<String> NON_NEGATIVE_INT_KEYS =
       List.of(MULTI_STAGE_LEAF_LIMIT, STREAMING_GROUP_BY_FLUSH_THRESHOLD, STREAMING_DISTINCT_FLUSH_THRESHOLD);
   private static final List<String> UNBOUNDED_INT_KEYS =
@@ -208,6 +209,35 @@ public class QueryOptionsUtilsTest {
   }
 
   @Test
+  public void testMSEAggregationSpillPartitions() {
+    int maxPartitions = CommonConstants.Server.MAX_MSE_AGGREGATION_SPILL_PARTITIONS;
+    assertNull(QueryOptionsUtils.getMSEAggregationSpillPartitions(Map.of()));
+    assertEquals(QueryOptionsUtils.getMSEAggregationSpillPartitions(
+        Map.of(MSE_AGGREGATION_SPILL_PARTITIONS, "1")), Integer.valueOf(1));
+    assertEquals(QueryOptionsUtils.getMSEAggregationSpillPartitions(
+        Map.of(MSE_AGGREGATION_SPILL_PARTITIONS, Integer.toString(maxPartitions))), Integer.valueOf(maxPartitions));
+
+    for (String value : new String[]{"0", Integer.toString(maxPartitions + 1), Integer.toString(Integer.MAX_VALUE)}) {
+      try {
+        QueryOptionsUtils.getMSEAggregationSpillPartitions(Map.of(MSE_AGGREGATION_SPILL_PARTITIONS, value));
+        fail();
+      } catch (IllegalArgumentException e) {
+        assertEquals(e.getMessage(),
+            MSE_AGGREGATION_SPILL_PARTITIONS + " must be a number between 1 and " + maxPartitions + ", got: " + value);
+      }
+    }
+  }
+
+  @Test
+  public void testMSEAggregationSpillEnabled() {
+    assertFalse(QueryOptionsUtils.isMSEAggregationSpillEnabled(Map.of()));
+    assertFalse(QueryOptionsUtils.isMSEAggregationSpillEnabled(
+        Map.of(MSE_AGGREGATION_SPILL_ENABLED, "false")));
+    assertTrue(QueryOptionsUtils.isMSEAggregationSpillEnabled(
+        Map.of(MSE_AGGREGATION_SPILL_ENABLED, "true")));
+  }
+
+  @Test
   public void testGetQueryHashWithValue() {
     Map<String, String> queryOptions = Map.of(QUERY_HASH, "abc123def456");
     String actualHash = QueryOptionsUtils.getQueryHash(queryOptions);
@@ -334,6 +364,10 @@ public class QueryOptionsUtilsTest {
         return QueryOptionsUtils.getMaxRowsInJoin(map);
       case MAX_ROWS_IN_WINDOW:
         return QueryOptionsUtils.getMaxRowsInWindow(map);
+      case MSE_AGGREGATION_SPILL_THRESHOLD:
+        return QueryOptionsUtils.getMSEAggregationSpillThreshold(map);
+      case MSE_AGGREGATION_SPILL_PARTITIONS:
+        return QueryOptionsUtils.getMSEAggregationSpillPartitions(map);
       // Non-negative ints
       case MULTI_STAGE_LEAF_LIMIT:
         return QueryOptionsUtils.getMultiStageLeafLimit(map);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AnyValueAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AnyValueAggregationFunction.java
@@ -36,6 +36,7 @@ import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.ByteArray;
 
 
 /// AnyValue aggregation function returns any arbitrary NON-NULL value from the column for each group.
@@ -268,6 +269,8 @@ public class AnyValueAggregationFunction extends BaseSingleInputAggregationFunct
       return serializeVariableValue(DataType.BIG_DECIMAL, value.toString().getBytes(StandardCharsets.UTF_8));
     } else if (value instanceof byte[]) {
       return serializeVariableValue(DataType.BYTES, (byte[]) value);
+    } else if (value instanceof ByteArray) {
+      return serializeVariableValue(DataType.BYTES, ((ByteArray) value).getBytes());
     } else {
       throw new IllegalStateException("Unsupported value type for serialization: " + value.getClass().getName());
     }
@@ -309,7 +312,7 @@ public class AnyValueAggregationFunction extends BaseSingleInputAggregationFunct
       case BIG_DECIMAL:
         return new BigDecimal(new String(deserializeVariableBytes(buffer), StandardCharsets.UTF_8));
       case BYTES:
-        return deserializeVariableBytes(buffer);
+        return new ByteArray(deserializeVariableBytes(buffer));
       default:
         throw new IllegalStateException("Unsupported data type for deserialization: " + dataType);
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.runtime;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.grpc.stub.StreamObserver;
 import java.time.Duration;
@@ -110,6 +111,8 @@ public class QueryRunner {
   private Integer _numGroupsWarningLimit;
   @Nullable
   private Integer _mseMinGroupTrimSize;
+  private boolean _mseAggregationSpillEnabled;
+  private SendStatsPredicate.Mode _sendStatsMode = SendStatsPredicate.Mode.ALWAYS;
 
   @Nullable
   private Integer _maxInitialResultHolderCapacity;
@@ -133,6 +136,7 @@ public class QueryRunner {
   /// at startup time. **May be overridden per-request** via the `KEY_OF_STATS_REPORTING_MODE` metadata key —
   /// see [#effectiveSendStats(Map)].
   private BooleanSupplier _sendStats;
+  private BooleanSupplier _clusterVersionCompatible;
   private BooleanSupplier _keepPipelineBreakerStats;
 
   /// Initializes the query runner.
@@ -143,7 +147,8 @@ public class QueryRunner {
   ///                            for processing leaf-stage queries. When null, only intermediate-stage execution
   ///                            is supported.
   public void init(PinotConfiguration serverConf, String instanceId, @Nullable InstanceDataManager instanceDataManager,
-      @Nullable TlsConfig tlsConfig, BooleanSupplier sendStats, BooleanSupplier keepPipelineBreakerStats) {
+      @Nullable TlsConfig tlsConfig, BooleanSupplier sendStats, BooleanSupplier clusterVersionCompatible,
+      BooleanSupplier keepPipelineBreakerStats) {
     String hostname = serverConf.getProperty(MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME);
     if (hostname.startsWith(Helix.PREFIX_OF_SERVER_INSTANCE)) {
       hostname = hostname.substring(Helix.SERVER_INSTANCE_PREFIX_LENGTH);
@@ -160,6 +165,8 @@ public class QueryRunner {
 
     String mseMinGroupTrimSizeStr = serverConf.getProperty(Server.CONFIG_OF_MSE_MIN_GROUP_TRIM_SIZE);
     _mseMinGroupTrimSize = mseMinGroupTrimSizeStr != null ? Integer.parseInt(mseMinGroupTrimSizeStr) : null;
+
+    initAggregationSpillConfig(serverConf);
 
     String maxInitialGroupHolderCapacity =
         serverConf.getProperty(Server.CONFIG_OF_QUERY_EXECUTOR_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
@@ -240,6 +247,7 @@ public class QueryRunner {
     }
 
     _sendStats = sendStats;
+    _clusterVersionCompatible = clusterVersionCompatible;
     _keepPipelineBreakerStats = keepPipelineBreakerStats;
 
     LOGGER.info("Initialized QueryRunner with hostname: {}, port: {}", hostname, port);
@@ -253,7 +261,7 @@ public class QueryRunner {
       _mailboxService = sharedMailboxService;
       _ownsMailboxService = false;
     }
-    init(serverConf, instanceId, instanceDataManager, tlsConfig, sendStats, keepPipelineBreakerStats);
+    init(serverConf, instanceId, instanceDataManager, tlsConfig, sendStats, () -> false, keepPipelineBreakerStats);
   }
 
   public void start() {
@@ -295,12 +303,13 @@ public class QueryRunner {
   private void processQueryBlocking(WorkerMetadata workerMetadata, StagePlan stagePlan,
       Map<String, String> requestMetadata) {
     StageMetadata stageMetadata = stagePlan.getStageMetadata();
-    Map<String, String> opChainMetadata = consolidateMetadata(stageMetadata.getCustomProperties(), requestMetadata);
 
     // The cluster-level _sendStats decision can be overridden per-request by the SubmitWithStream RPC handler via
     // MultiStageQueryRunner.KEY_OF_STATS_REPORTING_MODE; in stream mode stats travel out-of-band
     // and we suppress the mailbox-side path to avoid duplication.
     boolean sendStats = effectiveSendStats(requestMetadata);
+    Map<String, String> opChainMetadata = consolidateMetadata(stageMetadata.getCustomProperties(), requestMetadata,
+        canEnableAggregationSpill(_sendStatsMode, _clusterVersionCompatible.getAsBoolean()));
 
     // run pre-stage execution for all pipeline breakers
     PipelineBreakerResult pipelineBreakerResult = PipelineBreakerExecutor.executePipelineBreakers(
@@ -459,8 +468,9 @@ public class QueryRunner {
     }
   }
 
-  private Map<String, String> consolidateMetadata(Map<String, String> customProperties,
-      Map<String, String> requestMetadata) {
+  @VisibleForTesting
+  Map<String, String> consolidateMetadata(Map<String, String> customProperties,
+      Map<String, String> requestMetadata, boolean spillStatsCompatible) {
     Map<String, String> opChainMetadata = new HashMap<>();
     // 1. put all request level metadata
     opChainMetadata.putAll(requestMetadata);
@@ -470,6 +480,8 @@ public class QueryRunner {
     if (_numGroupsWarningLimit != null) {
       opChainMetadata.put(QueryOptionKey.NUM_GROUPS_WARNING_LIMIT, Integer.toString(_numGroupsWarningLimit));
     }
+    opChainMetadata.put(QueryOptionKey.MSE_AGGREGATION_SPILL_ENABLED,
+        Boolean.toString(_mseAggregationSpillEnabled && spillStatsCompatible));
     // 4. add all overrides from config if anything is still empty.
     Integer numGroupsLimit = QueryOptionsUtils.getNumGroupsLimit(opChainMetadata);
     if (numGroupsLimit == null) {
@@ -549,6 +561,20 @@ public class QueryRunner {
     return opChainMetadata;
   }
 
+  @VisibleForTesting
+  static boolean canEnableAggregationSpill(SendStatsPredicate.Mode sendStatsMode, boolean homogeneousCluster) {
+    // AggregateOperator stats use enum ordinals in both mailbox and stream transports. Only SAFE mode proves that
+    // every broker and server can decode the spill stat keys.
+    return sendStatsMode == SendStatsPredicate.Mode.SAFE && homogeneousCluster;
+  }
+
+  @VisibleForTesting
+  void initAggregationSpillConfig(PinotConfiguration serverConf) {
+    _mseAggregationSpillEnabled = serverConf.getProperty(Server.CONFIG_OF_MSE_AGGREGATION_SPILL_ENABLED,
+        Server.DEFAULT_MSE_AGGREGATION_SPILL_ENABLED);
+    _sendStatsMode = SendStatsPredicate.getMode(serverConf);
+  }
+
   public MailboxService getMailboxService() {
     return _mailboxService;
   }
@@ -598,7 +624,8 @@ public class QueryRunner {
     }
 
     StageMetadata stageMetadata = stagePlan.getStageMetadata();
-    Map<String, String> opChainMetadata = consolidateMetadata(stageMetadata.getCustomProperties(), requestMetadata);
+    Map<String, String> opChainMetadata = consolidateMetadata(stageMetadata.getCustomProperties(), requestMetadata,
+        canEnableAggregationSpill(_sendStatsMode, _clusterVersionCompatible.getAsBoolean()));
 
     if (PipelineBreakerExecutor.hasPipelineBreakers(stagePlan)) {
       //TODO: See https://github.com/apache/pinot/pull/13733#discussion_r1752031714

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/SendStatsPredicate.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/SendStatsPredicate.java
@@ -19,9 +19,11 @@
 package org.apache.pinot.query.runtime;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
@@ -61,21 +63,28 @@ public abstract class SendStatsPredicate implements InstanceConfigChangeListener
 
   public abstract boolean isSendStats();
 
+  /// Returns whether all broker and server versions have been successfully read and match this Pinot version.
+  public boolean isClusterVersionCompatible() {
+    return false;
+  }
+
   public abstract boolean needWatchForInstanceConfigChange();
 
   // NOTE: When this method is called, the helix manager is not yet connected.
   public static SendStatsPredicate create(PinotConfiguration serverConf, HelixManager helixManager) {
+    return getMode(serverConf).create(helixManager);
+  }
+
+  public static Mode getMode(PinotConfiguration serverConf) {
     String modeStr = serverConf.getProperty(
         CommonConstants.MultiStageQueryRunner.KEY_OF_SEND_STATS_MODE,
         CommonConstants.MultiStageQueryRunner.DEFAULT_SEND_STATS_MODE).toUpperCase(Locale.ENGLISH);
-    Mode mode;
     try {
-      mode = Mode.valueOf(modeStr.trim().toUpperCase(Locale.ENGLISH));
+      return Mode.valueOf(modeStr.trim().toUpperCase(Locale.ENGLISH));
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException("Invalid value " + modeStr + " for "
           + CommonConstants.MultiStageQueryRunner.KEY_OF_SEND_STATS_MODE, e);
     }
-    return mode.create(helixManager);
   }
 
   public enum Mode {
@@ -139,9 +148,12 @@ public abstract class SendStatsPredicate implements InstanceConfigChangeListener
     private final HelixManager _helixManager;
     private final String _clusterName;
     private final Map<String, String> _problematicVersionsById = new HashMap<>();
+    private final Set<String> _unknownVersionInstances = new HashSet<>();
 
     private HelixAdmin _helixAdmin;
     private volatile boolean _sendStats = true;
+    private volatile boolean _clusterVersionCompatible;
+    private boolean _initialized;
 
     public Safe(HelixManager helixManager) {
       _helixManager = helixManager;
@@ -151,6 +163,11 @@ public abstract class SendStatsPredicate implements InstanceConfigChangeListener
     @Override
     public boolean isSendStats() {
       return _sendStats;
+    }
+
+    @Override
+    public boolean isClusterVersionCompatible() {
+      return _clusterVersionCompatible;
     }
 
     @Override
@@ -168,8 +185,12 @@ public abstract class SendStatsPredicate implements InstanceConfigChangeListener
         LOGGER.warn("Ignoring notification type: {} for instance config change", type);
         return;
       }
-      if (type == NotificationContext.Type.INIT || context.getIsChildChange()) {
+      boolean fullScan = type == NotificationContext.Type.INIT || context.getIsChildChange();
+      if (fullScan) {
+        _initialized = false;
+        _clusterVersionCompatible = false;
         _problematicVersionsById.clear();
+        _unknownVersionInstances.clear();
         for (String instance : _helixAdmin.getInstancesInCluster(_clusterName)) {
           if (needVersionCheck(instance)) {
             InstanceConfig instanceConfig;
@@ -177,6 +198,7 @@ public abstract class SendStatsPredicate implements InstanceConfigChangeListener
               instanceConfig = _helixAdmin.getInstanceConfig(_clusterName, instance);
             } catch (Exception e) {
               LOGGER.warn("Failed to get instance config for instance: {}, continue", instance, e);
+              _unknownVersionInstances.add(instance);
               continue;
             }
             String version = getVersion(instanceConfig);
@@ -185,6 +207,7 @@ public abstract class SendStatsPredicate implements InstanceConfigChangeListener
             }
           }
         }
+        _initialized = true;
       } else {
         String pathChanged = context.getPathChanged();
         String instanceName = pathChanged.substring(pathChanged.lastIndexOf('/') + 1);
@@ -198,10 +221,12 @@ public abstract class SendStatsPredicate implements InstanceConfigChangeListener
             } else {
               _problematicVersionsById.remove(instanceName);
             }
+            _unknownVersionInstances.remove(instanceName);
           } catch (Exception e) {
             LOGGER.warn("Failed to get instance config for instance: {}, treating it as non-problematic", instanceName,
                 e);
             _problematicVersionsById.remove(instanceName);
+            _unknownVersionInstances.add(instanceName);
           }
         }
       }
@@ -216,6 +241,8 @@ public abstract class SendStatsPredicate implements InstanceConfigChangeListener
       } else if (!_sendStats) {
         LOGGER.info("Send MSE stats is still disabled (problematic versions: {})", _problematicVersionsById);
       }
+      _clusterVersionCompatible =
+          _initialized && _problematicVersionsById.isEmpty() && _unknownVersionInstances.isEmpty();
     }
 
     private boolean needVersionCheck(String instanceName) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -20,6 +20,7 @@ package org.apache.pinot.query.runtime.operator;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -33,6 +34,7 @@ import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.operator.docvalsets.DataBlockValSet;
@@ -52,6 +54,7 @@ import org.apache.pinot.query.runtime.blocks.MseBlock;
 import org.apache.pinot.query.runtime.blocks.RowHeapDataBlock;
 import org.apache.pinot.query.runtime.operator.utils.SortUtils;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.roaringbitmap.RoaringBitmap;
@@ -71,6 +74,13 @@ public class AggregateOperator extends MultiStageOperator {
   private final MultiStageOperator _input;
   private final DataSchema _resultSchema;
   private final AggregationFunction<?, ?>[] _aggFunctions;
+  private final int[] _groupKeyIds;
+  private final int[] _filterArgIds;
+  private final int _maxFilterArgId;
+  private final AggregateNode.AggType _aggType;
+  private final boolean _leafReturnFinalResult;
+  private final Map<String, String> _opChainMetadata;
+  private final PlanNode.NodeHint _nodeHint;
   @Nullable
   private MultistageAggregationExecutor _aggregationExecutor;
   @Nullable
@@ -78,9 +88,19 @@ public class AggregateOperator extends MultiStageOperator {
 
   @Nullable
   private MseBlock.Eos _eosBlock;
+  private boolean _inputConsumed;
   private final StatMap<StatKey> _statMap = new StatMap<>(StatKey.class);
 
   private final boolean _errorOnNumGroupsLimit;
+  private final int _numGroupsLimit;
+  private final int _spillThreshold;
+  private final int _spillPartitions;
+  @Nullable
+  private AggregationSpillManager _spillManager;
+  @Nullable
+  private Path _spillDirectory;
+  private int _nextSpillPartition;
+  private int _numSpilledGroupsProduced;
 
   // trimming - related members
   private final int _groupTrimSize;
@@ -97,17 +117,23 @@ public class AggregateOperator extends MultiStageOperator {
 
     // Process the filter argument indices
     List<Integer> filterArgs = node.getFilterArgs();
-    int[] filterArgIds = new int[numFunctions];
+    _filterArgIds = new int[numFunctions];
     int maxFilterArgId = -1;
     for (int i = 0; i < numFunctions; i++) {
-      filterArgIds[i] = filterArgs.get(i);
-      maxFilterArgId = Math.max(maxFilterArgId, filterArgIds[i]);
+      _filterArgIds[i] = filterArgs.get(i);
+      maxFilterArgId = Math.max(maxFilterArgId, _filterArgIds[i]);
     }
+    _maxFilterArgId = maxFilterArgId;
 
     /// Grouping-set aggregates never reach this operator directly: PlanNodeToOpChain pre-wraps the input in a
     /// RepeatOperator and rewrites the node into the equivalent plain GROUP BY over the expanded input.
     List<Integer> groupKeys = node.getGroupKeys();
+    _groupKeyIds = getGroupKeyIds(groupKeys);
     _input = input;
+    _aggType = node.getAggType();
+    _leafReturnFinalResult = node.isLeafReturnFinalResult();
+    _opChainMetadata = context.getOpChainMetadata();
+    _nodeHint = node.getNodeHint();
 
     int groupTrimSize = Integer.MAX_VALUE;
     Comparator<Object[]> comparator = null;
@@ -131,21 +157,56 @@ public class AggregateOperator extends MultiStageOperator {
     _comparator = comparator;
 
     _errorOnNumGroupsLimit = getErrorOnNumGroupsLimit(node.getNodeHint(), context.getOpChainMetadata());
+    _numGroupsLimit = MultistageGroupByExecutor.getNumGroupsLimit(_opChainMetadata, _nodeHint);
+    int spillThreshold = 0;
+    int spillPartitions = Server.DEFAULT_MSE_AGGREGATION_SPILL_PARTITIONS;
+    boolean spillEligible = !groupKeys.isEmpty() && !_leafReturnFinalResult
+        && groupTrimSize == Integer.MAX_VALUE && QueryOptionsUtils.isMSEAggregationSpillEnabled(_opChainMetadata);
+    if (spillEligible) {
+      Integer configuredSpillThreshold = QueryOptionsUtils.getMSEAggregationSpillThreshold(_opChainMetadata);
+      if (configuredSpillThreshold != null) {
+        spillThreshold = configuredSpillThreshold;
+        Integer configuredSpillPartitions = QueryOptionsUtils.getMSEAggregationSpillPartitions(_opChainMetadata);
+        if (configuredSpillPartitions != null) {
+          spillPartitions = configuredSpillPartitions;
+        }
+      }
+    }
+    _spillThreshold = spillThreshold;
+    _spillPartitions = spillPartitions;
 
     // Initialize the appropriate executor.
-    AggregateNode.AggType aggType = node.getAggType();
     // TODO: Allow leaf return final result for non-group-by queries
-    boolean leafReturnFinalResult = node.isLeafReturnFinalResult();
     if (groupKeys.isEmpty()) {
       _aggregationExecutor =
-          new MultistageAggregationExecutor(_aggFunctions, filterArgIds, maxFilterArgId, aggType, _resultSchema);
+          new MultistageAggregationExecutor(_aggFunctions, _filterArgIds, _maxFilterArgId, _aggType, _resultSchema);
       _groupByExecutor = null;
     } else {
-      _groupByExecutor =
-          new MultistageGroupByExecutor(getGroupKeyIds(groupKeys), _aggFunctions, filterArgIds, maxFilterArgId, aggType,
-              leafReturnFinalResult, _resultSchema, context.getOpChainMetadata(), node.getNodeHint());
+      _groupByExecutor = newInputGroupByExecutor();
       _aggregationExecutor = null;
     }
+  }
+
+  private MultistageGroupByExecutor newInputGroupByExecutor() {
+    if (_spillThreshold > 0) {
+      return MultistageGroupByExecutor.forSpillInput(_groupKeyIds, _aggFunctions, _filterArgIds, _maxFilterArgId,
+          _aggType, _resultSchema, _opChainMetadata, _nodeHint, _spillThreshold);
+    }
+    return new MultistageGroupByExecutor(_groupKeyIds, _aggFunctions, _filterArgIds, _maxFilterArgId, _aggType,
+        _leafReturnFinalResult, _resultSchema, _opChainMetadata, _nodeHint);
+  }
+
+  private MultistageGroupByExecutor newSpillMergeGroupByExecutor() {
+    AggregateNode.AggType mergeAggType =
+        _aggType.isOutputIntermediateFormat() ? AggregateNode.AggType.INTERMEDIATE : AggregateNode.AggType.FINAL;
+    int[] spillGroupKeyIds = new int[_groupKeyIds.length];
+    for (int i = 0; i < spillGroupKeyIds.length; i++) {
+      spillGroupKeyIds[i] = i;
+    }
+    int expectedPartitionGroups =
+        (int) Math.max(1L, ((long) _spillThreshold + _spillPartitions - 1) / _spillPartitions);
+    return MultistageGroupByExecutor.forSpillMerge(spillGroupKeyIds, _aggFunctions, _filterArgIds, _maxFilterArgId,
+        mergeAggType, _resultSchema, _opChainMetadata, _nodeHint, expectedPartitionGroups);
   }
 
   private static int getMinGroupTrimSize(PlanNode.NodeHint nodeHint, Map<String, String> opChainMetadata) {
@@ -197,20 +258,53 @@ public class AggregateOperator extends MultiStageOperator {
   }
 
   @Override
-  protected MseBlock getNextBlock() {
-    if (_eosBlock != null) {
-      return _eosBlock;
+  protected MseBlock getNextBlock()
+      throws Exception {
+    try {
+      return getNextBlockInternal();
+    } catch (Exception e) {
+      try {
+        closeSpillManager();
+      } catch (Exception cleanupException) {
+        e.addSuppressed(cleanupException);
+      }
+      throw e;
     }
-    MseBlock.Eos finalBlock = _aggregationExecutor != null ? consumeAggregation() : consumeGroupBy();
-    _eosBlock = finalBlock;
+  }
 
-    if (finalBlock.isError()) {
-      return finalBlock;
+  private MseBlock getNextBlockInternal() {
+    if (!_inputConsumed) {
+      _eosBlock = _aggregationExecutor != null ? consumeAggregation() : consumeGroupBy();
+      _inputConsumed = true;
+      if (_eosBlock.isError()) {
+        try {
+          closeSpillManager();
+        } catch (Exception e) {
+          LOGGER.warn("Failed to clean up aggregation spill after upstream error", e);
+        }
+        return _eosBlock;
+      }
+      if (_spillManager == null) {
+        MseBlock block = produceAggregatedBlock();
+        _aggregationExecutor = null;
+        _groupByExecutor = null;
+        return block;
+      }
+      spillCurrentGroups();
+      _groupByExecutor = null;
     }
-    MseBlock mseBlock = produceAggregatedBlock();
-    _aggregationExecutor = null;
-    _groupByExecutor = null;
-    return mseBlock;
+
+    if (_spillManager != null) {
+      while (_nextSpillPartition < _spillManager.getNumPartitions()) {
+        MseBlock.Data block = restoreSpillPartition(_nextSpillPartition++);
+        if (block != null) {
+          return block;
+        }
+      }
+      closeSpillManagerQuietly("end of stream");
+    }
+    assert _eosBlock != null;
+    return _eosBlock;
   }
 
   private MseBlock produceAggregatedBlock() {
@@ -219,14 +313,17 @@ public class AggregateOperator extends MultiStageOperator {
     } else {
       assert _groupByExecutor != null;
       List<Object[]> rows;
+      int maxRows = _spillThreshold > 0 ? Math.min(_groupTrimSize, _numGroupsLimit) : _groupTrimSize;
       if (_comparator != null) {
-        rows = _groupByExecutor.getResult(_comparator, _groupTrimSize);
+        rows = _groupByExecutor.getResult(_comparator, maxRows);
       } else {
-        rows = _groupByExecutor.getResult(_groupTrimSize);
+        rows = _groupByExecutor.getResult(maxRows);
       }
 
       // Record stat before we check for limit so we can propagate to query response
-      _statMap.merge(StatKey.NUM_GROUPS, _groupByExecutor.getNumGroups());
+      int numGroups = _spillThreshold > 0
+          ? Math.min(_groupByExecutor.getNumGroups(), _numGroupsLimit) : _groupByExecutor.getNumGroups();
+      _statMap.merge(StatKey.NUM_GROUPS, numGroups);
 
       if (rows.isEmpty()) {
         return _eosBlock;
@@ -236,7 +333,9 @@ public class AggregateOperator extends MultiStageOperator {
           _statMap.merge(StatKey.GROUPS_TRIMMED, true);
         }
 
-        if (_groupByExecutor.isNumGroupsLimitReached()) {
+        boolean numGroupsLimitReached = _spillThreshold > 0
+            ? _groupByExecutor.getNumGroups() >= _numGroupsLimit : _groupByExecutor.isNumGroupsLimitReached();
+        if (numGroupsLimitReached) {
           if (_errorOnNumGroupsLimit) {
             throw QueryErrorCode.SERVER_RESOURCE_LIMIT_EXCEEDED.asException(
                 "NUM_GROUPS_LIMIT has been reached at: " + _operatorId);
@@ -245,9 +344,9 @@ public class AggregateOperator extends MultiStageOperator {
             _input.earlyTerminate();
           }
         }
-        if (_groupByExecutor.getNumGroups() >= _groupByExecutor.getNumGroupsWarningLimit()) {
+        if (numGroups >= _groupByExecutor.getNumGroupsWarningLimit()) {
           LOGGER.warn("numGroups reached warning limit: {} (actual: {})",
-              _groupByExecutor.getNumGroupsWarningLimit(), _groupByExecutor.getNumGroups());
+              _groupByExecutor.getNumGroupsWarningLimit(), numGroups);
           _statMap.merge(StatKey.NUM_GROUPS_WARNING_LIMIT_REACHED, true);
         }
         return dataBlock;
@@ -268,10 +367,85 @@ public class AggregateOperator extends MultiStageOperator {
     MseBlock block = _input.nextBlock();
     while (block.isData()) {
       _groupByExecutor.processBlock((MseBlock.Data) block);
+      if (_spillThreshold > 0 && _groupByExecutor.getNumGroups() >= _spillThreshold) {
+        spillCurrentGroups();
+      }
       checkTerminationAndSampleUsage();
       block = _input.nextBlock();
     }
     return (MseBlock.Eos) block;
+  }
+
+  private void spillCurrentGroups() {
+    assert _groupByExecutor != null;
+    if (_groupByExecutor.getNumGroups() == 0) {
+      return;
+    }
+    if (_spillManager == null) {
+      _spillManager =
+          new AggregationSpillManager(_spillPartitions, _groupKeyIds.length, getSpillSchema(), _aggFunctions);
+      _spillDirectory = _spillManager.getSpillDirectory();
+    }
+    AggregationSpillManager.SpillResult spillResult =
+        _spillManager.spill(_groupByExecutor.getIntermediateResultIterator());
+    _statMap.merge(StatKey.SPILL_COUNT, 1L);
+    _statMap.merge(StatKey.SPILLED_ROWS, spillResult.getRows());
+    _statMap.merge(StatKey.SPILLED_BYTES, spillResult.getBytes());
+    _groupByExecutor = newInputGroupByExecutor();
+  }
+
+  private DataSchema getSpillSchema() {
+    String[] columnNames = _resultSchema.getColumnNames().clone();
+    ColumnDataType[] columnDataTypes = _resultSchema.getColumnDataTypes().clone();
+    int numKeys = _groupKeyIds.length;
+    for (int i = 0; i < _aggFunctions.length; i++) {
+      columnDataTypes[numKeys + i] = _aggFunctions[i].getType() == AggregationFunctionType.ANYVALUE
+          ? ColumnDataType.OBJECT : _aggFunctions[i].getIntermediateResultColumnType();
+    }
+    return new DataSchema(columnNames, columnDataTypes);
+  }
+
+  @Nullable
+  private MseBlock.Data restoreSpillPartition(int partitionId) {
+    assert _spillManager != null;
+    if (!_spillManager.hasPartition(partitionId)) {
+      return null;
+    }
+    MultistageGroupByExecutor executor = newSpillMergeGroupByExecutor();
+    _spillManager.consumePartition(partitionId, block -> {
+      executor.processSpillBlock(block);
+      if (executor.getNumGroups() > _spillThreshold) {
+        throw QueryErrorCode.SERVER_RESOURCE_LIMIT_EXCEEDED.asException(
+            "Aggregation spill partition exceeds the configured threshold at: " + _operatorId
+                + ". Increase mseAggregationSpillThreshold or mseAggregationSpillPartitions");
+      }
+    });
+    int numGroups = executor.getNumGroups();
+    if (numGroups == 0) {
+      return null;
+    }
+
+    int numGroupsLimit = executor.getNumGroupsLimit();
+    int remainingGroups = numGroupsLimit - _numSpilledGroupsProduced;
+    List<Object[]> rows = remainingGroups > 0 ? executor.getResult(remainingGroups) : List.of();
+    _numSpilledGroupsProduced += rows.size();
+    _statMap.merge(StatKey.NUM_GROUPS, _numSpilledGroupsProduced);
+
+    if (_numSpilledGroupsProduced >= numGroupsLimit) {
+      if (_errorOnNumGroupsLimit) {
+        throw QueryErrorCode.SERVER_RESOURCE_LIMIT_EXCEEDED.asException(
+            "NUM_GROUPS_LIMIT has been reached at: " + _operatorId);
+      }
+      _statMap.merge(StatKey.NUM_GROUPS_LIMIT_REACHED, true);
+      _input.earlyTerminate();
+      _nextSpillPartition = _spillManager.getNumPartitions();
+    }
+    if (_numSpilledGroupsProduced >= executor.getNumGroupsWarningLimit()) {
+      LOGGER.warn("numGroups reached warning limit: {} (actual: {})", executor.getNumGroupsWarningLimit(),
+          _numSpilledGroupsProduced);
+      _statMap.merge(StatKey.NUM_GROUPS_WARNING_LIMIT_REACHED, true);
+    }
+    return rows.isEmpty() ? null : new RowHeapDataBlock(rows, _resultSchema, _aggFunctions);
   }
 
   /// Consumes the input blocks as an aggregation
@@ -477,7 +651,10 @@ public class AggregateOperator extends MultiStageOperator {
     /// Allocated memory in bytes for this operator or its children in the same stage.
     ALLOCATED_MEMORY_BYTES(StatMap.Type.LONG),
     /// Time spent on GC while this operator or its children in the same stage were running.
-    GC_TIME_MS(StatMap.Type.LONG);
+    GC_TIME_MS(StatMap.Type.LONG),
+    SPILL_COUNT(StatMap.Type.LONG),
+    SPILLED_ROWS(StatMap.Type.LONG),
+    SPILLED_BYTES(StatMap.Type.LONG);
 
     private final StatMap.Type _type;
 
@@ -494,5 +671,44 @@ public class AggregateOperator extends MultiStageOperator {
   @VisibleForTesting
   int getGroupTrimSize() {
     return _groupTrimSize;
+  }
+
+  @VisibleForTesting
+  @Nullable
+  Path getSpillDirectory() {
+    return _spillDirectory;
+  }
+
+  private void closeSpillManager() {
+    if (_spillManager != null) {
+      _spillManager.close();
+      _spillManager = null;
+    }
+  }
+
+  private void closeSpillManagerQuietly(String action) {
+    try {
+      closeSpillManager();
+    } catch (RuntimeException e) {
+      LOGGER.warn("Failed to clean up aggregation spill during {}", action, e);
+    }
+  }
+
+  @Override
+  protected void earlyTerminate() {
+    closeSpillManagerQuietly("early termination");
+    super.earlyTerminate();
+  }
+
+  @Override
+  public void close() {
+    closeSpillManagerQuietly("close");
+    super.close();
+  }
+
+  @Override
+  public void cancel(Throwable e) {
+    closeSpillManagerQuietly("cancellation");
+    super.cancel(e);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregationSpillManager.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregationSpillManager.java
@@ -1,0 +1,428 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.apache.pinot.common.datablock.DataBlock;
+import org.apache.pinot.common.datablock.DataBlockUtils;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.query.runtime.blocks.MseBlock;
+import org.apache.pinot.query.runtime.blocks.RowHeapDataBlock;
+import org.apache.pinot.query.runtime.blocks.SerializedDataBlock;
+import org.apache.pinot.spi.query.QueryThreadContext;
+import org.apache.pinot.spi.utils.CommonConstants.Server;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/// Manages hash-partitioned aggregation spill files for one operator. The caller must finish reading before calling
+/// [#close()], which recursively removes the operator-scoped directory. This class is not thread-safe.
+@SuppressWarnings("rawtypes")
+class AggregationSpillManager implements AutoCloseable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AggregationSpillManager.class);
+  private static final String SPILL_FILE_PREFIX = "partition-";
+  private static final String SPILL_FILE_SUFFIX = ".spill";
+  private static final String SPILL_SCOPE = "AggregationSpillManager#spill";
+  private static final String RESTORE_SCOPE = "AggregationSpillManager#consumePartition";
+  private static final int MAX_BUFFERED_ROWS = 1024;
+  private static final int MAX_BUFFERED_PARTITIONS = 8;
+
+  private final int _numPartitions;
+  private final int _numGroupKeys;
+  private final DataSchema _spillSchema;
+  private final AggregationFunction[] _aggFunctions;
+  private final Path _spillDirectory;
+  private final Map<Integer, FileChannel> _spillWriters = new HashMap<>();
+  private final ByteBuffer _recordLengthBuffer = ByteBuffer.allocate(Integer.BYTES);
+
+  AggregationSpillManager(int numPartitions, int numGroupKeys, DataSchema spillSchema,
+      AggregationFunction[] aggFunctions) {
+    if (numPartitions <= 0 || numPartitions > Server.MAX_MSE_AGGREGATION_SPILL_PARTITIONS) {
+      throw new IllegalArgumentException(
+          "Number of spill partitions must be between 1 and " + Server.MAX_MSE_AGGREGATION_SPILL_PARTITIONS);
+    }
+    if (numGroupKeys < 0 || numGroupKeys > spillSchema.size()) {
+      throw new IllegalArgumentException("Invalid number of group keys: " + numGroupKeys);
+    }
+    _numPartitions = numPartitions;
+    _numGroupKeys = numGroupKeys;
+    _spillSchema = spillSchema;
+    _aggFunctions = aggFunctions;
+    try {
+      _spillDirectory = Files.createTempDirectory("pinot-aggregation-spill-");
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to create aggregation spill directory", e);
+    }
+  }
+
+  SpillResult spill(Iterator<Object[]> rows) {
+    List<Object[]>[] partitions = createPartitions();
+    boolean[] touched = new boolean[_numPartitions];
+    int[] touchedPartitions = new int[_numPartitions];
+    int numTouchedPartitions = 0;
+    int numRows = 0;
+    int numBufferedRows = 0;
+    long serializedBytes = 0;
+    int numRowsProcessed = 0;
+    int maxBufferedRows = MAX_BUFFERED_ROWS * Math.min(_numPartitions, MAX_BUFFERED_PARTITIONS);
+    while (rows.hasNext()) {
+      QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numRowsProcessed++, SPILL_SCOPE);
+      Object[] row = rows.next();
+      int partitionId = getPartition(row);
+      List<Object[]> partition = partitions[partitionId];
+      if (partition == null) {
+        partition = new ArrayList<>();
+        partitions[partitionId] = partition;
+      }
+      if (!touched[partitionId]) {
+        touched[partitionId] = true;
+        touchedPartitions[numTouchedPartitions++] = partitionId;
+      }
+      partition.add(row);
+      numRows++;
+      numBufferedRows++;
+      if (partition.size() == MAX_BUFFERED_ROWS) {
+        serializedBytes += appendPartition(partitionId, partition);
+        partition.clear();
+        numBufferedRows -= MAX_BUFFERED_ROWS;
+      }
+      if (numBufferedRows >= maxBufferedRows) {
+        serializedBytes += flushPartitions(partitions, touched, touchedPartitions, numTouchedPartitions);
+        numTouchedPartitions = 0;
+        numBufferedRows = 0;
+      }
+    }
+    if (numTouchedPartitions > 0) {
+      serializedBytes += flushPartitions(partitions, touched, touchedPartitions, numTouchedPartitions);
+    }
+    return new SpillResult(numRows, serializedBytes);
+  }
+
+  boolean hasPartition(int partitionId) {
+    checkPartitionId(partitionId);
+    return Files.exists(getSpillFile(partitionId));
+  }
+
+  /// Consumes all records from a partition and deletes its file after the attempt, including when reading or
+  /// processing fails.
+  void consumePartition(int partitionId, Consumer<MseBlock.Data> consumer) {
+    checkPartitionId(partitionId);
+    Path spillFile = getSpillFile(partitionId);
+    if (!Files.exists(spillFile)) {
+      return;
+    }
+
+    RuntimeException failure = null;
+    closeSpillWriter(partitionId);
+    try (DataInputStream input =
+        new DataInputStream(new BufferedInputStream(Files.newInputStream(spillFile)))) {
+      long remainingBytes = Files.size(spillFile);
+      int numRecordsRead = 0;
+      while (remainingBytes > 0) {
+        QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numRecordsRead++, RESTORE_SCOPE);
+        if (remainingBytes < Integer.BYTES) {
+          throw new IOException("Truncated spill record length in: " + spillFile);
+        }
+        int recordLength = input.readInt();
+        remainingBytes -= Integer.BYTES;
+        if (recordLength < 0 || recordLength > remainingBytes) {
+          throw new IOException("Invalid spill record length " + recordLength + " in: " + spillFile);
+        }
+        byte[] bytes = input.readNBytes(recordLength);
+        if (bytes.length != recordLength) {
+          throw new IOException("Truncated spill record in: " + spillFile);
+        }
+        remainingBytes -= recordLength;
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        DataBlock dataBlock = DataBlockUtils.readFrom(buffer);
+        if (buffer.hasRemaining()) {
+          throw new IOException("Trailing bytes in aggregation spill record: " + spillFile);
+        }
+        consumer.accept(new SerializedDataBlock(dataBlock));
+      }
+    } catch (IOException e) {
+      failure = new UncheckedIOException("Failed to read aggregation spill partition: " + partitionId, e);
+      throw failure;
+    } catch (RuntimeException e) {
+      failure = e;
+      throw e;
+    } finally {
+      try {
+        deleteSpillFile(spillFile);
+      } catch (RuntimeException e) {
+        if (failure != null) {
+          failure.addSuppressed(e);
+        } else {
+          LOGGER.warn("Failed to delete consumed aggregation spill partition; close will retry: {}", spillFile, e);
+        }
+      }
+    }
+  }
+
+  int getNumPartitions() {
+    return _numPartitions;
+  }
+
+  Path getSpillDirectory() {
+    return _spillDirectory;
+  }
+
+  @VisibleForTesting
+  int getNumOpenSpillWriters() {
+    return _spillWriters.size();
+  }
+
+  @Override
+  public void close() {
+    if (!Files.exists(_spillDirectory)) {
+      return;
+    }
+    RuntimeException failure = null;
+    try {
+      closeSpillWriters();
+    } catch (RuntimeException e) {
+      failure = e;
+    }
+    try {
+      Files.walkFileTree(_spillDirectory, new SimpleFileVisitor<>() {
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+            throws IOException {
+          Files.delete(file);
+          return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(Path directory, IOException exception)
+            throws IOException {
+          if (exception != null) {
+            throw exception;
+          }
+          Files.delete(directory);
+          return FileVisitResult.CONTINUE;
+        }
+      });
+    } catch (IOException e) {
+      RuntimeException cleanupFailure =
+          new UncheckedIOException("Failed to delete aggregation spill directory", e);
+      if (failure != null) {
+        failure.addSuppressed(cleanupFailure);
+      } else {
+        failure = cleanupFailure;
+      }
+    }
+    if (failure != null) {
+      throw failure;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Object[]>[] createPartitions() {
+    return new List[_numPartitions];
+  }
+
+  private long flushPartitions(List<Object[]>[] partitions, boolean[] touched, int[] touchedPartitions,
+      int numTouchedPartitions) {
+    long serializedBytes = 0;
+    for (int i = 0; i < numTouchedPartitions; i++) {
+      QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, SPILL_SCOPE);
+      int partitionId = touchedPartitions[i];
+      List<Object[]> partition = partitions[partitionId];
+      if (!partition.isEmpty()) {
+        serializedBytes += appendPartition(partitionId, partition);
+        partition.clear();
+      }
+      touched[partitionId] = false;
+    }
+    return serializedBytes;
+  }
+
+  private int getPartition(Object[] row) {
+    int hash = 1;
+    for (int i = 0; i < _numGroupKeys; i++) {
+      hash = 31 * hash + deepHashCode(row[i]);
+    }
+    return Math.floorMod(hash, _numPartitions);
+  }
+
+  @VisibleForTesting
+  static int deepHashCode(Object value) {
+    if (value instanceof Object[]) {
+      return Arrays.deepHashCode((Object[]) value);
+    }
+    if (value instanceof byte[]) {
+      return Arrays.hashCode((byte[]) value);
+    }
+    if (value instanceof short[]) {
+      return Arrays.hashCode((short[]) value);
+    }
+    if (value instanceof int[]) {
+      return Arrays.hashCode((int[]) value);
+    }
+    if (value instanceof long[]) {
+      return Arrays.hashCode((long[]) value);
+    }
+    if (value instanceof char[]) {
+      return Arrays.hashCode((char[]) value);
+    }
+    if (value instanceof float[]) {
+      return Arrays.hashCode((float[]) value);
+    }
+    if (value instanceof double[]) {
+      return Arrays.hashCode((double[]) value);
+    }
+    if (value instanceof boolean[]) {
+      return Arrays.hashCode((boolean[]) value);
+    }
+    return value != null ? value.hashCode() : 0;
+  }
+
+  private long appendPartition(int partitionId, List<Object[]> rows) {
+    DataBlock dataBlock = new RowHeapDataBlock(rows, _spillSchema, _aggFunctions).asSerialized().getDataBlock();
+    try {
+      List<ByteBuffer> buffers = dataBlock.serialize();
+      int recordLength = getRecordLength(buffers);
+      FileChannel output = getSpillWriter(partitionId);
+      _recordLengthBuffer.clear();
+      _recordLengthBuffer.putInt(recordLength).flip();
+      writeFully(output, _recordLengthBuffer);
+      for (ByteBuffer buffer : buffers) {
+        writeFully(output, buffer);
+      }
+      return Integer.BYTES + (long) recordLength;
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to spill aggregation partition: " + partitionId, e);
+    }
+  }
+
+  private static int getRecordLength(List<ByteBuffer> buffers) {
+    long length = 0;
+    for (ByteBuffer buffer : buffers) {
+      length += buffer.remaining();
+    }
+    if (length > Integer.MAX_VALUE) {
+      throw new IllegalStateException("Aggregation spill record exceeds maximum length: " + length);
+    }
+    return (int) length;
+  }
+
+  private FileChannel getSpillWriter(int partitionId)
+      throws IOException {
+    FileChannel writer = _spillWriters.get(partitionId);
+    if (writer != null) {
+      return writer;
+    }
+    writer = FileChannel.open(getSpillFile(partitionId), StandardOpenOption.CREATE, StandardOpenOption.WRITE,
+        StandardOpenOption.APPEND);
+    _spillWriters.put(partitionId, writer);
+    return writer;
+  }
+
+  private static void writeFully(FileChannel output, ByteBuffer buffer)
+      throws IOException {
+    while (buffer.hasRemaining()) {
+      output.write(buffer);
+    }
+  }
+
+  private void closeSpillWriter(int partitionId) {
+    FileChannel writer = _spillWriters.remove(partitionId);
+    if (writer != null) {
+      try {
+        writer.close();
+      } catch (IOException e) {
+        throw new UncheckedIOException("Failed to close aggregation spill partition: " + partitionId, e);
+      }
+    }
+  }
+
+  private void closeSpillWriters() {
+    IOException failure = null;
+    for (FileChannel writer : _spillWriters.values()) {
+      try {
+        writer.close();
+      } catch (IOException e) {
+        if (failure == null) {
+          failure = e;
+        } else {
+          failure.addSuppressed(e);
+        }
+      }
+    }
+    _spillWriters.clear();
+    if (failure != null) {
+      throw new UncheckedIOException("Failed to close aggregation spill files", failure);
+    }
+  }
+
+  private void checkPartitionId(int partitionId) {
+    if (partitionId < 0 || partitionId >= _numPartitions) {
+      throw new IllegalArgumentException("Invalid spill partition id: " + partitionId);
+    }
+  }
+
+  private Path getSpillFile(int partitionId) {
+    return _spillDirectory.resolve(SPILL_FILE_PREFIX + partitionId + SPILL_FILE_SUFFIX);
+  }
+
+  void deleteSpillFile(Path spillFile) {
+    try {
+      Files.deleteIfExists(spillFile);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to delete aggregation spill file: " + spillFile, e);
+    }
+  }
+
+  static final class SpillResult {
+    private final int _rows;
+    private final long _serializedBytes;
+
+    SpillResult(int rows, long serializedBytes) {
+      _rows = rows;
+      _serializedBytes = serializedBytes;
+    }
+
+    int getRows() {
+      return _rows;
+    }
+
+    long getBytes() {
+      return _serializedBytes;
+    }
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
@@ -44,6 +44,7 @@ import org.apache.pinot.query.runtime.blocks.MseBlock;
 import org.apache.pinot.query.runtime.operator.groupby.GroupIdGenerator;
 import org.apache.pinot.query.runtime.operator.groupby.GroupIdGeneratorFactory;
 import org.apache.pinot.query.runtime.operator.utils.TypeUtils;
+import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.RoaringBitmap;
@@ -52,6 +53,9 @@ import org.roaringbitmap.RoaringBitmap;
 /// Class that executes the keyed group by aggregations for the multistage AggregateOperator.
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class MultistageGroupByExecutor {
+  private static final String EXPORT_SPILL_ROWS_SCOPE = "MultistageGroupByExecutor#getIntermediateResultIterator";
+  private static final String MERGE_SPILL_ROWS_SCOPE = "MultistageGroupByExecutor#processSpillBlock";
+
   private final int[] _groupKeyIds;
   private final AggregationFunction[] _aggFunctions;
   private final int[] _filterArgIds;
@@ -75,6 +79,28 @@ public class MultistageGroupByExecutor {
   public MultistageGroupByExecutor(int[] groupKeyIds, AggregationFunction[] aggFunctions, int[] filterArgIds,
       int maxFilterArgId, AggType aggType, boolean leafReturnFinalResult, DataSchema resultSchema,
       Map<String, String> opChainMetadata, @Nullable PlanNode.NodeHint nodeHint) {
+    this(groupKeyIds, aggFunctions, filterArgIds, maxFilterArgId, aggType, leafReturnFinalResult, resultSchema,
+        opChainMetadata, nodeHint, null, null);
+  }
+
+  static MultistageGroupByExecutor forSpillInput(int[] groupKeyIds, AggregationFunction[] aggFunctions,
+      int[] filterArgIds, int maxFilterArgId, AggType aggType, DataSchema resultSchema,
+      Map<String, String> opChainMetadata, PlanNode.NodeHint nodeHint, int spillThreshold) {
+    return new MultistageGroupByExecutor(groupKeyIds, aggFunctions, filterArgIds, maxFilterArgId, aggType, false,
+        resultSchema, opChainMetadata, nodeHint, Integer.MAX_VALUE, spillThreshold);
+  }
+
+  static MultistageGroupByExecutor forSpillMerge(int[] groupKeyIds, AggregationFunction[] aggFunctions,
+      int[] filterArgIds, int maxFilterArgId, AggType aggType, DataSchema resultSchema,
+      Map<String, String> opChainMetadata, PlanNode.NodeHint nodeHint, int maxInitialCapacity) {
+    return new MultistageGroupByExecutor(groupKeyIds, aggFunctions, filterArgIds, maxFilterArgId, aggType, false,
+        resultSchema, opChainMetadata, nodeHint, null, maxInitialCapacity);
+  }
+
+  private MultistageGroupByExecutor(int[] groupKeyIds, AggregationFunction[] aggFunctions, int[] filterArgIds,
+      int maxFilterArgId, AggType aggType, boolean leafReturnFinalResult, DataSchema resultSchema,
+      Map<String, String> opChainMetadata, @Nullable PlanNode.NodeHint nodeHint, @Nullable Integer numGroupsLimit,
+      @Nullable Integer maxInitialCapacity) {
     _groupKeyIds = groupKeyIds;
     _aggFunctions = aggFunctions;
     _filterArgIds = filterArgIds;
@@ -84,8 +110,11 @@ public class MultistageGroupByExecutor {
     _resultSchema = resultSchema;
 
     int maxInitialResultHolderCapacity = getResolvedMaxInitialResultHolderCapacity(opChainMetadata, nodeHint);
+    if (maxInitialCapacity != null) {
+      maxInitialResultHolderCapacity = Math.min(maxInitialResultHolderCapacity, maxInitialCapacity);
+    }
 
-    _numGroupsLimit = getNumGroupsLimit(opChainMetadata, nodeHint);
+    _numGroupsLimit = numGroupsLimit != null ? numGroupsLimit : getNumGroupsLimit(opChainMetadata, nodeHint);
     _numGroupsWarningLimit = getNumGroupsWarningLimit(opChainMetadata);
 
     // By default, we compute all groups for SQL compliant results. However, we allow overriding this behavior via
@@ -110,7 +139,7 @@ public class MultistageGroupByExecutor {
             _numGroupsLimit, maxInitialResultHolderCapacity);
   }
 
-  private int getNumGroupsLimit(Map<String, String> opChainMetadata, @Nullable PlanNode.NodeHint nodeHint) {
+  static int getNumGroupsLimit(Map<String, String> opChainMetadata, @Nullable PlanNode.NodeHint nodeHint) {
     if (nodeHint != null) {
       Map<String, String> aggregateOptions = nodeHint.getHintOptions().get(PinotHintOptions.AGGREGATE_HINT_OPTIONS);
       if (aggregateOptions != null) {
@@ -184,6 +213,70 @@ public class MultistageGroupByExecutor {
     } else {
       processMerge(block);
     }
+  }
+
+  /// Returns all current groups with mergeable aggregation intermediate states.
+  Iterator<Object[]> getIntermediateResultIterator() {
+    int numGroups = _groupIdGenerator.getNumGroups();
+    if (numGroups == 0) {
+      return List.<Object[]>of().iterator();
+    }
+    int numKeys = _groupKeyIds.length;
+    int numFunctions = _aggFunctions.length;
+    Iterator<GroupIdGenerator.GroupKey> groupKeyIterator =
+        _groupIdGenerator.getGroupKeyIterator(numKeys + numFunctions);
+    return new Iterator<>() {
+      private int _numGroupsProcessed;
+
+      @Override
+      public boolean hasNext() {
+        return groupKeyIterator.hasNext();
+      }
+
+      @Override
+      public Object[] next() {
+        QueryThreadContext.checkTerminationAndSampleUsagePeriodically(_numGroupsProcessed++,
+            EXPORT_SPILL_ROWS_SCOPE);
+        GroupIdGenerator.GroupKey groupKey = groupKeyIterator.next();
+        Object[] row = groupKey._row;
+        int groupId = groupKey._groupId;
+        for (int i = 0; i < numFunctions; i++) {
+          row[numKeys + i] = _aggregateResultHolders != null
+              ? _aggFunctions[i].extractGroupByResult(_aggregateResultHolders[i], groupId)
+              : _mergeResultHolder.get(groupId)[i];
+        }
+        return row;
+      }
+    };
+  }
+
+  /// Merges a block produced by [#getIntermediateResultIterator()]. Group keys occupy the first columns, followed by
+  /// one intermediate-state column per aggregation function.
+  void processSpillBlock(MseBlock.Data block) {
+    int[] groupByKeys = generateGroupByKeys(block);
+    int numRows = groupByKeys.length;
+    int numFunctions = _aggFunctions.length;
+    int numKeys = _groupKeyIds.length;
+    Object[][] intermediateResults = new Object[numFunctions][];
+    if (block.isRowHeap()) {
+      List<Object[]> rows = block.asRowHeap().getRows();
+      for (int functionId = 0; functionId < numFunctions; functionId++) {
+        intermediateResults[functionId] = new Object[numRows];
+        Object[] values = intermediateResults[functionId];
+        int columnId = numKeys + functionId;
+        for (int rowId = 0; rowId < numRows; rowId++) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(rowId, MERGE_SPILL_ROWS_SCOPE);
+          values[rowId] = rows.get(rowId)[columnId];
+        }
+      }
+    } else {
+      DataBlock dataBlock = block.asSerialized().getDataBlock();
+      for (int functionId = 0; functionId < numFunctions; functionId++) {
+        intermediateResults[functionId] =
+            DataBlockExtractUtils.extractAggResult(dataBlock, numKeys + functionId, _aggFunctions[functionId]);
+      }
+    }
+    mergeIntermediateResults(groupByKeys, intermediateResults);
   }
 
   /// Get aggregation result limited to first `maxRows` rows, ordered with `comparator`.
@@ -376,6 +469,12 @@ public class MultistageGroupByExecutor {
     for (int i = 0; i < numFunctions; i++) {
       intermediateResults[i] = AggregateOperator.getIntermediateResults(_aggFunctions[i], block);
     }
+    mergeIntermediateResults(groupByKeys, intermediateResults);
+  }
+
+  private void mergeIntermediateResults(int[] groupByKeys, Object[][] intermediateResults) {
+    int numRows = groupByKeys.length;
+    int numFunctions = _aggFunctions.length;
     if (_leafReturnFinalResult) {
       for (int i = 0; i < numRows; i++) {
         int groupByKey = groupByKeys[i];

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
@@ -61,7 +61,7 @@ public class QueryServerEnclosure {
     InstanceDataManager instanceDataManager = factory.buildInstanceDataManager();
     _queryRunner = new QueryRunner();
     _queryRunner.init(new PinotConfiguration(runnerConfig), instanceDataManager.getInstanceId(), instanceDataManager,
-        null, () -> true, () -> true);
+        null, () -> true, () -> true, () -> true);
   }
 
   public int getPort() {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerMetadataTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerMetadataTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime;
+
+import java.util.Map;
+import org.apache.pinot.query.runtime.SendStatsPredicate.Mode;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
+import org.apache.pinot.spi.utils.CommonConstants.Server;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+/// Tests server-owned query metadata consolidation.
+public class QueryRunnerMetadataTest {
+  @DataProvider(name = "userMetadata")
+  public Object[][] userMetadata() {
+    Map<String, String> enabled = Map.of(QueryOptionKey.MSE_AGGREGATION_SPILL_ENABLED, "true");
+    return new Object[][]{{enabled, Map.of()}, {Map.of(), enabled}};
+  }
+
+  @DataProvider(name = "spillStatsCompatibility")
+  public Object[][] spillStatsCompatibility() {
+    return new Object[][]{
+        {Mode.ALWAYS, true, false},
+        {Mode.ALWAYS, false, false},
+        {Mode.SAFE, true, true},
+        {Mode.SAFE, false, false},
+        {Mode.NEVER, true, false},
+        {Mode.NEVER, false, false}
+    };
+  }
+
+  @Test(dataProvider = "userMetadata")
+  public void testServerSpillGateOverridesUserMetadata(Map<String, String> customProperties,
+      Map<String, String> requestMetadata) {
+    QueryRunner queryRunner = new QueryRunner();
+    queryRunner.initAggregationSpillConfig(new PinotConfiguration());
+    Map<String, String> metadata = queryRunner.consolidateMetadata(customProperties, requestMetadata, true);
+
+    assertEquals(metadata.get(QueryOptionKey.MSE_AGGREGATION_SPILL_ENABLED), "false");
+  }
+
+  @Test
+  public void testConfiguredSpillGateRequiresCompatibleStats() {
+    QueryRunner queryRunner = new QueryRunner();
+    queryRunner.initAggregationSpillConfig(
+        new PinotConfiguration(Map.of(Server.CONFIG_OF_MSE_AGGREGATION_SPILL_ENABLED, true)));
+
+    Map<String, String> incompatibleMetadata =
+        queryRunner.consolidateMetadata(Map.of(), Map.of(QueryOptionKey.MSE_AGGREGATION_SPILL_ENABLED, "true"), false);
+    Map<String, String> compatibleMetadata =
+        queryRunner.consolidateMetadata(Map.of(), Map.of(QueryOptionKey.MSE_AGGREGATION_SPILL_ENABLED, "false"), true);
+
+    assertEquals(incompatibleMetadata.get(QueryOptionKey.MSE_AGGREGATION_SPILL_ENABLED), "false");
+    assertEquals(compatibleMetadata.get(QueryOptionKey.MSE_AGGREGATION_SPILL_ENABLED), "true");
+  }
+
+  @Test(dataProvider = "spillStatsCompatibility")
+  public void testCanEnableAggregationSpill(Mode mode, boolean sendStats, boolean expected) {
+    assertEquals(QueryRunner.canEnableAggregationSpill(mode, sendStats), expected);
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/SendStatsPredicateTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/SendStatsPredicateTest.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.common.version.PinotVersion;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+/// Tests the fail-closed cluster-version compatibility state used by aggregation spill.
+public class SendStatsPredicateTest {
+  @Test
+  public void testSafeModeRequiresSuccessfulFullVersionScan() {
+    String clusterName = "testCluster";
+    String serverName = "Server_localhost_1234";
+    HelixManager helixManager = mock(HelixManager.class);
+    HelixAdmin helixAdmin = mock(HelixAdmin.class);
+    when(helixManager.getClusterName()).thenReturn(clusterName);
+    when(helixManager.getClusterManagmentTool()).thenReturn(helixAdmin);
+    when(helixAdmin.getInstancesInCluster(clusterName)).thenReturn(List.of(serverName));
+    when(helixAdmin.getInstanceConfig(clusterName, serverName)).thenThrow(new RuntimeException("read failure"));
+
+    SendStatsPredicate predicate = SendStatsPredicate.create(new PinotConfiguration(Map.of(
+        CommonConstants.MultiStageQueryRunner.KEY_OF_SEND_STATS_MODE, SendStatsPredicate.Mode.SAFE.name())),
+        helixManager);
+    NotificationContext context = mock(NotificationContext.class);
+    when(context.getType()).thenReturn(NotificationContext.Type.INIT);
+
+    assertFalse(predicate.isClusterVersionCompatible());
+    predicate.onInstanceConfigChange(List.of(), context);
+    assertFalse(predicate.isClusterVersionCompatible());
+    assertTrue(predicate.isSendStats());
+
+    InstanceConfig instanceConfig = new InstanceConfig(serverName);
+    instanceConfig.getRecord().setSimpleField(CommonConstants.Helix.Instance.PINOT_VERSION_KEY, PinotVersion.VERSION);
+    doReturn(instanceConfig).when(helixAdmin).getInstanceConfig(clusterName, serverName);
+
+    predicate.onInstanceConfigChange(List.of(), context);
+
+    assertTrue(predicate.isClusterVersionCompatible());
+
+    doThrow(new RuntimeException("enumeration failure")).when(helixAdmin).getInstancesInCluster(clusterName);
+    assertThrows(RuntimeException.class, () -> predicate.onInstanceConfigChange(List.of(), context));
+    assertFalse(predicate.isClusterVersionCompatible());
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
@@ -18,6 +18,13 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,23 +46,30 @@ import org.apache.pinot.query.runtime.blocks.SuccessMseBlock;
 import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.mockito.Mock;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.BOOLEAN;
+import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.BYTES;
 import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.DOUBLE;
 import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.INT;
+import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.OBJECT;
 import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.STRING;
+import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.UUID;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -162,6 +176,511 @@ public class AggregateOperatorTest {
     StatMap<AggregateOperator.StatKey> statMap = OperatorTestUtil.getStatMap(AggregateOperator.StatKey.class, stats);
     assertEquals(statMap.getLong(AggregateOperator.StatKey.NUM_GROUPS), 1,
         "Num groups should equal the number of distinct group keys");
+  }
+
+  @Test
+  public void testGroupBySpillProducesExactResultsAndCleansUp() {
+    List<RexExpression.FunctionCall> aggCalls = List.of(getSum(new RexExpression.InputRef(1)));
+    List<Integer> filterArgs = List.of(-1);
+    List<Integer> groupKeys = List.of(0);
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, DOUBLE});
+    _input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 1.0)
+        .addRow(2, 2.0)
+        .finishBlock()
+        .addRow(1, 3.0)
+        .addRow(3, 4.0)
+        .finishBlock()
+        .addRow(2, 5.0)
+        .addRow(4, 6.0)
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(new String[]{"group", "sum"}, new ColumnDataType[]{INT, DOUBLE});
+    AggregateOperator operator = getOperator(resultSchema, aggCalls, filterArgs, groupKeys, PlanNode.NodeHint.EMPTY,
+        spillOptions(2, 2));
+
+    List<Object[]> resultRows = new ArrayList<>();
+    MseBlock block = operator.nextBlock();
+    Path spillDirectory = operator.getSpillDirectory();
+    assertNotNull(spillDirectory);
+    assertTrue(Files.exists(spillDirectory), "Spill directory should exist while partition results are produced");
+    while (block.isData()) {
+      resultRows.addAll(((MseBlock.Data) block).asRowHeap().getRows());
+      block = operator.nextBlock();
+    }
+
+    resultRows.sort((left, right) -> Integer.compare((int) left[0], (int) right[0]));
+    assertEquals(resultRows.size(), 4);
+    assertEquals(resultRows.get(0), new Object[]{1, 4.0});
+    assertEquals(resultRows.get(1), new Object[]{2, 7.0});
+    assertEquals(resultRows.get(2), new Object[]{3, 4.0});
+    assertEquals(resultRows.get(3), new Object[]{4, 6.0});
+    assertTrue(block.isSuccess());
+    assertFalse(Files.exists(spillDirectory), "Spill directory should be deleted after the operator reaches EOS");
+
+    StatMap<AggregateOperator.StatKey> statMap =
+        OperatorTestUtil.getStatMap(AggregateOperator.StatKey.class, operator.calculateStats());
+    assertEquals(statMap.getLong(AggregateOperator.StatKey.NUM_GROUPS), 4);
+    assertEquals(statMap.getLong(AggregateOperator.StatKey.SPILL_COUNT), 3);
+    assertEquals(statMap.getLong(AggregateOperator.StatKey.SPILLED_ROWS), 6);
+    assertTrue(statMap.getLong(AggregateOperator.StatKey.SPILLED_BYTES) > 0);
+  }
+
+  @Test
+  public void testGroupBySpillRoundTripsObjectIntermediateResults() {
+    List<RexExpression.FunctionCall> aggCalls =
+        List.of(new RexExpression.FunctionCall(DOUBLE, SqlKind.AVG.name(), List.of(new RexExpression.InputRef(1))));
+    List<Integer> filterArgs = List.of(-1);
+    List<Integer> groupKeys = List.of(0);
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, DOUBLE});
+    _input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 1.0)
+        .addRow(2, 10.0)
+        .finishBlock()
+        .addRow(1, 3.0)
+        .addRow(2, 20.0)
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(new String[]{"group", "avg"}, new ColumnDataType[]{INT, DOUBLE});
+    AggregateOperator operator = getOperator(resultSchema, aggCalls, filterArgs, groupKeys, PlanNode.NodeHint.EMPTY,
+        spillOptions(1, 2));
+
+    List<Object[]> resultRows = new ArrayList<>();
+    MseBlock block = operator.nextBlock();
+    while (block.isData()) {
+      resultRows.addAll(((MseBlock.Data) block).asRowHeap().getRows());
+      block = operator.nextBlock();
+    }
+
+    resultRows.sort((left, right) -> Integer.compare((int) left[0], (int) right[0]));
+    assertEquals(resultRows.size(), 2);
+    assertEquals(resultRows.get(0), new Object[]{1, 2.0});
+    assertEquals(resultRows.get(1), new Object[]{2, 15.0});
+    assertTrue(block.isSuccess());
+  }
+
+  @Test
+  public void testGroupBySpillWritesMultipleBoundedRecords() {
+    DataSchema inputSchema = new DataSchema(new String[]{"group"}, new ColumnDataType[]{INT});
+    BlockListMultiStageOperator.Builder inputBuilder = new BlockListMultiStageOperator.Builder(inputSchema);
+    int numGroups = 1025;
+    for (int group = 0; group < numGroups; group++) {
+      inputBuilder.addRow(group);
+    }
+    _input = inputBuilder.buildWithEos();
+    AggregateOperator operator =
+        getOperator(inputSchema, List.of(), List.of(), List.of(0), PlanNode.NodeHint.EMPTY,
+            spillOptions(numGroups, 1));
+
+    assertEquals(drainRows(operator).size(), numGroups);
+    StatMap<AggregateOperator.StatKey> statMap =
+        OperatorTestUtil.getStatMap(AggregateOperator.StatKey.class, operator.calculateStats());
+    assertEquals(statMap.getLong(AggregateOperator.StatKey.SPILL_COUNT), 1);
+    assertEquals(statMap.getLong(AggregateOperator.StatKey.SPILLED_ROWS), numGroups);
+  }
+
+  @Test
+  public void testDistinctGroupBySpill() {
+    DataSchema inputSchema = new DataSchema(new String[]{"group"}, new ColumnDataType[]{INT});
+    _input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1)
+        .finishBlock()
+        .addRow(2)
+        .finishBlock()
+        .addRow(1)
+        .buildWithEos();
+    AggregateOperator operator =
+        getOperator(inputSchema, List.of(), List.of(), List.of(0), PlanNode.NodeHint.EMPTY,
+            spillOptions(1, Server.DEFAULT_MSE_AGGREGATION_SPILL_PARTITIONS));
+
+    List<Object[]> resultRows = new ArrayList<>();
+    MseBlock block = operator.nextBlock();
+    while (block.isData()) {
+      resultRows.addAll(((MseBlock.Data) block).asRowHeap().getRows());
+      block = operator.nextBlock();
+    }
+
+    resultRows.sort((left, right) -> Integer.compare((int) left[0], (int) right[0]));
+    assertEquals(resultRows.size(), 2);
+    assertEquals(resultRows.get(0), new Object[]{1});
+    assertEquals(resultRows.get(1), new Object[]{2});
+    assertTrue(block.isSuccess());
+  }
+
+  @Test
+  public void testGroupBySpillSupportsCompositeNullKeysAndFilters() {
+    List<RexExpression.FunctionCall> aggCalls = List.of(getSum(new RexExpression.InputRef(2)));
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "subgroup", "arg", "filter"},
+        new ColumnDataType[]{INT, STRING, DOUBLE, BOOLEAN});
+    _input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, null, 1.0, 1)
+        .addRow(1, "x", 10.0, 1)
+        .finishBlock()
+        .addRow(1, null, 2.0, 0)
+        .addRow(1, "x", 5.0, 1)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "subgroup", "sum"}, new ColumnDataType[]{INT, STRING, DOUBLE});
+    AggregateOperator operator =
+        getOperator(resultSchema, aggCalls, List.of(3), List.of(0, 1), PlanNode.NodeHint.EMPTY,
+            spillOptions(1, Server.MAX_MSE_AGGREGATION_SPILL_PARTITIONS));
+
+    List<Object[]> resultRows = drainRows(operator);
+    resultRows.sort((left, right) -> {
+      String leftKey = (String) left[1];
+      String rightKey = (String) right[1];
+      if (leftKey == null) {
+        return rightKey == null ? 0 : -1;
+      }
+      return rightKey == null ? 1 : leftKey.compareTo(rightKey);
+    });
+
+    assertEquals(resultRows.size(), 2);
+    assertEquals(resultRows.get(0), new Object[]{1, null, 1.0});
+    assertEquals(resultRows.get(1), new Object[]{1, "x", 15.0});
+  }
+
+  @Test
+  public void testSpillPreservesIntermediateAndFinalAggregationModes() {
+    RexExpression.FunctionCall avgCall =
+        new RexExpression.FunctionCall(DOUBLE, SqlKind.AVG.name(), List.of(new RexExpression.InputRef(1)));
+    Map<String, String> spillOptions = spillOptions(1, 2);
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, DOUBLE});
+    _input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 1.0)
+        .addRow(2, 10.0)
+        .finishBlock()
+        .addRow(1, 3.0)
+        .addRow(2, 20.0)
+        .buildWithEos();
+    DataSchema intermediateSchema =
+        new DataSchema(new String[]{"group", "avg"}, new ColumnDataType[]{INT, OBJECT});
+
+    AggregateOperator leafOperator =
+        getOperator(intermediateSchema, List.of(avgCall), List.of(-1), List.of(0), AggType.LEAF, spillOptions);
+    _input = new BlockListMultiStageOperator(OperatorTestUtil.getTracingContext(), drainDataBlocks(leafOperator));
+    AggregateOperator intermediateOperator =
+        getOperator(intermediateSchema, List.of(avgCall), List.of(-1), List.of(0), AggType.INTERMEDIATE, spillOptions);
+    _input =
+        new BlockListMultiStageOperator(OperatorTestUtil.getTracingContext(), drainDataBlocks(intermediateOperator));
+    DataSchema finalSchema = new DataSchema(new String[]{"group", "avg"}, new ColumnDataType[]{INT, DOUBLE});
+    AggregateOperator finalOperator =
+        getOperator(finalSchema, List.of(avgCall), List.of(-1), List.of(0), AggType.FINAL, spillOptions);
+
+    List<Object[]> resultRows = drainRows(finalOperator);
+    resultRows.sort((left, right) -> Integer.compare((int) left[0], (int) right[0]));
+    assertEquals(resultRows.size(), 2);
+    assertEquals(resultRows.get(0), new Object[]{1, 2.0});
+    assertEquals(resultRows.get(1), new Object[]{2, 15.0});
+  }
+
+  @Test
+  public void testSpillEnforcesGlobalNumGroupsLimit() {
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, DOUBLE});
+    _input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 1.0)
+        .finishBlock()
+        .addRow(2, 2.0)
+        .finishBlock()
+        .addRow(3, 3.0)
+        .buildWithEos();
+    PlanNode.NodeHint nodeHint = new PlanNode.NodeHint(Map.of(PinotHintOptions.AGGREGATE_HINT_OPTIONS,
+        Map.of(PinotHintOptions.AggregateOptions.NUM_GROUPS_LIMIT, "2")));
+    DataSchema resultSchema = new DataSchema(new String[]{"group", "sum"}, new ColumnDataType[]{INT, DOUBLE});
+    AggregateOperator operator =
+        getOperator(resultSchema, List.of(getSum(new RexExpression.InputRef(1))), List.of(-1), List.of(0), nodeHint,
+            spillOptions(1, Server.DEFAULT_MSE_AGGREGATION_SPILL_PARTITIONS));
+
+    assertEquals(drainRows(operator).size(), 2);
+    StatMap<AggregateOperator.StatKey> statMap =
+        OperatorTestUtil.getStatMap(AggregateOperator.StatKey.class, operator.calculateStats());
+    assertTrue(statMap.getBoolean(AggregateOperator.StatKey.NUM_GROUPS_LIMIT_REACHED));
+    assertEquals(statMap.getLong(AggregateOperator.StatKey.NUM_GROUPS), 2);
+  }
+
+  @Test
+  public void testSpillErrorsOnGlobalNumGroupsLimit() {
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, DOUBLE});
+    _input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 1.0)
+        .finishBlock()
+        .addRow(2, 2.0)
+        .buildWithEos();
+    PlanNode.NodeHint nodeHint = new PlanNode.NodeHint(Map.of(PinotHintOptions.AGGREGATE_HINT_OPTIONS,
+        Map.of(PinotHintOptions.AggregateOptions.NUM_GROUPS_LIMIT, "2")));
+    DataSchema resultSchema = new DataSchema(new String[]{"group", "sum"}, new ColumnDataType[]{INT, DOUBLE});
+    AggregateOperator operator =
+        getOperator(resultSchema, List.of(getSum(new RexExpression.InputRef(1))), List.of(-1), List.of(0), nodeHint,
+            Map.of(QueryOptionKey.MSE_AGGREGATION_SPILL_ENABLED, "true",
+                QueryOptionKey.MSE_AGGREGATION_SPILL_THRESHOLD, "1",
+                QueryOptionKey.MSE_AGGREGATION_SPILL_PARTITIONS, "2",
+                QueryOptionKey.ERROR_ON_NUM_GROUPS_LIMIT, "true"));
+
+    MseBlock block = operator.nextBlock();
+    Path spillDirectory = operator.getSpillDirectory();
+    while (block.isData()) {
+      block = operator.nextBlock();
+    }
+    assertTrue(block.isError());
+    assertNotNull(spillDirectory);
+    assertFalse(Files.exists(spillDirectory));
+  }
+
+  @Test
+  public void testSpillErrorsWhenRestoredPartitionExceedsThreshold() {
+    DataSchema inputSchema = new DataSchema(new String[]{"group"}, new ColumnDataType[]{INT});
+    _input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1)
+        .addRow(2)
+        .addRow(3)
+        .buildWithEos();
+    AggregateOperator operator =
+        getOperator(inputSchema, List.of(), List.of(), List.of(0), PlanNode.NodeHint.EMPTY, spillOptions(2, 1));
+
+    MseBlock block = operator.nextBlock();
+    Path spillDirectory = operator.getSpillDirectory();
+
+    assertTrue(block.isError());
+    assertNotNull(spillDirectory);
+    assertFalse(Files.exists(spillDirectory));
+  }
+
+  @DataProvider(name = "spillCleanupActions")
+  public Object[][] spillCleanupActions() {
+    return new Object[][]{{"close"}, {"cancel"}, {"earlyTerminate"}};
+  }
+
+  @Test(dataProvider = "spillCleanupActions")
+  public void testSpillCleanupOnTerminalAction(String action) {
+    AggregateOperator operator = createSpillingSumOperator(false);
+    assertTrue(operator.nextBlock().isData());
+    Path spillDirectory = operator.getSpillDirectory();
+    assertNotNull(spillDirectory);
+    assertTrue(Files.exists(spillDirectory));
+
+    switch (action) {
+      case "close":
+        operator.close();
+        break;
+      case "cancel":
+        operator.cancel(new RuntimeException("cancelled"));
+        break;
+      case "earlyTerminate":
+        operator.earlyTerminate();
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported cleanup action: " + action);
+    }
+
+    assertFalse(Files.exists(spillDirectory));
+  }
+
+  @Test
+  public void testSpillCleanupOnUpstreamError() {
+    AggregateOperator operator = createSpillingSumOperator(true);
+
+    MseBlock block = operator.nextBlock();
+    Path spillDirectory = operator.getSpillDirectory();
+
+    assertTrue(block.isError());
+    assertNotNull(spillDirectory);
+    assertFalse(Files.exists(spillDirectory));
+  }
+
+  @DataProvider(name = "unsupportedSpillModes")
+  public Object[][] unsupportedSpillModes() {
+    return new Object[][]{{true, 0}, {false, 1}};
+  }
+
+  @Test(dataProvider = "unsupportedSpillModes")
+  public void testSpillDisabledForUnsupportedModes(boolean leafReturnFinalResult, int limit) {
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, DOUBLE});
+    _input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 1.0)
+        .addRow(2, 2.0)
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(new String[]{"group", "sum"}, new ColumnDataType[]{INT, DOUBLE});
+    AggregateNode node = new AggregateNode(-1, resultSchema, PlanNode.NodeHint.EMPTY, List.of(),
+        List.of(getSum(new RexExpression.InputRef(1))), List.of(-1), List.of(0), AggType.DIRECT,
+        leafReturnFinalResult, null, limit);
+    AggregateOperator operator =
+        new AggregateOperator(OperatorTestUtil.getContext(
+            Map.of(QueryOptionKey.MSE_AGGREGATION_SPILL_ENABLED, "true",
+                QueryOptionKey.MSE_AGGREGATION_SPILL_THRESHOLD, "0",
+                QueryOptionKey.MSE_AGGREGATION_SPILL_PARTITIONS, "0")), _input, node);
+
+    assertTrue(operator.nextBlock().isData());
+    assertNull(operator.getSpillDirectory());
+  }
+
+  @Test
+  public void testSpillOptionsIgnoredForGlobalAggregation() {
+    DataSchema inputSchema = new DataSchema(new String[]{"arg"}, new ColumnDataType[]{DOUBLE});
+    _input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1.0)
+        .addRow(2.0)
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
+    AggregateOperator operator =
+        getOperator(resultSchema, List.of(getSum(new RexExpression.InputRef(0))), List.of(-1), List.of(),
+            PlanNode.NodeHint.EMPTY, Map.of(QueryOptionKey.MSE_AGGREGATION_SPILL_ENABLED, "true",
+                QueryOptionKey.MSE_AGGREGATION_SPILL_THRESHOLD, "0",
+                QueryOptionKey.MSE_AGGREGATION_SPILL_PARTITIONS, "0"));
+
+    List<Object[]> rows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    assertEquals(rows.size(), 1);
+    assertEquals(rows.get(0), new Object[]{3.0});
+    assertNull(operator.getSpillDirectory());
+    assertTrue(operator.nextBlock().isSuccess());
+  }
+
+  @Test
+  public void testSpillDisabledWithoutServerGate() {
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, DOUBLE});
+    _input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 1.0)
+        .finishBlock()
+        .addRow(2, 2.0)
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(new String[]{"group", "sum"}, new ColumnDataType[]{INT, DOUBLE});
+    AggregateOperator operator =
+        getOperator(resultSchema, List.of(getSum(new RexExpression.InputRef(1))), List.of(-1), List.of(0),
+            PlanNode.NodeHint.EMPTY, Map.of(QueryOptionKey.MSE_AGGREGATION_SPILL_ENABLED, "false",
+                QueryOptionKey.MSE_AGGREGATION_SPILL_THRESHOLD, "0",
+                QueryOptionKey.MSE_AGGREGATION_SPILL_PARTITIONS, "0"));
+
+    assertTrue(operator.nextBlock().isData());
+    assertNull(operator.getSpillDirectory());
+  }
+
+  @Test
+  public void testDisabledSpillStatsCanBeReadByLegacyNode()
+      throws Exception {
+    DataSchema inputSchema = new DataSchema(new String[]{"group"}, new ColumnDataType[]{INT});
+    _input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1)
+        .addRow(2)
+        .buildWithEos();
+    AggregateOperator operator =
+        getOperator(inputSchema, List.of(), List.of(), List.of(0), PlanNode.NodeHint.EMPTY,
+            Map.of(QueryOptionKey.MSE_AGGREGATION_SPILL_ENABLED, "false"));
+    drainRows(operator);
+    StatMap<AggregateOperator.StatKey> statMap =
+        OperatorTestUtil.getStatMap(AggregateOperator.StatKey.class, operator.calculateStats());
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    statMap.serialize(new DataOutputStream(bytes));
+
+    StatMap<LegacyAggregateStatKey> legacyStatMap =
+        StatMap.deserialize(new DataInputStream(new ByteArrayInputStream(bytes.toByteArray())),
+            LegacyAggregateStatKey.class);
+
+    assertEquals(legacyStatMap.getLong(LegacyAggregateStatKey.NUM_GROUPS), 2);
+  }
+
+  @Test
+  public void testSpillDoesNotApplyNumGroupsLimitPerRun() {
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, DOUBLE});
+    _input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 1.0)
+        .addRow(2, 2.0)
+        .addRow(3, 5.0)
+        .finishBlock()
+        .addRow(3, 7.0)
+        .buildWithEos();
+    PlanNode.NodeHint nodeHint = new PlanNode.NodeHint(Map.of(PinotHintOptions.AGGREGATE_HINT_OPTIONS,
+        Map.of(PinotHintOptions.AggregateOptions.NUM_GROUPS_LIMIT, "2")));
+    DataSchema resultSchema = new DataSchema(new String[]{"group", "sum"}, new ColumnDataType[]{INT, DOUBLE});
+    AggregateOperator operator =
+        getOperator(resultSchema, List.of(getSum(new RexExpression.InputRef(1))), List.of(-1), List.of(0), nodeHint,
+            spillOptions(2, 2));
+
+    Map<Integer, Double> resultByGroup = new HashMap<>();
+    for (Object[] row : drainRows(operator)) {
+      resultByGroup.put((int) row[0], (double) row[1]);
+    }
+    assertEquals(resultByGroup, Map.of(1, 1.0, 3, 12.0));
+  }
+
+  @Test
+  public void testSpillRoundTripsAnyValueIntermediateResult() {
+    RexExpression.FunctionCall anyValue =
+        new RexExpression.FunctionCall(INT, SqlKind.ANY_VALUE.name(), List.of(new RexExpression.InputRef(1)));
+    DataSchema intermediateSchema =
+        new DataSchema(new String[]{"group", "anyValue"}, new ColumnDataType[]{INT, INT});
+    _input = new BlockListMultiStageOperator.Builder(intermediateSchema)
+        .addRow(1, 10)
+        .finishBlock()
+        .addRow(1, 20)
+        .buildWithEos();
+    AggregateOperator operator =
+        getOperator(intermediateSchema, List.of(anyValue), List.of(-1), List.of(0), AggType.INTERMEDIATE,
+            spillOptions(1, 2));
+
+    List<Object[]> rows = drainRows(operator);
+    assertEquals(rows.size(), 1);
+    assertEquals(rows.get(0), new Object[]{1, 10});
+  }
+
+  @DataProvider(name = "binaryAnyValueModes")
+  public Object[][] binaryAnyValueModes() {
+    return new Object[][]{
+        {BYTES, AggType.DIRECT},
+        {BYTES, AggType.INTERMEDIATE},
+        {UUID, AggType.DIRECT},
+        {UUID, AggType.INTERMEDIATE}
+    };
+  }
+
+  @Test(dataProvider = "binaryAnyValueModes")
+  public void testSpillRoundTripsBinaryAnyValue(ColumnDataType dataType, AggType aggType) {
+    RexExpression.FunctionCall anyValue =
+        new RexExpression.FunctionCall(dataType, SqlKind.ANY_VALUE.name(), List.of(new RexExpression.InputRef(1)));
+    DataSchema schema = new DataSchema(new String[]{"group", "anyValue"}, new ColumnDataType[]{INT, dataType});
+    ByteArray firstValue = new ByteArray(new byte[16]);
+    ByteArray secondValue = new ByteArray(new byte[]{
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+    });
+    _input = new BlockListMultiStageOperator.Builder(schema)
+        .addRow(1, firstValue)
+        .finishBlock()
+        .addRow(1, secondValue)
+        .buildWithEos();
+    AggregateOperator operator =
+        getOperator(schema, List.of(anyValue), List.of(-1), List.of(0), aggType, spillOptions(1, 2));
+
+    List<Object[]> rows = drainRows(operator);
+    assertEquals(rows.size(), 1);
+    assertEquals(rows.get(0), new Object[]{1, firstValue});
+  }
+
+  @DataProvider(name = "numGroupsLimitModes")
+  public Object[][] numGroupsLimitModes() {
+    return new Object[][]{{false}, {true}};
+  }
+
+  @Test(dataProvider = "numGroupsLimitModes")
+  public void testSpillEnabledWithoutSpillStillEnforcesNumGroupsLimit(boolean errorOnLimit) {
+    DataSchema inputSchema = new DataSchema(new String[]{"group"}, new ColumnDataType[]{INT});
+    _input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1)
+        .addRow(2)
+        .addRow(3)
+        .buildWithEos();
+    Map<String, String> options = new HashMap<>(spillOptions(100, 2));
+    options.put(QueryOptionKey.NUM_GROUPS_LIMIT, "2");
+    options.put(QueryOptionKey.ERROR_ON_NUM_GROUPS_LIMIT, Boolean.toString(errorOnLimit));
+    AggregateOperator operator =
+        getOperator(inputSchema, List.of(), List.of(), List.of(0), PlanNode.NodeHint.EMPTY, options);
+
+    if (errorOnLimit) {
+      assertTrue(operator.nextBlock().isError());
+    } else {
+      assertEquals(drainRows(operator).size(), 2);
+      StatMap<AggregateOperator.StatKey> statMap =
+          OperatorTestUtil.getStatMap(AggregateOperator.StatKey.class, operator.calculateStats());
+      assertTrue(statMap.getBoolean(AggregateOperator.StatKey.NUM_GROUPS_LIMIT_REACHED));
+      assertEquals(statMap.getLong(AggregateOperator.StatKey.NUM_GROUPS), 2);
+    }
+    assertNull(operator.getSpillDirectory());
   }
 
   @Test
@@ -397,16 +916,94 @@ public class AggregateOperatorTest {
     return new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.SUM.name(), List.of(arg));
   }
 
+  private static List<MseBlock.Data> drainDataBlocks(AggregateOperator operator) {
+    List<MseBlock.Data> blocks = new ArrayList<>();
+    MseBlock block = operator.nextBlock();
+    while (block.isData()) {
+      blocks.add((MseBlock.Data) block);
+      block = operator.nextBlock();
+    }
+    assertTrue(block.isSuccess());
+    return blocks;
+  }
+
+  private static List<Object[]> drainRows(AggregateOperator operator) {
+    List<Object[]> rows = new ArrayList<>();
+    for (MseBlock.Data block : drainDataBlocks(operator)) {
+      rows.addAll(block.asRowHeap().getRows());
+    }
+    return rows;
+  }
+
+  private AggregateOperator createSpillingSumOperator(boolean error) {
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, DOUBLE});
+    BlockListMultiStageOperator.Builder inputBuilder = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 1.0)
+        .finishBlock()
+        .addRow(2, 2.0);
+    _input = error
+        ? inputBuilder.buildWithError(ErrorMseBlock.fromException(new RuntimeException("upstream failure")))
+        : inputBuilder.buildWithEos();
+    DataSchema resultSchema = new DataSchema(new String[]{"group", "sum"}, new ColumnDataType[]{INT, DOUBLE});
+    return getOperator(resultSchema, List.of(getSum(new RexExpression.InputRef(1))), List.of(-1), List.of(0),
+        PlanNode.NodeHint.EMPTY, spillOptions(1, 2));
+  }
+
+  private static Map<String, String> spillOptions(int threshold, int partitions) {
+    return Map.of(QueryOptionKey.MSE_AGGREGATION_SPILL_ENABLED, "true",
+        QueryOptionKey.MSE_AGGREGATION_SPILL_THRESHOLD, Integer.toString(threshold),
+        QueryOptionKey.MSE_AGGREGATION_SPILL_PARTITIONS, Integer.toString(partitions));
+  }
+
   private AggregateOperator getOperator(DataSchema resultSchema, List<RexExpression.FunctionCall> aggCalls,
       List<Integer> filterArgs, List<Integer> groupKeys, PlanNode.NodeHint nodeHint,
       Map<String, String> opChainMetadata) {
+    return getOperator(resultSchema, aggCalls, filterArgs, groupKeys, AggType.DIRECT, nodeHint, opChainMetadata);
+  }
+
+  private AggregateOperator getOperator(DataSchema resultSchema, List<RexExpression.FunctionCall> aggCalls,
+      List<Integer> filterArgs, List<Integer> groupKeys, AggType aggType, Map<String, String> opChainMetadata) {
+    return getOperator(resultSchema, aggCalls, filterArgs, groupKeys, aggType, PlanNode.NodeHint.EMPTY,
+        opChainMetadata);
+  }
+
+  private AggregateOperator getOperator(DataSchema resultSchema, List<RexExpression.FunctionCall> aggCalls,
+      List<Integer> filterArgs, List<Integer> groupKeys, AggType aggType, PlanNode.NodeHint nodeHint,
+      Map<String, String> opChainMetadata) {
     return new AggregateOperator(OperatorTestUtil.getContext(opChainMetadata), _input,
-        new AggregateNode(-1, resultSchema, nodeHint, List.of(), aggCalls, filterArgs, groupKeys, AggType.DIRECT,
-            false, null, 0));
+        new AggregateNode(-1, resultSchema, nodeHint, List.of(), aggCalls, filterArgs, groupKeys, aggType, false, null,
+            0));
   }
 
   private AggregateOperator getOperator(DataSchema resultSchema, List<RexExpression.FunctionCall> aggCalls,
       List<Integer> filterArgs, List<Integer> groupKeys) {
     return getOperator(resultSchema, aggCalls, filterArgs, groupKeys, PlanNode.NodeHint.EMPTY, Map.of());
+  }
+
+  private enum LegacyAggregateStatKey implements StatMap.Key {
+    EXECUTION_TIME_MS(StatMap.Type.LONG),
+    EMITTED_ROWS(StatMap.Type.LONG),
+    GROUPS_TRIMMED(StatMap.Type.BOOLEAN),
+    NUM_GROUPS_LIMIT_REACHED(StatMap.Type.BOOLEAN),
+    NUM_GROUPS_WARNING_LIMIT_REACHED(StatMap.Type.BOOLEAN),
+    NUM_GROUPS(StatMap.Type.LONG) {
+      @Override
+      public long merge(long value1, long value2) {
+        return Math.max(value1, value2);
+      }
+    },
+    ALLOCATED_MEMORY_BYTES(StatMap.Type.LONG),
+    GC_TIME_MS(StatMap.Type.LONG);
+
+    private final StatMap.Type _type;
+
+    LegacyAggregateStatKey(StatMap.Type type) {
+      _type = type;
+    }
+
+    @Override
+    public StatMap.Type getType() {
+      return _type;
+    }
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregationSpillManagerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregationSpillManagerTest.java
@@ -1,0 +1,169 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.spi.utils.CommonConstants.Server;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+/// Tests partitioning, serialization, and cleanup behavior of [AggregationSpillManager].
+public class AggregationSpillManagerTest {
+  @DataProvider(name = "equivalentValues")
+  public Object[][] equivalentValues() {
+    return new Object[][]{
+        {null, null},
+        {"key", new String("key")},
+        {new Object[]{"key", new int[]{1, 2}}, new Object[]{"key", new int[]{1, 2}}},
+        {new byte[]{1, 2}, new byte[]{1, 2}},
+        {new short[]{1, 2}, new short[]{1, 2}},
+        {new int[]{1, 2}, new int[]{1, 2}},
+        {new long[]{1, 2}, new long[]{1, 2}},
+        {new char[]{1, 2}, new char[]{1, 2}},
+        {new float[]{1, 2}, new float[]{1, 2}},
+        {new double[]{1, 2}, new double[]{1, 2}},
+        {new boolean[]{true, false}, new boolean[]{true, false}}
+    };
+  }
+
+  @Test(dataProvider = "equivalentValues")
+  public void testDeepHashCode(Object left, Object right) {
+    assertEquals(AggregationSpillManager.deepHashCode(left), AggregationSpillManager.deepHashCode(right));
+  }
+
+  @DataProvider(name = "partitionConsumers")
+  public Object[][] partitionConsumers() {
+    return new Object[][]{{false}, {true}};
+  }
+
+  @Test(dataProvider = "partitionConsumers")
+  public void testConsumePartitionDeletesFileAndCloseIsIdempotent(boolean consumerFails) {
+    DataSchema spillSchema = new DataSchema(new String[]{"key"}, new ColumnDataType[]{ColumnDataType.INT});
+    AggregationSpillManager spillManager = new AggregationSpillManager(1, 1, spillSchema, new AggregationFunction[0]);
+    Path spillDirectory = spillManager.getSpillDirectory();
+    spillManager.spill(List.<Object[]>of(new Object[]{1}).iterator());
+    assertTrue(spillManager.hasPartition(0));
+
+    if (consumerFails) {
+      assertThrows(RuntimeException.class,
+          () -> spillManager.consumePartition(0, block -> {
+            throw new RuntimeException("consumer failure");
+          }));
+    } else {
+      spillManager.consumePartition(0, block -> assertEquals(block.getNumRows(), 1));
+    }
+
+    assertFalse(spillManager.hasPartition(0));
+    spillManager.close();
+    spillManager.close();
+    assertFalse(Files.exists(spillDirectory));
+  }
+
+  @Test
+  public void testSuccessfulConsumeRetriesCleanupOnClose() {
+    DataSchema spillSchema = new DataSchema(new String[]{"key"}, new ColumnDataType[]{ColumnDataType.INT});
+    AggregationSpillManager spillManager =
+        new AggregationSpillManager(1, 1, spillSchema, new AggregationFunction[0]) {
+          @Override
+          void deleteSpillFile(Path spillFile) {
+            throw new UncheckedIOException("delete failure", new IOException("delete failure"));
+          }
+        };
+    Path spillDirectory = spillManager.getSpillDirectory();
+    spillManager.spill(List.<Object[]>of(new Object[]{1}).iterator());
+
+    spillManager.consumePartition(0, block -> assertEquals(block.getNumRows(), 1));
+
+    assertTrue(spillManager.hasPartition(0));
+    spillManager.close();
+    assertFalse(Files.exists(spillDirectory));
+  }
+
+  @Test
+  public void testSpillFlushesMultipleBoundedRecords() {
+    DataSchema spillSchema = new DataSchema(new String[]{"key"}, new ColumnDataType[]{ColumnDataType.INT});
+    AggregationSpillManager spillManager = new AggregationSpillManager(1, 1, spillSchema, new AggregationFunction[0]);
+    List<Object[]> rows = new ArrayList<>(1025);
+    for (int i = 0; i < 1025; i++) {
+      rows.add(new Object[]{i});
+    }
+    spillManager.spill(rows.iterator());
+    List<Integer> recordSizes = new ArrayList<>();
+
+    spillManager.consumePartition(0, block -> recordSizes.add(block.getNumRows()));
+
+    assertEquals(recordSizes, List.of(1024, 1));
+    spillManager.close();
+  }
+
+  @Test
+  public void testSpillWriterCacheIsBounded() {
+    int numPartitions = Server.MAX_MSE_AGGREGATION_SPILL_PARTITIONS;
+    DataSchema spillSchema = new DataSchema(new String[]{"key"}, new ColumnDataType[]{ColumnDataType.INT});
+    AggregationSpillManager spillManager =
+        new AggregationSpillManager(numPartitions, 1, spillSchema, new AggregationFunction[0]);
+    List<Object[]> rows = new ArrayList<>(numPartitions);
+    for (int i = 0; i < numPartitions; i++) {
+      rows.add(new Object[]{i});
+    }
+
+    spillManager.spill(rows.iterator());
+
+    assertEquals(spillManager.getNumOpenSpillWriters(), numPartitions);
+    spillManager.close();
+  }
+
+  @Test
+  public void testSpillBatchesRowsPerPartition() {
+    int numPartitions = Server.DEFAULT_MSE_AGGREGATION_SPILL_PARTITIONS;
+    DataSchema spillSchema = new DataSchema(new String[]{"key"}, new ColumnDataType[]{ColumnDataType.INT});
+    AggregationSpillManager spillManager =
+        new AggregationSpillManager(numPartitions, 1, spillSchema, new AggregationFunction[0]);
+    List<Object[]> rows = new ArrayList<>(8192);
+    for (int i = 0; i < 8192; i++) {
+      rows.add(new Object[]{i});
+    }
+    spillManager.spill(rows.iterator());
+    int[] recordsAndRows = new int[2];
+
+    for (int partitionId = 0; partitionId < numPartitions; partitionId++) {
+      spillManager.consumePartition(partitionId, block -> {
+        recordsAndRows[0]++;
+        recordsAndRows[1] += block.getNumRows();
+      });
+    }
+
+    assertEquals(recordsAndRows, new int[]{numPartitions, rows.size()});
+    spillManager.close();
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
@@ -35,6 +35,7 @@ import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
 import org.apache.pinot.query.routing.QueryServerInstance;
 import org.apache.pinot.query.runtime.MultiStageStatsTreeBuilder;
+import org.apache.pinot.query.runtime.SendStatsPredicate.Mode;
 import org.apache.pinot.query.service.dispatch.QueryDispatcher;
 import org.apache.pinot.query.testutils.MockInstanceDataManagerFactory;
 import org.apache.pinot.query.testutils.QueryTestUtils;
@@ -46,6 +47,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner;
+import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.parsers.rewriter.RlsUtils;
@@ -97,7 +99,8 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
   }
 
   protected Map<String, Object> getConfiguration() {
-    return Map.of();
+    return Map.of(Server.CONFIG_OF_MSE_AGGREGATION_SPILL_ENABLED, true,
+        MultiStageQueryRunner.KEY_OF_SEND_STATS_MODE, Mode.SAFE.name());
   }
 
   @BeforeClass
@@ -185,6 +188,28 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
 
     int checked = assertSelfStatsAreNotNegative(statsTree);
     Assert.assertTrue(checked > 0, "expected some self stats to check, got: " + statsTree);
+  }
+
+  @Test
+  public void testMSEAggregationSpill() {
+    String query = "SELECT col1, SUM(col3), AVG(col3) FROM a GROUP BY col1 ORDER BY col1";
+    ResultTable expected = queryRunner(query, false).getResultTable();
+    String spillQuery =
+        "SET mseAggregationSpillThreshold = 2; SET mseAggregationSpillPartitions = 8; " + query;
+    QueryDispatcher.QueryResult queryResult = queryRunner(spillQuery, true);
+    ResultTable actual = queryResult.getResultTable();
+
+    Assertions.assertThat(actual.getDataSchema()).isEqualTo(expected.getDataSchema());
+    Assertions.assertThat(actual.getRows()).containsExactlyElementsOf(expected.getRows());
+
+    Map<Integer, DispatchablePlanFragment> planNodes = planQuery(spillQuery).getQueryPlan().getQueryStageMap();
+    ObjectNode statsTree =
+        new MultiStageStatsTreeBuilder(planNodes, queryResult.getQueryStats()).jsonStatsByStage(1);
+    ObjectNode spillStats = findFieldOwner(statsTree, "spillCount");
+    Assertions.assertThat(spillStats).isNotNull();
+    Assertions.assertThat(spillStats.path("spillCount").asLong()).isPositive();
+    Assertions.assertThat(spillStats.path("spilledRows").asLong()).isPositive();
+    Assertions.assertThat(spillStats.path("spilledBytes").asLong()).isPositive();
   }
 
   /// Asserts that no self stat in the tree is negative, and returns how many were checked.

--- a/pinot-server/src/main/java/org/apache/pinot/server/worker/WorkerQueryServer.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/worker/WorkerQueryServer.java
@@ -46,7 +46,7 @@ public class WorkerQueryServer {
         MultiStageQueryRunner.DEFAULT_QUERY_SERVER_PORT);
     _queryRunner = new QueryRunner();
     _queryRunner.init(serverConf, instanceDataManager.getInstanceId(), instanceDataManager, tlsConfig,
-        sendStats::isSendStats, keepPipelineBreakerStatsPredicate::isEnabled);
+        sendStats::isSendStats, sendStats::isClusterVersionCompatible, keepPipelineBreakerStatsPredicate::isEnabled);
     _queryWorkerService =
         new QueryServer(serverConf, instanceDataManager.getInstanceId(), _queryServicePort, _queryRunner, tlsConfig,
             threadAccountant);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -808,6 +808,20 @@ public class CommonConstants {
         /// Flush threshold for streaming group-by on MSE leaf stages.
         public static final String STREAMING_GROUP_BY_FLUSH_THRESHOLD = "streamingGroupByFlushThreshold";
 
+        /// Maximum number of groups retained by a keyed MSE aggregation executor before its intermediate states are
+        /// spilled to local disk. This option is honored only when the server-level aggregation spill gate is enabled.
+        /// An absent value disables spilling. The first spill version does not apply to global aggregation,
+        /// leaf-final-result, or group-trim modes.
+        public static final String MSE_AGGREGATION_SPILL_THRESHOLD = "mseAggregationSpillThreshold";
+
+        /// Number of hash partitions used by MSE aggregation spilling. Must be between 1 and
+        /// [Server#MAX_MSE_AGGREGATION_SPILL_PARTITIONS].
+        public static final String MSE_AGGREGATION_SPILL_PARTITIONS = "mseAggregationSpillPartitions";
+
+        /// Internal metadata populated from the server-level MSE aggregation spill gate. Query-supplied values are
+        /// overwritten by the server.
+        public static final String MSE_AGGREGATION_SPILL_ENABLED = "mseAggregationSpillEnabled";
+
         /// Flush threshold for streaming distinct on MSE leaf stages. When positive, the leaf flushes its
         /// accumulated distinct values downstream once they reach this count and starts a fresh table, bounding
         /// server memory and pushing the residual de-duplication into the partitioned intermediate stage.
@@ -1492,6 +1506,13 @@ public class CommonConstants {
     public static final String CONFIG_OF_MSE_MIN_GROUP_TRIM_SIZE = MSE_CONFIG_PREFIX + ".min.group.trim.size";
     // Match the value of GroupByUtils.DEFAULT_MIN_NUM_GROUPS
     public static final int DEFAULT_MSE_MIN_GROUP_TRIM_SIZE = 5000;
+    // Spill adds AggregateOperator stat keys that older nodes cannot deserialize. QueryRunner requires SAFE stats
+    // mode and a homogeneous cluster before enabling spill.
+    public static final String CONFIG_OF_MSE_AGGREGATION_SPILL_ENABLED =
+        MSE_CONFIG_PREFIX + ".aggregation.spill.enabled";
+    public static final boolean DEFAULT_MSE_AGGREGATION_SPILL_ENABLED = false;
+    public static final int DEFAULT_MSE_AGGREGATION_SPILL_PARTITIONS = 8;
+    public static final int MAX_MSE_AGGREGATION_SPILL_PARTITIONS = 64;
 
     // TODO: Merge this with "mse"
     /// The ExecutorServiceProvider to use for execution threads, which are the ones that execute


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Aggregation spill flow: spill when threshold exceeded, then restore and merge partitions after input\.

```mermaid
flowchart TD
  N0["AggregateOperator #40;F5#41;"]:::stModified
  N1["MultistageGroupByExecutor #40;F7#41;"]:::stModified
  N2["AggregationSpillManager #40;F6#41;"]:::stAdded
  N0 -->|"processBlock#40;input block#41;"| N1
  N0 -->|"spillCurrentGroups#40;#41;"| N2
  N1 -->|"provides intermediate iterator for spill"| N2
  N0 -->|"reset groupByExecutor after spill"| N1
  N0 -->|"restore partitions after EOS"| N2
  N2 -->|"consume partition #38; processSpillBlock#40;#41;"| N1
  N0 -->|"getResult#40;#41; from merge executor"| N1
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

Partial evidence: 0 file patches omitted; 1 truncated.

<details>
<summary>Diff evidence</summary>

- F5: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java) · [after](https://github.com/apache/pinot/blob/bfdff704739e8e00af027c9b985755cd156e7d5b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java)
- F6: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregationSpillManager\.java — [after](https://github.com/apache/pinot/blob/bfdff704739e8e00af027c9b985755cd156e7d5b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregationSpillManager.java)
- F7: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java) · [after](https://github.com/apache/pinot/blob/bfdff704739e8e00af027c9b985755cd156e7d5b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImU2Nzg3ZTE3ODY0NWZkM2M1YTg4N2UyYWJhN2UwZGU4MzQzY2Q1MjQiLCJjb250ZXh0X2hhc2giOiIyYzllY2VmNGEyMDQ1MTgwYjVhZjNhODA5NzY4NTMyYmEwMWE2MDM1YzYyMzNhM2M5YzFhYmVkODllYjkyYTM1IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NjEyNTg0LCJoZWFkX3NoYSI6ImJmZGZmNzA0NzM5ZThlMDBhZjAyN2M5Yjk4NTc1NWNkMTU2ZTdkNWIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJlNjc4N2UxNzg2NDVmZDNjNWE4ODdlMmFiYTdlMGRlODM0M2NkNTI0IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 9c559fc0d4843619ee9315f28a0d8e26c8dd8c1a2a615bd2ecb46bda27064727 -->
<!-- pinot-pr-flow:end -->

## Summary

High-cardinality keyed aggregations in the multi-stage engine can retain an unbounded number of groups in the operator's hash table. This PR adds a default-off, local-disk spill path that exports group keys and aggregation intermediate states, hash-partitions them, and merges one partition at a time after input is consumed.

The first version intentionally supports keyed MSE aggregation only. Global aggregation, leaf-final-result mode, group-trim mode, and recursive repartitioning are out of scope.

Close: #12080

## Design

```text
                         input MseBlock.Data
                                 |
                                 v
                    +--------------------------+
                    | MultistageGroupByExecutor|
                    | in-memory hash table     |
                    +--------------------------+
                         |               |
        groups < threshold               | groups >= threshold
                         |               v
                         |    export [group keys + intermediate states]
                         |               |
                         |               v
                         |       hash(group keys) % P
                         |        /        |        \
                         |       v         v         v
                         |   part-0     part-1 ... part-P-1
                         |   append-only, length-prefixed DataBlocks
                         |               |
                         +------- continue with a fresh hash table
                                         |
                                         v
                                end of input (EOS)
                                         |
                                         v
                    +------------------------------------+
                    | restore one partition at a time    |
                    | merge intermediate aggregation     |
                    | states into a bounded hash table   |
                    +------------------------------------+
                         | emit rows | delete partition
                         v
                    next partition ... -> EOS

 cleanup: success / upstream error / cancellation / early termination / close
```

Key properties:

- Spill files are scoped to one `AggregateOperator` under the JVM temporary directory (`pinot-aggregation-spill-*`).
- Rows are partitioned using a deep hash of all group keys, including arrays and nulls.
- Each serialized spill record contains at most 1,024 rows; aggregate buffering is bounded at 8,192 rows.
- Aggregation intermediate states are serialized instead of finalized values, preserving DIRECT, INTERMEDIATE, and FINAL aggregation semantics.
- Partitions are restored and emitted sequentially. A restored partition that still exceeds the configured threshold fails with `SERVER_RESOURCE_LIMIT_EXCEEDED` instead of risking an OOM; users can increase the threshold or partition count.
- Existing global `numGroupsLimit`, warning, error, and trimming semantics are preserved across all spill runs.
- Spill files are removed after consumption and on success, failure, cancellation, early termination, or operator close.
- Operator stats expose `spillCount`, `spilledRows`, and `spilledBytes`.

## Enabling spill

Spill requires both a server-side feature gate and per-query options.

### 1. Enable the server gate

Set the following properties on every server participating in multi-stage query execution, then restart or roll the cluster:

```properties
pinot.query.mse.aggregation.spill.enabled=true
pinot.query.mse.stats.mode=SAFE
```

The spill gate defaults to `false`. `SAFE` mode enables spill only after Pinot successfully verifies that all broker and server instances report the same Pinot version. Spill fails closed during a mixed-version rolling upgrade or when an instance version cannot be read, because the new aggregation stat keys are not safe to send to older nodes.

The user-facing query cannot override this server gate. `mseAggregationSpillEnabled` is internal metadata and any query-supplied value is overwritten by the server.

Ensure the JVM temporary directory (`java.io.tmpdir`) has sufficient local disk capacity for concurrent spilling queries.

### 2. Configure each query

Submit the query through the multi-stage engine and set a positive group threshold. The partition count is optional:

```sql
SET mseAggregationSpillThreshold = 100000;
SET mseAggregationSpillPartitions = 16;

SELECT dimension, SUM(metric)
FROM myTable
GROUP BY dimension;
```

- `mseAggregationSpillThreshold`: maximum in-memory groups before the current hash table is spilled. If absent, spilling is disabled for the query.
- `mseAggregationSpillPartitions`: hash partition count, from 1 through 64; defaults to 8.

Choose enough partitions that each restored partition is expected to remain below `mseAggregationSpillThreshold`.

## End-to-end test

`QueryRunnerTest.testMSEAggregationSpill` exercises the complete in-process MSE path with two query servers, distributed realtime segments, mailbox exchange, and broker-side reduction.

It first runs the baseline query without spilling:

```sql
SELECT col1, SUM(col3), AVG(col3)
FROM a
GROUP BY col1
ORDER BY col1;
```

It then forces multiple spill cycles with:

```sql
SET mseAggregationSpillThreshold = 2;
SET mseAggregationSpillPartitions = 8;

SELECT col1, SUM(col3), AVG(col3)
FROM a
GROUP BY col1
ORDER BY col1;
```

The test verifies that the spilled query has exactly the same schema and ordered rows as the non-spilled query, and that the returned execution stats contain positive `spillCount`, `spilledRows`, and `spilledBytes` values.

## Test Plan

- In-process end-to-end MSE spill test described above.
- Query runtime spill suite: 207 tests passed.
- `QueryOptionsUtilsTest`: 29 tests passed.
- `AnyValueAggregationFunctionTest`: 36 tests passed.
- Spotless, Checkstyle, and license checks passed for all affected modules.
- Dedicated operator tests cover intermediate-state round trips, composite/null keys, filters, hash collisions, `ANY_VALUE` OBJECT/BYTES/UUID values, bounded records, group limits, oversized restore partitions, and cleanup on all terminal paths.

## Revert Plan

Revert this PR. The feature is default-off, so disabling `pinot.query.mse.aggregation.spill.enabled` also immediately prevents new queries from using the spill path.