### PR TITLE
[query-runtime] Skip leaf execution for empty dynamic filter

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java
@@ -99,6 +99,8 @@ public class LeafOperator extends MultiStageOperator {
   private final ResultsBlockStreamer _resultsBlockStreamer = this::addResultsBlock;
   @Nullable
   private final MultiStageQueryStats _pipelineBreakerStats;
+  private final boolean _skipExecution;
+  private final boolean _hasSegmentsAssigned;
 
   // Use a limit-sized BlockingQueue to store the results blocks and apply back pressure to the single-stage threads
   @VisibleForTesting
@@ -120,9 +122,37 @@ public class LeafOperator extends MultiStageOperator {
       QueryExecutor queryExecutor,
       ExecutorService executorService,
       @Nullable MultiStageQueryStats pipelineBreakerStats) {
+    this(context, requests, dataSchema, queryExecutor, executorService, pipelineBreakerStats, false);
+  }
+
+  /// Creates a leaf operator that skips SSE execution while retaining the normal MSE completion and statistics path.
+  ///
+  /// @param context op-chain execution context
+  /// @param dataSchema schema of the skipped leaf output
+  /// @param queryExecutor leaf query executor retained by the operator
+  /// @param executorService executor used by the operator lifecycle
+  /// @param pipelineBreakerStats upstream pipeline-breaker statistics to propagate
+  public static LeafOperator forSkippedExecution(
+      OpChainExecutionContext context,
+      DataSchema dataSchema,
+      QueryExecutor queryExecutor,
+      ExecutorService executorService,
+      @Nullable MultiStageQueryStats pipelineBreakerStats) {
+    return new LeafOperator(context, List.of(), dataSchema, queryExecutor, executorService, pipelineBreakerStats, true);
+  }
+
+  private LeafOperator(
+      OpChainExecutionContext context,
+      List<ServerQueryRequest> requests,
+      DataSchema dataSchema,
+      QueryExecutor queryExecutor,
+      ExecutorService executorService,
+      @Nullable MultiStageQueryStats pipelineBreakerStats,
+      boolean skipExecution) {
     super(context);
     int numRequests = requests.size();
-    Preconditions.checkArgument(numRequests == 1 || numRequests == 2, "Expected 1 or 2 requests, got: %s", numRequests);
+    Preconditions.checkArgument(skipExecution ? numRequests == 0 : numRequests == 1 || numRequests == 2,
+        "Expected %s requests, got: %s", skipExecution ? "no" : "1 or 2", numRequests);
     _requests = requests;
     _dataSchema = dataSchema;
     _queryExecutor = queryExecutor;
@@ -134,6 +164,8 @@ public class LeafOperator extends MultiStageOperator {
     _blockingQueue = new ArrayBlockingQueue<>(maxStreamingPendingBlocks != null ? maxStreamingPendingBlocks
         : QueryOptionValue.DEFAULT_MAX_STREAMING_PENDING_BLOCKS);
     _pipelineBreakerStats = pipelineBreakerStats;
+    _skipExecution = skipExecution;
+    _hasSegmentsAssigned = skipExecution ? hasSegmentsAssigned(context) : hasSegmentsAssigned(requests);
   }
 
   public List<ServerQueryRequest> getRequests() {
@@ -294,24 +326,27 @@ public class LeafOperator extends MultiStageOperator {
   @Override
   public StatMap<StatKey> copyStatMaps() {
     StatMap<StatKey> statMap = new StatMap<>(_statMap);
-    if (!hasSegmentsAssigned()) {
+    if (!_hasSegmentsAssigned) {
       statMap.merge(StatKey.NON_ACTIVE_WORKERS, 1);
     }
     return statMap;
   }
 
-  /// Whether this worker was given at least one segment to read.
-  ///
-  /// Decided from the request rather than from anything the query produces, so that a worker whose segments are all
-  /// pruned, or all of whose rows are filtered out, still counts as having been given work. A hybrid table produces
-  /// one request per table type, and segments on either of them are enough.
-  private boolean hasSegmentsAssigned() {
-    for (ServerQueryRequest request : _requests) {
+  private static boolean hasSegmentsAssigned(List<ServerQueryRequest> requests) {
+    for (ServerQueryRequest request : requests) {
       if (request.hasSegmentsToQuery()) {
         return true;
       }
     }
     return false;
+  }
+
+  private static boolean hasSegmentsAssigned(OpChainExecutionContext context) {
+    Map<String, List<String>> tableSegmentsMap = context.getWorkerMetadata().getLogicalTableSegmentsMap();
+    if (tableSegmentsMap == null) {
+      tableSegmentsMap = context.getWorkerMetadata().getTableSegmentsMap();
+    }
+    return tableSegmentsMap != null && tableSegmentsMap.values().stream().anyMatch(segments -> !segments.isEmpty());
   }
 
   @Override
@@ -513,7 +548,9 @@ public class LeafOperator extends MultiStageOperator {
 
   @VisibleForTesting
   void execute() {
-    if (_requests.size() == 1) {
+    if (_skipExecution) {
+      return;
+    } else if (_requests.size() == 1) {
       executeOneRequest(_requests.get(0), null);
     } else {
       // Hit 2 physical tables, one REALTIME and one OFFLINE

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanNodeToOpChain.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanNodeToOpChain.java
@@ -158,9 +158,15 @@ public class PlanNodeToOpChain {
         } else {
           pipelineBreakerQueryStats = null;
         }
-        result = new LeafOperator(context, leafStageContext.getServerQueryRequests(),
-            leafStageContext.getLeafStageBoundaryNode().getDataSchema(), leafStageContext.getLeafQueryExecutor(),
-            leafStageContext.getExecutorService(), pipelineBreakerQueryStats);
+        DataSchema dataSchema = leafStageContext.getLeafStageBoundaryNode().getDataSchema();
+        if (leafStageContext.shouldSkipLeafQueryExecution()) {
+          result = LeafOperator.forSkippedExecution(context, dataSchema, leafStageContext.getLeafQueryExecutor(),
+              leafStageContext.getExecutorService(), pipelineBreakerQueryStats);
+        } else {
+          result = new LeafOperator(context, leafStageContext.getServerQueryRequests(), dataSchema,
+              leafStageContext.getLeafQueryExecutor(), leafStageContext.getExecutorService(),
+              pipelineBreakerQueryStats);
+        }
       } else {
         result = node.visit(this, context);
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestContext.java
@@ -44,6 +44,8 @@ public class ServerPlanRequestContext {
   private final PinotQuery _pinotQuery;
   private PlanNode _leafStageBoundaryNode;
   private List<ServerQueryRequest> _serverQueryRequests;
+  private boolean _emptyDynamicFilter;
+  private boolean _leafQueryExecutionRequiredForEmptyInput;
 
   public ServerPlanRequestContext(StagePlan stagePlan, QueryExecutor leafQueryExecutor,
       ExecutorService executorService, @Nullable PipelineBreakerResult pipelineBreakerResult) {
@@ -89,5 +91,20 @@ public class ServerPlanRequestContext {
 
   public void setServerQueryRequests(List<ServerQueryRequest> serverQueryRequests) {
     _serverQueryRequests = serverQueryRequests;
+  }
+
+  /// Returns whether the completed dynamic filter proves that SSE leaf execution can be skipped safely.
+  public boolean shouldSkipLeafQueryExecution() {
+    return _emptyDynamicFilter && !_leafQueryExecutionRequiredForEmptyInput && !_pinotQuery.isExplain();
+  }
+
+  /// Records that the materialized dynamic-filter build side produced no rows.
+  public void setEmptyDynamicFilter() {
+    _emptyDynamicFilter = true;
+  }
+
+  /// Records that the leaf plan must execute because an operator above the dynamic filter is sensitive to empty input.
+  public void requireLeafQueryExecutionForEmptyInput() {
+    _leafQueryExecutionRequiredForEmptyInput = true;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -116,7 +116,9 @@ public class ServerPlanRequestUtils {
     }
 
     List<InstanceRequest> instanceRequests;
-    if (executionContext.getWorkerMetadata().getLogicalTableSegmentsMap() != null) {
+    if (serverContext.shouldSkipLeafQueryExecution()) {
+      instanceRequests = List.of();
+    } else if (executionContext.getWorkerMetadata().getLogicalTableSegmentsMap() != null) {
       instanceRequests = constructLogicalTableServerQueryRequests(executionContext, pinotQuery,
           leafQueryExecutor.getInstanceDataManager());
     } else {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestVisitor.java
@@ -75,6 +75,10 @@ public class ServerPlanRequestVisitor implements PlanNodeVisitor<Void, ServerPla
       if (!groupByList.isEmpty()) {
         pinotQuery.setGroupByList(groupByList);
       }
+      if (node.getGroupKeys().isEmpty() || node.getGroupingSets().stream().anyMatch(List::isEmpty)) {
+        // Global aggregates and grand-total grouping sets are empty-input-sensitive; retain the normal SSE path.
+        context.requireLeafQueryExecutionForEmptyInput();
+      }
       /// GROUP BY GROUPING SETS / ROLLUP / CUBE: push the per-set row expansion down to the single-stage engine. The
       /// per-set column-index lists are over groupByList (== node.getGroupKeys()), so they transfer directly. The
       /// single-stage leaf expands each row across the sets and appends the synthetic $groupingId ordinal column; the
@@ -160,19 +164,7 @@ public class ServerPlanRequestVisitor implements PlanNodeVisitor<Void, ServerPla
       // For dynamic broadcast SEMI join, right child should be a PIPELINE_BREAKER exchange. Visit the left child and
       // attach the dynamic filter to the query.
       if (visit(left, context)) {
-        PipelineBreakerResult pipelineBreakerResult = context.getPipelineBreakerResult();
-        int resultMapId = pipelineBreakerResult.getNodeIdMap().get(right);
-        List<MseBlock> blocks = pipelineBreakerResult.getResultMap().getOrDefault(resultMapId, List.of());
-        List<Object[]> resultDataContainer = new ArrayList<>();
-        DataSchema dataSchema = right.getDataSchema();
-        for (MseBlock block : blocks) {
-          if (block.isData()) {
-            resultDataContainer.addAll(((MseBlock.Data) block).asRowHeap().getRows());
-          }
-        }
-        // TODO: we should keep query stats here as well
-        ServerPlanRequestUtils.attachDynamicFilter(context.getPinotQuery(), node.getLeftKeys(), node.getRightKeys(),
-            resultDataContainer, dataSchema);
+        attachDynamicFilter(node, right, context);
       }
     } else {
       // For lookup join, visit the right child and set it as the leaf boundary.
@@ -200,19 +192,7 @@ public class ServerPlanRequestVisitor implements PlanNodeVisitor<Void, ServerPla
       // attach the dynamic filter to the query.
       if (visit(left, context)) {
         // semi join to dynamic filter logic
-        PipelineBreakerResult pipelineBreakerResult = context.getPipelineBreakerResult();
-        int resultMapId = pipelineBreakerResult.getNodeIdMap().get(right);
-        List<MseBlock> blocks = pipelineBreakerResult.getResultMap().getOrDefault(resultMapId, List.of());
-        List<Object[]> resultDataContainer = new ArrayList<>();
-        DataSchema dataSchema = right.getDataSchema();
-        for (MseBlock block : blocks) {
-          if (block.isData()) {
-            resultDataContainer.addAll(((MseBlock.Data) block).asRowHeap().getRows());
-          }
-        }
-        // TODO: we should keep query stats here as well
-        ServerPlanRequestUtils.attachDynamicFilter(context.getPinotQuery(), node.getLeftKeys(), node.getRightKeys(),
-            resultDataContainer, dataSchema);
+        attachDynamicFilter(node, right, context);
 
         PinotQuery pinotQuery = context.getPinotQuery();
         for (EnrichedJoinNode.FilterProjectRex rex : node.getFilterProjectRexes()) {
@@ -250,6 +230,25 @@ public class ServerPlanRequestVisitor implements PlanNodeVisitor<Void, ServerPla
     }
 
     return null;
+  }
+
+  private static void attachDynamicFilter(JoinNode node, PlanNode right, ServerPlanRequestContext context) {
+    PipelineBreakerResult pipelineBreakerResult = context.getPipelineBreakerResult();
+    int resultMapId = pipelineBreakerResult.getNodeIdMap().get(right);
+    List<MseBlock> blocks = pipelineBreakerResult.getResultMap().getOrDefault(resultMapId, List.of());
+    List<Object[]> resultDataContainer = new ArrayList<>();
+    DataSchema dataSchema = right.getDataSchema();
+    for (MseBlock block : blocks) {
+      if (block.isData()) {
+        resultDataContainer.addAll(((MseBlock.Data) block).asRowHeap().getRows());
+      }
+    }
+    if (resultDataContainer.isEmpty()) {
+      context.setEmptyDynamicFilter();
+    }
+    // TODO: we should keep query stats here as well
+    ServerPlanRequestUtils.attachDynamicFilter(context.getPinotQuery(), node.getLeftKeys(), node.getRightKeys(),
+        resultDataContainer, dataSchema);
   }
 
   @Override

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtilsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtilsTest.java
@@ -1,0 +1,260 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.plan.server;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.pinot.calcite.rel.logical.PinotRelExchangeType;
+import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.query.executor.QueryExecutor;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.mailbox.SendingMailbox;
+import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
+import org.apache.pinot.query.planner.plannode.AggregateNode;
+import org.apache.pinot.query.planner.plannode.AggregateNode.AggType;
+import org.apache.pinot.query.planner.plannode.EnrichedJoinNode;
+import org.apache.pinot.query.planner.plannode.JoinNode;
+import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
+import org.apache.pinot.query.planner.plannode.MailboxSendNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.apache.pinot.query.planner.plannode.TableScanNode;
+import org.apache.pinot.query.routing.MailboxInfo;
+import org.apache.pinot.query.routing.MailboxInfos;
+import org.apache.pinot.query.routing.StageMetadata;
+import org.apache.pinot.query.routing.StagePlan;
+import org.apache.pinot.query.routing.WorkerMetadata;
+import org.apache.pinot.query.runtime.blocks.MseBlock;
+import org.apache.pinot.query.runtime.operator.LeafOperator;
+import org.apache.pinot.query.runtime.operator.MultiStageOperator;
+import org.apache.pinot.query.runtime.operator.OpChain;
+import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.query.runtime.plan.pipeline.PipelineBreakerResult;
+import org.apache.pinot.segment.spi.memory.DataBuffer;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.executor.ExecutorServiceUtils;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+/// Verifies runtime pruning of probe-side leaf execution after an empty dynamic-broadcast build.
+///
+/// The class has no shared mutable state; each test owns and closes its executor.
+public class ServerPlanRequestUtilsTest {
+  private static final int STAGE_ID = 1;
+  private static final int BUILD_STAGE_ID = 2;
+  private static final int RECEIVER_STAGE_ID = 0;
+  private static final DataSchema DATA_SCHEMA =
+      new DataSchema(new String[]{"key"}, new ColumnDataType[]{ColumnDataType.INT});
+
+  @DataProvider(name = "dynamicFilterCases")
+  public Object[][] dynamicFilterCases() {
+    return new Object[][]{
+        {false, false, true, 0},
+        {true, false, true, 0},
+        {false, true, true, 0},
+        {false, false, false, 1}
+    };
+  }
+
+  @SuppressWarnings("removal")
+  @Test(dataProvider = "dynamicFilterCases")
+  public void testEmptyDynamicBroadcastBuildSkipsLeafExecution(boolean enrichedJoin, boolean logicalTable,
+      boolean hasSegments, int expectedNonActiveWorkers) {
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+    try {
+      QueryExecutor queryExecutor = mock(QueryExecutor.class);
+      when(queryExecutor.getInstanceDataManager())
+          .thenThrow(new AssertionError("Empty dynamic-filter build must not construct a leaf request"));
+
+      SendingMailbox sendingMailbox = mock(SendingMailbox.class);
+      MailboxService mailboxService = mock(MailboxService.class);
+      when(mailboxService.getHostname()).thenReturn("localhost");
+      when(mailboxService.getPort()).thenReturn(8000);
+      when(mailboxService.getSendingMailbox(anyString(), anyInt(), anyString(), anyLong(), any()))
+          .thenReturn(sendingMailbox);
+      MultiStageQueryStats receivedStats = MultiStageQueryStats.emptyStats(RECEIVER_STAGE_ID);
+      doAnswer(invocation -> {
+        List<DataBuffer> serializedStats = invocation.getArgument(1);
+        receivedStats.mergeUpstream(serializedStats);
+        return true;
+      }).when(sendingMailbox).send(any(MseBlock.Eos.class), anyList());
+
+      MailboxReceiveNode buildInput = new MailboxReceiveNode(STAGE_ID, DATA_SCHEMA, BUILD_STAGE_ID,
+          PinotRelExchangeType.PIPELINE_BREAKER, RelDistribution.Type.SINGLETON, List.of(0), List.of(), false, false,
+          null);
+      TableScanNode probeInput =
+          new TableScanNode(STAGE_ID, DATA_SCHEMA, PlanNode.NodeHint.EMPTY, List.of(), "probe", List.of("key"));
+      PlanNode dynamicFilter =
+          newDynamicFilterNode(enrichedJoin, probeInput, buildInput);
+      MailboxSendNode root = new MailboxSendNode(STAGE_ID, DATA_SCHEMA, List.of(dynamicFilter), RECEIVER_STAGE_ID,
+          PinotRelExchangeType.STREAMING, RelDistribution.Type.RANDOM_DISTRIBUTED, List.of(), false, List.of(), false,
+          "MURMUR3");
+
+      MailboxInfo receiver = new MailboxInfo("localhost", 9000, List.of(0));
+      WorkerMetadata workerMetadata =
+          new WorkerMetadata(0, Map.of(RECEIVER_STAGE_ID, new MailboxInfos(receiver)));
+      if (logicalTable) {
+        workerMetadata.setLogicalTableSegmentsMap(Map.of("probe", hasSegments ? List.of("segment") : List.of()));
+      } else {
+        workerMetadata.setTableSegmentsMap(
+            Map.of(TableType.OFFLINE.name(), hasSegments ? List.of("segment") : List.of()));
+      }
+      StageMetadata stageMetadata = new StageMetadata(STAGE_ID, List.of(workerMetadata),
+          Map.of(DispatchablePlanFragment.TABLE_NAME_KEY, "probe"));
+      MultiStageQueryStats pipelineBreakerStats = MultiStageQueryStats.emptyStats(STAGE_ID);
+      pipelineBreakerStats.mergeUpstream(MultiStageQueryStats.emptyStats(BUILD_STAGE_ID));
+      PipelineBreakerResult emptyBuild =
+          new PipelineBreakerResult(Map.of(buildInput, 0), Map.of(0, List.of()), null, pipelineBreakerStats);
+      OpChainExecutionContext context = new OpChainExecutionContext(mailboxService, 123L, "cid",
+          System.currentTimeMillis() + 60_000, System.currentTimeMillis() + 60_000, "broker", Map.of(), stageMetadata,
+          workerMetadata, emptyBuild, true, true);
+
+      OpChain opChain = ServerPlanRequestUtils.compileLeafStage(context, new StagePlan(root, stageMetadata),
+          queryExecutor, executorService, Map.of());
+      try {
+        MseBlock block = opChain.getRoot().nextBlock();
+        assertTrue(block.isSuccess());
+      } finally {
+        opChain.close();
+      }
+
+      verify(queryExecutor, never()).getInstanceDataManager();
+      verify(queryExecutor, never()).execute(any(), any(), any());
+      verify(sendingMailbox).send(any(MseBlock.Eos.class), anyList());
+      MultiStageQueryStats.StageStats.Closed stageStats = receivedStats.getUpstreamStageStats(STAGE_ID);
+      assertNotNull(stageStats);
+      assertEquals(stageStats.getOperatorType(0), MultiStageOperator.Type.LEAF);
+      assertEquals(stageStats.getOperatorType(1), MultiStageOperator.Type.MAILBOX_SEND);
+      @SuppressWarnings("unchecked")
+      StatMap<LeafOperator.StatKey> leafStats = (StatMap<LeafOperator.StatKey>) stageStats.getOperatorStats(0);
+      assertEquals(leafStats.getInt(LeafOperator.StatKey.NON_ACTIVE_WORKERS), expectedNonActiveWorkers);
+      assertNotNull(receivedStats.getUpstreamStageStats(BUILD_STAGE_ID));
+    } finally {
+      ExecutorServiceUtils.close(executorService);
+    }
+  }
+
+  @DataProvider(name = "emptyInputAggregates")
+  public Object[][] emptyInputAggregates() {
+    return new Object[][]{
+        {List.of(), List.of()},
+        {List.of(0), List.of(List.of(0), List.of())}
+    };
+  }
+
+  @Test(dataProvider = "emptyInputAggregates")
+  public void testEmptyDynamicBroadcastBuildDoesNotSkipEmptyInputAggregate(List<Integer> groupKeys,
+      List<List<Integer>> groupingSets) {
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+    try {
+      MailboxReceiveNode buildInput = new MailboxReceiveNode(STAGE_ID, DATA_SCHEMA, BUILD_STAGE_ID,
+          PinotRelExchangeType.PIPELINE_BREAKER, RelDistribution.Type.SINGLETON, List.of(0), List.of(), false, false,
+          null);
+      TableScanNode probeInput =
+          new TableScanNode(STAGE_ID, DATA_SCHEMA, PlanNode.NodeHint.EMPTY, List.of(), "probe", List.of("key"));
+      PlanNode dynamicFilter = newDynamicFilterNode(false, probeInput, buildInput);
+      DataSchema aggregateSchema = new DataSchema(new String[]{"count"}, new ColumnDataType[]{ColumnDataType.LONG});
+      AggregateNode aggregate = new AggregateNode(STAGE_ID, aggregateSchema, PlanNode.NodeHint.EMPTY,
+          List.of(dynamicFilter),
+          List.of(new RexExpression.FunctionCall(ColumnDataType.LONG, "COUNT", List.of())), List.of(-1), groupKeys,
+          AggType.LEAF, false, null, -1, groupingSets);
+      PipelineBreakerResult emptyBuild =
+          new PipelineBreakerResult(Map.of(buildInput, 0), Map.of(0, List.of()), null, null);
+      ServerPlanRequestContext context =
+          new ServerPlanRequestContext(new StagePlan(aggregate, mock(StageMetadata.class)), mock(QueryExecutor.class),
+              executorService, emptyBuild);
+
+      ServerPlanRequestVisitor.walkPlanNode(aggregate, context);
+
+      assertFalse(context.shouldSkipLeafQueryExecution());
+    } finally {
+      ExecutorServiceUtils.close(executorService);
+    }
+  }
+
+  @Test
+  public void testEmptyDynamicBroadcastBuildDoesNotSkipExplain() {
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+    try {
+      QueryExecutor queryExecutor = mock(QueryExecutor.class);
+      when(queryExecutor.getInstanceDataManager())
+          .thenThrow(new AssertionError("EXPLAIN must construct the leaf request"));
+      MailboxReceiveNode buildInput = new MailboxReceiveNode(STAGE_ID, DATA_SCHEMA, BUILD_STAGE_ID,
+          PinotRelExchangeType.PIPELINE_BREAKER, RelDistribution.Type.SINGLETON, List.of(0), List.of(), false, false,
+          null);
+      TableScanNode probeInput =
+          new TableScanNode(STAGE_ID, DATA_SCHEMA, PlanNode.NodeHint.EMPTY, List.of(), "probe", List.of("key"));
+      PlanNode dynamicFilter = newDynamicFilterNode(false, probeInput, buildInput);
+      PipelineBreakerResult emptyBuild =
+          new PipelineBreakerResult(Map.of(buildInput, 0), Map.of(0, List.of()), null, null);
+      WorkerMetadata workerMetadata = new WorkerMetadata(0, Map.of());
+      workerMetadata.setTableSegmentsMap(Map.of(TableType.OFFLINE.name(), List.of("segment")));
+      StageMetadata stageMetadata = new StageMetadata(STAGE_ID, List.of(workerMetadata),
+          Map.of(DispatchablePlanFragment.TABLE_NAME_KEY, "probe"));
+      OpChainExecutionContext context =
+          new OpChainExecutionContext(mock(MailboxService.class), 123L, "cid", System.currentTimeMillis() + 60_000,
+              System.currentTimeMillis() + 60_000, "broker", Map.of(), stageMetadata, workerMetadata, emptyBuild,
+              false, false);
+      StagePlan stagePlan = new StagePlan(dynamicFilter, stageMetadata);
+
+      assertThrows(AssertionError.class,
+          () -> ServerPlanRequestUtils.compileLeafStage(context, stagePlan, queryExecutor, executorService,
+              (planNode, operator) -> {
+              }, true, Map.of()));
+    } finally {
+      ExecutorServiceUtils.close(executorService);
+    }
+  }
+
+  @SuppressWarnings("removal")
+  private static PlanNode newDynamicFilterNode(boolean enrichedJoin, PlanNode probeInput, PlanNode buildInput) {
+    if (enrichedJoin) {
+      // Retain coverage for plans produced by older brokers during a rolling upgrade.
+      return new EnrichedJoinNode(STAGE_ID, DATA_SCHEMA, DATA_SCHEMA, PlanNode.NodeHint.EMPTY,
+          List.of(probeInput, buildInput), JoinRelType.SEMI, List.of(0), List.of(0), List.of(),
+          JoinNode.JoinStrategy.HASH, null, List.of(), -1, 0);
+    }
+    return new JoinNode(STAGE_ID, DATA_SCHEMA, PlanNode.NodeHint.EMPTY, List.of(probeInput, buildInput),
+        JoinRelType.SEMI, List.of(0), List.of(0), List.of(), JoinNode.JoinStrategy.HASH);
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
@@ -57,6 +57,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertNull;
+
 
 /// all special tests that doesn't fit into [org.apache.pinot.query.runtime.queries.ResourceBasedQueriesTest]
 /// pattern goes here.
@@ -386,6 +388,29 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
     Assert.assertNull(queryResult.getProcessingException(), "Query failed: " + queryResult.getProcessingException());
     // The RLS filter keeps only the two rows with col3 = 42.
     compareRowEquals(queryResult.getResultTable(), List.of(new Object[]{"bar", 1}, new Object[]{"bob", 1}), true);
+  }
+
+  @DataProvider(name = "emptyDynamicBroadcastAggregations")
+  public Object[][] emptyDynamicBroadcastAggregations() {
+    return new Object[][]{
+        {
+            "SELECT /*+ joinOptions(join_strategy='dynamic_broadcast') */ COUNT(*) FROM a "
+                + "WHERE a.col1 IN (SELECT b.col2 FROM b WHERE b.col3 < 0)",
+            List.<Object[]>of(new Object[]{0L})
+        },
+        {
+            "SELECT /*+ joinOptions(join_strategy='dynamic_broadcast') */ COUNT(a.col3) FROM a "
+                + "WHERE a.col1 IN (SELECT b.col2 FROM b WHERE b.col3 < 0)",
+            List.<Object[]>of(new Object[]{0L})
+        }
+    };
+  }
+
+  @Test(dataProvider = "emptyDynamicBroadcastAggregations")
+  public void testEmptyDynamicBroadcastAggregation(String sql, List<Object[]> expectedRows) {
+    QueryDispatcher.QueryResult queryResult = queryRunner(sql, false);
+    assertNull(queryResult.getProcessingException(), "Query failed: " + queryResult.getProcessingException());
+    compareRowEquals(queryResult.getResultTable(), expectedRows, true);
   }
 
   @DataProvider(name = "testDataWithSqlToFinalRowCount")


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Skip probe\-side leaf execution for empty dynamic broadcast build when not required for empty input, preserving statistics\.

```mermaid
flowchart TD
  N0["Process dynamic filter result#58; set empty flag if no data #40;F5#41;"]:::stModified
  N1["Check if leaf execution required for empty input #40;e#46;g#46;#44; global aggregate#41; #40;F5#41;"]:::stModified
  N2["Determine if leaf execution can be skipped#58; empty dynamic filter and notrequired #40;F3#44; F4#41;"]:::stModified
  N3["Create LeafOperator configured to skip execution #40;no requests#44; #95;skipExecution#61;tr #40;F1#44; F2#41;"]:::stModified
  N4["Skip leaf execution early in LeafOperator#46;execute#40;#41; #40;F1#41;"]:::stModified
  N0 --> N2
  N1 --> N2
  N2 --> N3
  N3 --> N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java) · [after](https://github.com/apache/pinot/blob/03f7a9c51e558aeba715f2b0bacb6c350ae39e96/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java)
- F2: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanNodeToOpChain\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanNodeToOpChain.java) · [after](https://github.com/apache/pinot/blob/03f7a9c51e558aeba715f2b0bacb6c350ae39e96/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanNodeToOpChain.java)
- F3: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestContext\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestContext.java) · [after](https://github.com/apache/pinot/blob/03f7a9c51e558aeba715f2b0bacb6c350ae39e96/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestContext.java)
- F4: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java) · [after](https://github.com/apache/pinot/blob/03f7a9c51e558aeba715f2b0bacb6c350ae39e96/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java)
- F5: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestVisitor\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestVisitor.java) · [after](https://github.com/apache/pinot/blob/03f7a9c51e558aeba715f2b0bacb6c350ae39e96/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestVisitor.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImU2Nzg3ZTE3ODY0NWZkM2M1YTg4N2UyYWJhN2UwZGU4MzQzY2Q1MjQiLCJjb250ZXh0X2hhc2giOiI1Yzc2MTRjODQwNmJkYWQyYmQ0MjY2OWQ0NzVhNzRiOGFkNTkzNTdhMWY5MDhiN2NiMDVhYjUwZDhlYTE0YzI3IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NjEyNzI5LCJoZWFkX3NoYSI6IjAzZjdhOWM1MWU1NThhZWJhNzE1ZjJiMGJhY2I2YzM1MGFlMzllOTYiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJlNjc4N2UxNzg2NDVmZDNjNWE4ODdlMmFiYTdlMGRlODM0M2NkNTI0IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 1e53a7e1424933cf97060ea9ac22c211db7cd460c120f70da266c9397b78aaaa -->
<!-- pinot-pr-flow:end -->

## Summary

This PR replaces the unused partition-coalescing policy with a minimal, executable AQE proof of concept in Pinot's multi-stage engine.

For a dynamic-broadcast SEMI JOIN, the existing pipeline breaker materializes the build side before the probe leaf is compiled. When that runtime result is empty, Pinot now skips constructing and executing the probe-side single-stage requests while preserving the normal multi-stage operator chain, mailbox EOS, pipeline-breaker statistics, and leaf/send statistics.

This is deliberately narrower than changing stage parallelism: Pinot's current streaming mailbox graph is eagerly dispatched and binds routing to concrete workers, so resizing a downstream stage after its producer completes is not yet safe.

## Design

```text
build-side mailbox exchange (PIPELINE_BREAKER)
                      |
                      v
          materialize build rows + stats
                      |
                 build empty?
                 /          \
              yes            no
               |              |
      skip probe SSE      construct 1-2 SSE
      request creation      leaf requests
               |              |
               +-------+------+
                       |
                       v
             normal LeafOperator path
                       |
                       v
          mailbox EOS + leaf/send/build stats
```

The skip decision is explicit: normal `LeafOperator` construction still requires one or two server requests. Empty-input-sensitive operators—global aggregates and grouping sets containing the grand-total `()` set—remain on the normal SSE path. EXPLAIN also retains normal request construction.

## Roadmap: downstream parallelism AQE

Supporting "complete a stage, then resize an undispatched downstream stage" requires all three seams together:

```text
producer stage
      |
      v
materialized logical partitions (consumer-independent identities)
      |
      v
all-worker completion barrier + exact partition bytes
      |
      v
broker AQE rule: coalesce M logical partitions into K ranges
      |
      v
late-bind ranges to K workers and dispatch consumer stage
```

1. Add an opt-in materialized HASH exchange with static parallelism.
2. Add broker-owned staged dispatch and all-worker completion barriers, initially without adaptation.
3. Late-bind materialized logical partitions to consumer workers.
4. Add deterministic contiguous partition coalescing (`M -> K`) using completed byte statistics.
5. Harden with stage-attempt fencing, cleanup/quotas, observability, rollout gating, and mixed-version behavior.

Join reordering, dynamic stage insertion/removal, running-stage cancellation, and retries are out of scope for the first rule.

## Test Plan

- 37 focused `LeafOperator`, pipeline-breaker, and server-plan tests passed.
- 141 `QueryRunnerTest` cases passed, including empty-build global aggregation and dynamic-broadcast success/failure paths.
- `./mvnw spotless:apply -pl pinot-query-runtime`
- `./mvnw checkstyle:check -pl pinot-query-runtime`
- `./mvnw license:format -pl pinot-query-runtime`
- `./mvnw license:check -pl pinot-query-runtime`
- `./mvnw test-compile -pl pinot-query-runtime -Dmaven.compiler.showDeprecation=true -Dmaven.compiler.showWarnings=true`

A full dependency build was also attempted but is currently blocked by the existing `pinot-segment-local` `ZstandardDecompressor` / `org.jetbrains.annotations.NotNull` compilation issue.
