### PR TITLE
Add dependency-ordered staged dispatch

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -726,6 +726,11 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.MATERIALIZED_EXCHANGE));
   }
 
+  /// Returns whether the query opts into dependency-ordered stage dispatch.
+  public static boolean isStagedDispatch(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.STAGED_DISPATCH));
+  }
+
   public static boolean isMultiClusterRoutingEnabled(Map<String, String> queryOptions, boolean defaultValue) {
     String option = queryOptions.get(QueryOptionKey.ENABLE_MULTI_CLUSTER_ROUTING);
     return option != null ? Boolean.parseBoolean(option) : defaultValue;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -721,6 +721,11 @@ public class QueryOptionsUtils {
     return option != null ? Boolean.parseBoolean(option) : defaultValue;
   }
 
+  /// Returns whether the query opts into the experimental file-backed HASH exchange.
+  public static boolean isMaterializedExchange(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.MATERIALIZED_EXCHANGE));
+  }
+
   public static boolean isMultiClusterRoutingEnabled(Map<String, String> queryOptions, boolean defaultValue) {
     String option = queryOptions.get(QueryOptionKey.ENABLE_MULTI_CLUSTER_ROUTING);
     return option != null ? Boolean.parseBoolean(option) : defaultValue;

--- a/pinot-common/src/main/proto/mailbox.proto
+++ b/pinot-common/src/main/proto/mailbox.proto
@@ -23,6 +23,8 @@ package org.apache.pinot.common.proto;
 
 service PinotMailbox {
   rpc open(stream MailboxContent) returns (stream MailboxStatus);
+
+  rpc readMaterializedPartition(MaterializedPartitionRequest) returns (stream MaterializedPartitionContent);
 }
 
 message MailboxStatus {
@@ -35,4 +37,17 @@ message MailboxContent {
   bytes payload = 2;
   map<string, string> metadata = 3;
   bool waitForMore = 4;
+}
+
+message MaterializedPartitionRequest {
+  int64 requestId = 1;
+  int32 producerStageId = 2;
+  int32 producerWorkerId = 3;
+  int32 logicalPartitionId = 4;
+  int64 deadlineMs = 5;
+}
+
+message MaterializedPartitionContent {
+  bytes payload = 1;
+  bool endOfBlock = 2;
 }

--- a/pinot-common/src/main/proto/plan.proto
+++ b/pinot-common/src/main/proto/plan.proto
@@ -199,6 +199,7 @@ message MailboxReceiveNode {
   repeated Collation collations = 5;
   bool sort = 6;
   bool sortedOnSender = 7;
+  bool materialized = 8;
 }
 
 message MailboxSendNode {
@@ -212,6 +213,7 @@ message MailboxSendNode {
   bool sort = 7;
   repeated int32 receiverStageIds = 8;
   string hashFunction = 9;
+  bool materialized = 10;
 }
 
 message ProjectNode {

--- a/pinot-common/src/main/proto/worker.proto
+++ b/pinot-common/src/main/proto/worker.proto
@@ -150,6 +150,21 @@ message OpChainComplete {
   bool success = 3;
   string error_msg = 4;            // populated when success = false
   MultiStageStatsTree stats = 5;   // structured, tree-shaped stats payload
+  repeated MaterializedPartitionHandle materialized_output = 6;
+}
+
+// Producer-local materialized HASH partition. Its identity deliberately excludes
+// consumer stage and worker ids so a later phase can bind consumers after production.
+message MaterializedPartitionHandle {
+  int64 request_id = 1;
+  int32 producer_stage_id = 2;
+  int32 producer_worker_id = 3;
+  int32 logical_partition_id = 4;
+  string host = 5;
+  int32 transfer_port = 6;
+  string opaque_file_id = 7;
+  int64 row_count = 8;
+  int64 byte_count = 9;
 }
 
 // Final marker on the server-to-broker stream.

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -82,6 +82,7 @@ import org.apache.pinot.query.planner.logical.PinotLogicalQueryPlanner;
 import org.apache.pinot.query.planner.logical.RelToPlanNodeConverter;
 import org.apache.pinot.query.planner.logical.TransformationTracker;
 import org.apache.pinot.query.planner.physical.DispatchableSubPlan;
+import org.apache.pinot.query.planner.physical.MaterializedExchangePlanner;
 import org.apache.pinot.query.planner.physical.PinotDispatchPlanner;
 import org.apache.pinot.query.planner.physical.v2.PRelNode;
 import org.apache.pinot.query.planner.physical.v2.PRelNodeTreeValidator;
@@ -518,19 +519,25 @@ public class QueryEnvironment {
   private DispatchableSubPlan toDispatchableSubPlan(RelRoot relRoot, PlannerContext plannerContext,
       @Nullable TransformationTracker.Builder<PlanNode, RelNode> tracker) {
     long requestId = _envConfig.getRequestId();
+    DispatchableSubPlan dispatchableSubPlan;
     if (plannerContext.isUsePhysicalOptimizer()) {
       Pair<SubPlan, PlanFragmentAndMailboxAssignment.Result> plan = PinotLogicalQueryPlanner.makePlanV2(relRoot,
           plannerContext.getPhysicalPlannerContext());
       PinotDispatchPlanner pinotDispatchPlanner = new PinotDispatchPlanner(plannerContext,
           _envConfig.getWorkerManager(), requestId, _envConfig.getTableCache());
-      return pinotDispatchPlanner.createDispatchableSubPlanV2(plan.getLeft(), plan.getRight());
+      dispatchableSubPlan = pinotDispatchPlanner.createDispatchableSubPlanV2(plan.getLeft(), plan.getRight());
+    } else {
+      SubPlan plan = PinotLogicalQueryPlanner.makePlan(relRoot, tracker, useSpools(plannerContext.getOptions()),
+          _envConfig.defaultHashFunction(), pruneUnnestColumns(plannerContext.getOptions()));
+      PinotDispatchPlanner pinotDispatchPlanner =
+          new PinotDispatchPlanner(plannerContext, _envConfig.getWorkerManager(), _envConfig.getRequestId(),
+              _envConfig.getTableCache());
+      dispatchableSubPlan = pinotDispatchPlanner.createDispatchableSubPlan(plan, _multiClusterRoutingContext);
     }
-    SubPlan plan = PinotLogicalQueryPlanner.makePlan(relRoot, tracker, useSpools(plannerContext.getOptions()),
-        _envConfig.defaultHashFunction(), pruneUnnestColumns(plannerContext.getOptions()));
-    PinotDispatchPlanner pinotDispatchPlanner =
-        new PinotDispatchPlanner(plannerContext, _envConfig.getWorkerManager(), _envConfig.getRequestId(),
-            _envConfig.getTableCache());
-    return pinotDispatchPlanner.createDispatchableSubPlan(plan, _multiClusterRoutingContext);
+    if (QueryOptionsUtils.isMaterializedExchange(plannerContext.getOptions())) {
+      MaterializedExchangePlanner.markFirstEligible(dispatchableSubPlan);
+    }
+    return dispatchableSubPlan;
   }
 
   // --------------------------------------------------------------------------

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/MaterializedExchangePlanner.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/MaterializedExchangePlanner.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.pinot.calcite.rel.logical.PinotRelExchangeType;
+import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
+import org.apache.pinot.query.planner.plannode.MailboxSendNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+
+
+/// Marks one deterministic HASH exchange for file-backed materialization.
+///
+/// This planner changes no worker assignment or mailbox metadata and marks at most one ordinary, unsorted,
+/// single-consumer exchange whose receiver is a server stage. The query option that invokes it is disabled by default.
+public final class MaterializedExchangePlanner {
+  private MaterializedExchangePlanner() {
+  }
+
+  public static boolean markFirstEligible(DispatchableSubPlan subPlan) {
+    for (DispatchablePlanFragment receiverFragment : subPlan.getQueryStagesWithoutRoot()) {
+      List<MailboxReceiveNode> receiveNodes = new ArrayList<>();
+      collectReceiveNodes(receiverFragment.getPlanFragment().getFragmentRoot(), receiveNodes);
+      for (MailboxReceiveNode receiveNode : receiveNodes) {
+        DispatchablePlanFragment senderFragment = subPlan.getQueryStageMap().get(receiveNode.getSenderStageId());
+        if (senderFragment == null
+            || !(senderFragment.getPlanFragment().getFragmentRoot() instanceof MailboxSendNode)) {
+          continue;
+        }
+        MailboxSendNode sendNode = (MailboxSendNode) senderFragment.getPlanFragment().getFragmentRoot();
+        if (isEligible(sendNode, receiveNode, receiverFragment.getPlanFragment().getFragmentId())) {
+          sendNode.setMaterialized(true);
+          receiveNode.setMaterialized(true);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean isEligible(MailboxSendNode sendNode, MailboxReceiveNode receiveNode, int receiverStageId) {
+    return sendNode.getExchangeType() == PinotRelExchangeType.STREAMING
+        && receiveNode.getExchangeType() == PinotRelExchangeType.STREAMING
+        && sendNode.getDistributionType() == RelDistribution.Type.HASH_DISTRIBUTED
+        && receiveNode.getDistributionType() == RelDistribution.Type.HASH_DISTRIBUTED
+        && !sendNode.isMultiSend()
+        && !sendNode.isPrePartitioned()
+        && !sendNode.isSort()
+        && !receiveNode.isSort()
+        && sendNode.getReceiverStageId() == receiverStageId;
+  }
+
+  private static void collectReceiveNodes(PlanNode node, List<MailboxReceiveNode> receiveNodes) {
+    if (node instanceof MailboxReceiveNode) {
+      receiveNodes.add((MailboxReceiveNode) node);
+    }
+    for (PlanNode input : node.getInputs()) {
+      collectReceiveNodes(input, receiveNodes);
+    }
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/MailboxReceiveNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/MailboxReceiveNode.java
@@ -36,6 +36,7 @@ public class MailboxReceiveNode extends BasePlanNode {
   private final List<RelFieldCollation> _collations;
   private final boolean _sort;
   private final boolean _sortedOnSender;
+  private boolean _materialized;
 
   // NOTE: This is only available during query planning, and should not be serialized.
   private transient MailboxSendNode _sender;
@@ -45,6 +46,14 @@ public class MailboxReceiveNode extends BasePlanNode {
       PinotRelExchangeType exchangeType, RelDistribution.Type distributionType, @Nullable List<Integer> keys,
       @Nullable List<RelFieldCollation> collations, boolean sort, boolean sortedOnSender,
       @Nullable MailboxSendNode sender) {
+    this(stageId, dataSchema, senderStageId, exchangeType, distributionType, keys, collations, sort, sortedOnSender,
+        sender, false);
+  }
+
+  public MailboxReceiveNode(int stageId, DataSchema dataSchema, int senderStageId,
+      PinotRelExchangeType exchangeType, RelDistribution.Type distributionType, @Nullable List<Integer> keys,
+      @Nullable List<RelFieldCollation> collations, boolean sort, boolean sortedOnSender,
+      @Nullable MailboxSendNode sender, boolean materialized) {
     super(stageId, dataSchema, null, List.of());
     _senderStageId = senderStageId;
     _exchangeType = exchangeType;
@@ -54,6 +63,7 @@ public class MailboxReceiveNode extends BasePlanNode {
     _sort = sort;
     _sortedOnSender = sortedOnSender;
     _sender = sender;
+    _materialized = materialized;
   }
 
   public int getSenderStageId() {
@@ -90,6 +100,14 @@ public class MailboxReceiveNode extends BasePlanNode {
     return _sortedOnSender;
   }
 
+  public boolean isMaterialized() {
+    return _materialized;
+  }
+
+  public void setMaterialized(boolean materialized) {
+    _materialized = materialized;
+  }
+
   public MailboxSendNode getSender() {
     assert _sender != null;
     return _sender;
@@ -102,7 +120,7 @@ public class MailboxReceiveNode extends BasePlanNode {
 
   @Override
   public String explain() {
-    return "MAIL_RECEIVE(" + _distributionType + ")";
+    return "MAIL_RECEIVE(" + _distributionType + ")" + (_materialized ? "[MATERIALIZED]" : "");
   }
 
   @Override
@@ -118,7 +136,7 @@ public class MailboxReceiveNode extends BasePlanNode {
 
   public MailboxReceiveNode withSender(MailboxSendNode sender) {
     return new MailboxReceiveNode(_stageId, _dataSchema, _senderStageId, _exchangeType, _distributionType, _keys,
-        _collations, _sort, _sortedOnSender, sender);
+        _collations, _sort, _sortedOnSender, sender, _materialized);
   }
 
   @Override
@@ -135,12 +153,12 @@ public class MailboxReceiveNode extends BasePlanNode {
     MailboxReceiveNode that = (MailboxReceiveNode) o;
     return _senderStageId == that._senderStageId && _sort == that._sort && _sortedOnSender == that._sortedOnSender
         && _exchangeType == that._exchangeType && _distributionType == that._distributionType && Objects.equals(_keys,
-        that._keys) && Objects.equals(_collations, that._collations);
+        that._keys) && Objects.equals(_collations, that._collations) && _materialized == that._materialized;
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), _senderStageId, _exchangeType, _distributionType, _keys, _collations, _sort,
-        _sortedOnSender);
+        _sortedOnSender, _materialized);
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/MailboxSendNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/MailboxSendNode.java
@@ -39,12 +39,13 @@ public class MailboxSendNode extends BasePlanNode {
   private final List<RelFieldCollation> _collations;
   private final boolean _sort;
   private final String _hashFunction;
+  private boolean _materialized;
 
   // NOTE: null List is converted to empty List because there is no way to differentiate them in proto during ser/de.
   private MailboxSendNode(int stageId, DataSchema dataSchema, List<PlanNode> inputs,
       BitSet receiverStages, PinotRelExchangeType exchangeType,
       RelDistribution.Type distributionType, @Nullable List<Integer> keys, boolean prePartitioned,
-      @Nullable List<RelFieldCollation> collations, boolean sort, String hashFunction) {
+      @Nullable List<RelFieldCollation> collations, boolean sort, String hashFunction, boolean materialized) {
     super(stageId, dataSchema, null, inputs);
     _receiverStages = receiverStages;
     _exchangeType = exchangeType;
@@ -54,6 +55,7 @@ public class MailboxSendNode extends BasePlanNode {
     _collations = collations != null ? collations : List.of();
     _sort = sort;
     _hashFunction = hashFunction;
+    _materialized = materialized;
   }
 
   public MailboxSendNode(int stageId, DataSchema dataSchema, List<PlanNode> inputs,
@@ -61,7 +63,7 @@ public class MailboxSendNode extends BasePlanNode {
       RelDistribution.Type distributionType, @Nullable List<Integer> keys, boolean prePartitioned,
       @Nullable List<RelFieldCollation> collations, boolean sort, String hashFunction) {
     this(stageId, dataSchema, inputs, toBitSet(receiverStages), exchangeType,
-        distributionType, keys, prePartitioned, collations, sort, hashFunction);
+        distributionType, keys, prePartitioned, collations, sort, hashFunction, false);
   }
 
   public MailboxSendNode(int stageId, DataSchema dataSchema, List<PlanNode> inputs,
@@ -69,7 +71,15 @@ public class MailboxSendNode extends BasePlanNode {
       RelDistribution.Type distributionType, @Nullable List<Integer> keys, boolean prePartitioned,
       @Nullable List<RelFieldCollation> collations, boolean sort, String hashFunction) {
     this(stageId, dataSchema, inputs, toBitSet(receiverStage), exchangeType, distributionType, keys, prePartitioned,
-        collations, sort, hashFunction);
+        collations, sort, hashFunction, false);
+  }
+
+  public MailboxSendNode(int stageId, DataSchema dataSchema, List<PlanNode> inputs,
+      @Nullable List<Integer> receiverStages, PinotRelExchangeType exchangeType,
+      RelDistribution.Type distributionType, @Nullable List<Integer> keys, boolean prePartitioned,
+      @Nullable List<RelFieldCollation> collations, boolean sort, String hashFunction, boolean materialized) {
+    this(stageId, dataSchema, inputs, toBitSet(receiverStages), exchangeType,
+        distributionType, keys, prePartitioned, collations, sort, hashFunction, materialized);
   }
 
   private static BitSet toBitSet(int receiverStage) {
@@ -162,6 +172,14 @@ public class MailboxSendNode extends BasePlanNode {
     return _hashFunction;
   }
 
+  public boolean isMaterialized() {
+    return _materialized;
+  }
+
+  public void setMaterialized(boolean materialized) {
+    _materialized = materialized;
+  }
+
   @Override
   public String explain() {
     StringBuilder sb = new StringBuilder();
@@ -174,6 +192,9 @@ public class MailboxSendNode extends BasePlanNode {
     if (isSort()) {
       sb.append("[SORTED]");
     }
+    if (isMaterialized()) {
+      sb.append("[MATERIALIZED]");
+    }
     return sb.toString();
   }
 
@@ -185,7 +206,7 @@ public class MailboxSendNode extends BasePlanNode {
   @Override
   public PlanNode withInputs(List<PlanNode> inputs) {
     return new MailboxSendNode(_stageId, _dataSchema, inputs, _receiverStages, _exchangeType, _distributionType, _keys,
-        _prePartitioned, _collations, _sort, _hashFunction);
+        _prePartitioned, _collations, _sort, _hashFunction, _materialized);
   }
 
   @Override
@@ -203,13 +224,13 @@ public class MailboxSendNode extends BasePlanNode {
     return Objects.equals(_receiverStages, that._receiverStages) && _prePartitioned == that._prePartitioned
         && _sort == that._sort && _exchangeType == that._exchangeType && _distributionType == that._distributionType
         && Objects.equals(_keys, that._keys) && Objects.equals(_collations, that._collations)
-        && Objects.equals(_hashFunction, that._hashFunction);
+        && Objects.equals(_hashFunction, that._hashFunction) && _materialized == that._materialized;
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), _receiverStages, _exchangeType, _distributionType, _keys, _prePartitioned,
-        _collations, _sort, _hashFunction);
+        _collations, _sort, _hashFunction, _materialized);
   }
 
   @Override

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeDeserializer.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeDeserializer.java
@@ -158,7 +158,7 @@ public class PlanNodeDeserializer {
         protoMailboxReceiveNode.getSenderStageId(), convertExchangeType(protoMailboxReceiveNode.getExchangeType()),
         convertDistributionType(protoMailboxReceiveNode.getDistributionType()), protoMailboxReceiveNode.getKeysList(),
         convertCollations(protoMailboxReceiveNode.getCollationsList()), protoMailboxReceiveNode.getSort(),
-        protoMailboxReceiveNode.getSortedOnSender(), null);
+        protoMailboxReceiveNode.getSortedOnSender(), null, protoMailboxReceiveNode.getMaterialized());
   }
 
   private static MailboxSendNode deserializeMailboxSendNode(Plan.PlanNode protoNode) {
@@ -181,7 +181,7 @@ public class PlanNodeDeserializer {
         receiverIds, convertExchangeType(protoMailboxSendNode.getExchangeType()),
         convertDistributionType(protoMailboxSendNode.getDistributionType()), protoMailboxSendNode.getKeysList(),
         protoMailboxSendNode.getPrePartitioned(), convertCollations(protoMailboxSendNode.getCollationsList()),
-        protoMailboxSendNode.getSort(), hashFunction);
+        protoMailboxSendNode.getSort(), hashFunction, protoMailboxSendNode.getMaterialized());
   }
 
   private static ProjectNode deserializeProjectNode(Plan.PlanNode protoNode) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeSerializer.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeSerializer.java
@@ -183,6 +183,7 @@ public class PlanNodeSerializer {
           .addAllCollations(convertCollations(node.getCollations()))
           .setSort(node.isSort())
           .setSortedOnSender(node.isSortedOnSender())
+          .setMaterialized(node.isMaterialized())
           .build();
       builder.setMailboxReceiveNode(mailboxReceiveNode);
       return null;
@@ -207,6 +208,7 @@ public class PlanNodeSerializer {
           .setHashFunction(node.getHashFunction())
           .addAllCollations(convertCollations(node.getCollations()))
           .setSort(node.isSort())
+          .setMaterialized(node.isMaterialized())
           .build();
       builder.setMailboxSendNode(mailboxSendNode);
       return null;

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/PinotDispatchPlannerTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/PinotDispatchPlannerTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.query.QueryEnvironmentTestBase;
+import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
 import org.apache.pinot.query.planner.plannode.MailboxSendNode;
 import org.apache.pinot.query.planner.plannode.PlanNode;
 import org.testng.annotations.Test;
@@ -120,6 +121,52 @@ public class PinotDispatchPlannerTest extends QueryEnvironmentTestBase {
     for (Map.Entry<Integer, DispatchablePlanFragment> entry : subPlan.getQueryStageMap().entrySet()) {
       assertFalse(entry.getValue().getWorkerMetadataList().isEmpty(), "No worker for stage: " + entry.getKey());
     }
+  }
+
+  @Test
+  public void testMaterializedExchangeIsDefaultOff() {
+    DispatchableSubPlan subPlan =
+        _queryEnvironment.planQuery("SELECT col1, COUNT(*) FROM a GROUP BY col1");
+
+    assertEquals(countMaterializedNodes(subPlan), 0);
+  }
+
+  @Test
+  public void testMaterializedExchangeMarksOneHashEdge() {
+    DispatchableSubPlan subPlan =
+        _queryEnvironment.planQuery("SET materializedExchange=true; SELECT col1, COUNT(*) FROM a GROUP BY col1");
+
+    assertEquals(countMaterializedNodes(subPlan), 2);
+  }
+
+  @Test
+  public void testMaterializedExchangeMarksOneHashEdgeWithPhysicalOptimizer() {
+    DispatchableSubPlan subPlan = _queryEnvironment.planQuery(
+        "SET usePhysicalOptimizer=true; SET materializedExchange=true; "
+            + "SELECT col1, COUNT(*) FROM a GROUP BY col1");
+
+    assertEquals(countMaterializedNodes(subPlan), 2);
+  }
+
+  private static int countMaterializedNodes(DispatchableSubPlan subPlan) {
+    int count = 0;
+    for (DispatchablePlanFragment fragment : subPlan.getQueryStages()) {
+      count += countMaterializedNodes(fragment.getPlanFragment().getFragmentRoot());
+    }
+    return count;
+  }
+
+  private static int countMaterializedNodes(PlanNode node) {
+    int count = 0;
+    if (node instanceof MailboxSendNode && ((MailboxSendNode) node).isMaterialized()) {
+      count++;
+    } else if (node instanceof MailboxReceiveNode && ((MailboxReceiveNode) node).isMaterialized()) {
+      count++;
+    }
+    for (PlanNode input : node.getInputs()) {
+      count += countMaterializedNodes(input);
+    }
+    return count;
   }
 
   private static boolean hasMultiReceiverSend(DispatchableSubPlan subPlan) {

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/serde/PlanNodeSerDeTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/serde/PlanNodeSerDeTest.java
@@ -51,6 +51,16 @@ public class PlanNodeSerDeTest extends QueryEnvironmentTestBase {
   }
 
   @Test
+  public void testMaterializedExchangeSerDe() {
+    DispatchableSubPlan dispatchableSubPlan =
+        _queryEnvironment.planQuery("SET materializedExchange=true; SELECT col1, COUNT(*) FROM a GROUP BY col1");
+    for (DispatchablePlanFragment dispatchablePlanFragment : dispatchableSubPlan.getQueryStages()) {
+      PlanNode stagePlan = dispatchablePlanFragment.getPlanFragment().getFragmentRoot();
+      assertEquals(PlanNodeDeserializer.process(PlanNodeSerializer.process(stagePlan)), stagePlan);
+    }
+  }
+
+  @Test
   public void testPrunedUnnestNodeSerDe() {
     // Round-trips the passthrough-pruning wire fields (passthroughInputIndexes, prunedPassthrough). A non-sequential
     // index list plus WITH ORDINALITY exercise the proto repeated/bool fields and ordering.

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/MailboxService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/MailboxService.java
@@ -22,19 +22,33 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
+import io.grpc.Status;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.config.TlsConfig;
+import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.metrics.BrokerGauge;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.proto.Mailbox;
+import org.apache.pinot.common.proto.PinotMailboxGrpc;
+import org.apache.pinot.common.proto.Worker;
 import org.apache.pinot.common.utils.grpc.ServerGrpcQueryClient;
 import org.apache.pinot.core.instance.context.BrokerContext;
 import org.apache.pinot.core.instance.context.ControllerContext;
@@ -44,6 +58,11 @@ import org.apache.pinot.query.access.QueryAccessControlFactory;
 import org.apache.pinot.query.grpc.GrpcKeepAliveConfig;
 import org.apache.pinot.query.mailbox.channel.ChannelManager;
 import org.apache.pinot.query.mailbox.channel.GrpcMailboxServer;
+import org.apache.pinot.query.mailbox.materialized.MaterializedMailboxKey;
+import org.apache.pinot.query.mailbox.materialized.MaterializedMailboxStore;
+import org.apache.pinot.query.mailbox.materialized.MaterializedSendingMailbox;
+import org.apache.pinot.query.runtime.blocks.MseBlock;
+import org.apache.pinot.query.runtime.blocks.SerializedDataBlock;
 import org.apache.pinot.query.runtime.operator.MailboxSendOperator;
 import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -81,6 +100,11 @@ public class MailboxService {
   private final InstanceType _instanceType;
   private final PinotConfiguration _config;
   private final ChannelManager _channelManager;
+  private final Path _materializedMailboxRoot;
+  private final Object _materializedMailboxStoreLock = new Object();
+  @Nullable
+  private MaterializedMailboxStore _materializedMailboxStore;
+  private boolean _shutdown;
   @Nullable private final TlsConfig _tlsConfig;
   @Nullable
   private final SslContext _clientSslContext;
@@ -111,6 +135,14 @@ public class MailboxService {
 
   public MailboxService(String hostname, int port, InstanceType instanceType, PinotConfiguration config,
       @Nullable TlsConfig tlsConfig, @Nullable QueryAccessControlFactory accessControlFactory) {
+    this(hostname, port, instanceType, config, tlsConfig, accessControlFactory,
+        MaterializedMailboxStore.defaultRoot(hostname, port));
+  }
+
+  @VisibleForTesting
+  MailboxService(String hostname, int port, InstanceType instanceType, PinotConfiguration config,
+      @Nullable TlsConfig tlsConfig, @Nullable QueryAccessControlFactory accessControlFactory,
+      Path materializedMailboxRoot) {
     _hostname = hostname;
     _port = port;
     _instanceType = instanceType;
@@ -135,6 +167,7 @@ public class MailboxService {
     GrpcKeepAliveConfig keepAliveConfig = GrpcKeepAliveConfig.forMailboxChannels(config);
     _channelManager = new ChannelManager(_clientSslContext, _maxInboundMessageSize, getIdleTimeout(config),
         writeBufferHighWaterMarkBytes, writeBufferLowWaterMarkBytes, keepAliveConfig);
+    _materializedMailboxRoot = materializedMailboxRoot;
     _accessControlFactory = accessControlFactory;
     registerMailboxClientGauges();
     LOGGER.info("Initialized MailboxService with hostname: {}, port: {}, channel {}", hostname, port,
@@ -192,7 +225,19 @@ public class MailboxService {
   /// Shuts down the mailbox service.
   public void shutdown() {
     LOGGER.info("Shutting down GrpcMailboxServer");
-    _grpcMailboxServer.shutdown();
+    MaterializedMailboxStore materializedMailboxStore;
+    synchronized (_materializedMailboxStoreLock) {
+      _shutdown = true;
+      materializedMailboxStore = _materializedMailboxStore;
+      _materializedMailboxStore = null;
+    }
+    try {
+      _grpcMailboxServer.shutdown();
+    } finally {
+      if (materializedMailboxStore != null) {
+        materializedMailboxStore.close();
+      }
+    }
   }
 
   public String getHostname() {
@@ -220,6 +265,97 @@ public class MailboxService {
     } else {
       return new GrpcSendingMailbox(mailboxId, _channelManager, hostname, port, deadlineMs, statMap,
           _maxInboundMessageSize, _grpcSenderBackpressureEnabled);
+    }
+  }
+
+  /// Returns a producer-local mailbox that publishes its output handle only after successful EOS.
+  public SendingMailbox getMaterializedSendingMailbox(long requestId, int producerStageId, int producerWorkerId,
+      int logicalPartitionId, StatMap<MailboxSendOperator.StatKey> statMap,
+      Consumer<Worker.MaterializedPartitionHandle> onCommit) {
+    MaterializedMailboxKey key =
+        new MaterializedMailboxKey(requestId, producerStageId, producerWorkerId, logicalPartitionId);
+    return new MaterializedSendingMailbox(getMaterializedMailboxStore(), key, statMap, onCommit);
+  }
+
+  /// Reads one producer partition as a lazy iterator of serialized MSE data blocks.
+  ///
+  /// Local and remote reads have the same contract: creation waits for atomic commit until `deadlineMs`; iteration
+  /// throws on storage or transport failure; exhausting the iterator causes the producer to delete the file.
+  public Iterator<MseBlock.Data> readMaterializedPartition(String hostname, int port, long requestId,
+      int producerStageId, int producerWorkerId, int logicalPartitionId, long deadlineMs) {
+    Iterator<byte[]> records;
+    if (_hostname.equals(hostname) && _port == port) {
+      records = readMaterializedPartitionRecords(requestId, producerStageId, producerWorkerId, logicalPartitionId,
+          deadlineMs);
+    } else {
+      long remainingMs = deadlineMs - System.currentTimeMillis();
+      if (remainingMs <= 0) {
+        throw Status.DEADLINE_EXCEEDED.withDescription("Materialized partition deadline elapsed").asRuntimeException();
+      }
+      Mailbox.MaterializedPartitionRequest request = Mailbox.MaterializedPartitionRequest.newBuilder()
+          .setRequestId(requestId)
+          .setProducerStageId(producerStageId)
+          .setProducerWorkerId(producerWorkerId)
+          .setLogicalPartitionId(logicalPartitionId)
+          .setDeadlineMs(deadlineMs)
+          .build();
+      Iterator<Mailbox.MaterializedPartitionContent> chunks =
+          PinotMailboxGrpc.newBlockingStub(_channelManager.getChannel(hostname, port))
+              .withDeadlineAfter(remainingMs, TimeUnit.MILLISECONDS)
+              .readMaterializedPartition(request);
+      records = new MaterializedRecordIterator(chunks);
+    }
+    return new Iterator<MseBlock.Data>() {
+      @Override
+      public boolean hasNext() {
+        return records.hasNext();
+      }
+
+      @Override
+      public MseBlock.Data next() {
+        byte[] payload = records.next();
+        try {
+          return new SerializedDataBlock(DataBlockUtils.deserialize(List.of(ByteBuffer.wrap(payload))));
+        } catch (IOException e) {
+          throw new UncheckedIOException("Failed to deserialize materialized partition", e);
+        }
+      }
+    };
+  }
+
+  /// Internal transport seam used by [GrpcMailboxServer] to stream the exact records stored on disk.
+  public Iterator<byte[]> readMaterializedPartitionRecords(long requestId, int producerStageId, int producerWorkerId,
+      int logicalPartitionId, long deadlineMs) {
+    try {
+      return getMaterializedMailboxStore().read(
+          new MaterializedMailboxKey(requestId, producerStageId, producerWorkerId, logicalPartitionId), deadlineMs);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to open materialized partition", e);
+    }
+  }
+
+  /// Cancels pending readers and removes all materialized output for a query request.
+  public void cleanupMaterializedMailboxRequest(long requestId) {
+    synchronized (_materializedMailboxStoreLock) {
+      if (_materializedMailboxStore != null) {
+        _materializedMailboxStore.cleanupRequest(requestId);
+      }
+    }
+  }
+
+  private MaterializedMailboxStore getMaterializedMailboxStore() {
+    synchronized (_materializedMailboxStoreLock) {
+      if (_shutdown) {
+        throw new IllegalStateException("Mailbox service is shut down");
+      }
+      if (_materializedMailboxStore == null) {
+        try {
+          _materializedMailboxStore = new MaterializedMailboxStore(_materializedMailboxRoot, _hostname, _port);
+        } catch (IOException e) {
+          throw new UncheckedIOException("Failed to initialize materialized mailbox store", e);
+        }
+      }
+      return _materializedMailboxStore;
     }
   }
 
@@ -293,6 +429,52 @@ public class MailboxService {
   /// being created.
   public void releaseReceivingMailbox(ReceivingMailbox mailbox) {
     _receivingMailboxCache.invalidate(mailbox.getId());
+  }
+
+  private static final class MaterializedRecordIterator implements Iterator<byte[]> {
+    private final Iterator<Mailbox.MaterializedPartitionContent> _chunks;
+    private final ByteArrayOutputStream _record = new ByteArrayOutputStream();
+    private byte[] _next;
+    private boolean _finished;
+
+    private MaterializedRecordIterator(Iterator<Mailbox.MaterializedPartitionContent> chunks) {
+      _chunks = chunks;
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (_next != null) {
+        return true;
+      }
+      if (_finished) {
+        return false;
+      }
+      while (_chunks.hasNext()) {
+        Mailbox.MaterializedPartitionContent chunk = _chunks.next();
+        byte[] payload = chunk.getPayload().toByteArray();
+        _record.write(payload, 0, payload.length);
+        if (chunk.getEndOfBlock()) {
+          _next = _record.toByteArray();
+          _record.reset();
+          return true;
+        }
+      }
+      _finished = true;
+      if (_record.size() != 0) {
+        throw new IllegalStateException("Materialized partition stream ended in the middle of a data block");
+      }
+      return false;
+    }
+
+    @Override
+    public byte[] next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      byte[] next = _next;
+      _next = null;
+      return next;
+    }
   }
 
   private static Duration getIdleTimeout(PinotConfiguration config) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/GrpcMailboxServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/GrpcMailboxServer.java
@@ -21,6 +21,7 @@ package org.apache.pinot.query.mailbox.channel;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.grpc.Server;
+import io.grpc.Status;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.netty.shaded.io.netty.buffer.PooledByteBufAllocator;
 import io.grpc.netty.shaded.io.netty.buffer.PooledByteBufAllocatorMetric;
@@ -30,7 +31,12 @@ import io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.SocketTimeoutException;
+import java.util.Iterator;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.metrics.BrokerGauge;
@@ -57,6 +63,7 @@ import org.slf4j.LoggerFactory;
 public class GrpcMailboxServer extends PinotMailboxGrpc.PinotMailboxImplBase {
   private static final Logger LOGGER = LoggerFactory.getLogger(GrpcMailboxServer.class);
   private static final long DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000L;
+  private static final int PROTOBUF_OVERHEAD_BYTES = 1024;
 
   private final MailboxService _mailboxService;
   private final Server _server;
@@ -66,6 +73,7 @@ public class GrpcMailboxServer extends PinotMailboxGrpc.PinotMailboxImplBase {
   private final boolean _manualInboundFlowControlEnabled;
   private final int _permitKeepAliveTimeMs;
   private final boolean _permitKeepAliveWithoutCalls;
+  private final int _materializedChunkSize;
 
   /// Constructs a gRPC-based mailbox server.
   ///
@@ -152,6 +160,7 @@ public class GrpcMailboxServer extends PinotMailboxGrpc.PinotMailboxImplBase {
     int maxInboundMessageSize = config.getProperty(
         CommonConstants.MultiStageQueryRunner.KEY_OF_MAX_INBOUND_QUERY_DATA_BLOCK_SIZE_BYTES,
         CommonConstants.MultiStageQueryRunner.DEFAULT_MAX_INBOUND_QUERY_DATA_BLOCK_SIZE_BYTES);
+    _materializedChunkSize = Math.max(1, maxInboundMessageSize - PROTOBUF_OVERHEAD_BYTES);
     Preconditions.checkArgument(_inboundMessageCredit > 0,
         "%s must be positive, got: %s",
         CommonConstants.MultiStageQueryRunner.KEY_OF_GRPC_INBOUND_MESSAGE_CREDIT,
@@ -254,5 +263,149 @@ public class GrpcMailboxServer extends PinotMailboxGrpc.PinotMailboxImplBase {
     // behaviour, retained as a rollback knob via KEY_OF_GRPC_MANUAL_INBOUND_FLOW_CONTROL_ENABLED.
     return new MailboxContentObserver(_mailboxService, mailboxId, serverCallObserver,
         _manualInboundFlowControlEnabled);
+  }
+
+  @Override
+  public void readMaterializedPartition(Mailbox.MaterializedPartitionRequest request,
+      StreamObserver<Mailbox.MaterializedPartitionContent> responseObserver) {
+    ServerCallStreamObserver<Mailbox.MaterializedPartitionContent> serverObserver =
+        (ServerCallStreamObserver<Mailbox.MaterializedPartitionContent>) responseObserver;
+    Iterator<byte[]> records;
+    try {
+      records = _mailboxService.readMaterializedPartitionRecords(
+          request.getRequestId(), request.getProducerStageId(), request.getProducerWorkerId(),
+          request.getLogicalPartitionId(), request.getDeadlineMs());
+    } catch (RuntimeException e) {
+      responseObserver.onError(toStatus(e));
+      return;
+    }
+    new MaterializedPartitionPump(records, serverObserver, _materializedChunkSize).start();
+  }
+
+  private static RuntimeException toStatus(RuntimeException e) {
+    if (e instanceof CancellationException) {
+      return Status.CANCELLED.withDescription(e.getMessage()).withCause(e).asRuntimeException();
+    }
+    if (e instanceof UncheckedIOException && e.getCause() instanceof SocketTimeoutException) {
+      return Status.DEADLINE_EXCEEDED.withDescription(e.getMessage()).withCause(e).asRuntimeException();
+    }
+    return Status.INTERNAL.withDescription("Failed to read materialized partition").withCause(e).asRuntimeException();
+  }
+
+  @VisibleForTesting
+  static final class MaterializedPartitionPump implements Runnable {
+    private final Iterator<byte[]> _records;
+    private final ServerCallStreamObserver<Mailbox.MaterializedPartitionContent> _observer;
+    private final int _chunkSize;
+    private final AtomicBoolean _draining = new AtomicBoolean();
+    private final AtomicBoolean _terminated = new AtomicBoolean();
+    private final Object _lock = new Object();
+
+    private byte[] _record;
+    private int _offset;
+
+    MaterializedPartitionPump(Iterator<byte[]> records,
+        ServerCallStreamObserver<Mailbox.MaterializedPartitionContent> observer, int chunkSize) {
+      _records = records;
+      _observer = observer;
+      _chunkSize = chunkSize;
+    }
+
+    void start() {
+      try {
+        _observer.setOnCancelHandler(this::cancel);
+        _observer.setOnReadyHandler(this);
+        if (_observer.isCancelled()) {
+          cancel();
+        } else {
+          run();
+        }
+      } catch (RuntimeException e) {
+        synchronized (_lock) {
+          failLocked(e);
+        }
+      }
+    }
+
+    @Override
+    public void run() {
+      if (!_draining.compareAndSet(false, true)) {
+        return;
+      }
+      do {
+        drain();
+        _draining.set(false);
+      } while (shouldDrain() && _draining.compareAndSet(false, true));
+    }
+
+    private void drain() {
+      while (_observer.isReady()) {
+        synchronized (_lock) {
+          if (_terminated.get()) {
+            return;
+          }
+          if (_observer.isCancelled()) {
+            cancelLocked();
+            return;
+          }
+          try {
+            if (_record == null && !_records.hasNext()) {
+              _terminated.set(true);
+              _observer.onCompleted();
+              return;
+            }
+            if (_record == null) {
+              _record = _records.next();
+              _offset = 0;
+            }
+            int length = Math.min(_chunkSize, _record.length - _offset);
+            _observer.onNext(Mailbox.MaterializedPartitionContent.newBuilder()
+                .setPayload(com.google.protobuf.ByteString.copyFrom(_record, _offset, length))
+                .setEndOfBlock(_offset + length == _record.length)
+                .build());
+            _offset += length;
+            if (_offset == _record.length) {
+              _record = null;
+            }
+          } catch (RuntimeException e) {
+            failLocked(e);
+            return;
+          }
+        }
+      }
+    }
+
+    private boolean shouldDrain() {
+      return !_terminated.get() && !_observer.isCancelled() && _observer.isReady();
+    }
+
+    private void cancel() {
+      synchronized (_lock) {
+        cancelLocked();
+      }
+    }
+
+    private void cancelLocked() {
+      if (_terminated.compareAndSet(false, true)) {
+        closeRecords();
+      }
+    }
+
+    private void failLocked(RuntimeException e) {
+      if (_terminated.compareAndSet(false, true)) {
+        closeRecords();
+        _observer.onError(toStatus(e));
+      }
+    }
+
+    private void closeRecords() {
+      if (_records instanceof AutoCloseable) {
+        try {
+          ((AutoCloseable) _records).close();
+        } catch (Exception e) {
+          LOGGER.debug("Failed to close materialized partition reader", e);
+        }
+      }
+    }
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/materialized/MaterializedMailboxKey.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/materialized/MaterializedMailboxKey.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.mailbox.materialized;
+
+import java.util.Objects;
+
+
+/// Consumer-independent identity of one producer-local materialized partition.
+public final class MaterializedMailboxKey {
+  private final long _requestId;
+  private final int _producerStageId;
+  private final int _producerWorkerId;
+  private final int _logicalPartitionId;
+
+  public MaterializedMailboxKey(long requestId, int producerStageId, int producerWorkerId, int logicalPartitionId) {
+    _requestId = requestId;
+    _producerStageId = producerStageId;
+    _producerWorkerId = producerWorkerId;
+    _logicalPartitionId = logicalPartitionId;
+  }
+
+  public long getRequestId() {
+    return _requestId;
+  }
+
+  public int getProducerStageId() {
+    return _producerStageId;
+  }
+
+  public int getProducerWorkerId() {
+    return _producerWorkerId;
+  }
+
+  public int getLogicalPartitionId() {
+    return _logicalPartitionId;
+  }
+
+  public String toOpaqueFileId() {
+    return _requestId + "/" + _producerStageId + "/" + _producerWorkerId + "/" + _logicalPartitionId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MaterializedMailboxKey)) {
+      return false;
+    }
+    MaterializedMailboxKey that = (MaterializedMailboxKey) o;
+    return _requestId == that._requestId && _producerStageId == that._producerStageId
+        && _producerWorkerId == that._producerWorkerId && _logicalPartitionId == that._logicalPartitionId;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_requestId, _producerStageId, _producerWorkerId, _logicalPartitionId);
+  }
+
+  @Override
+  public String toString() {
+    return toOpaqueFileId();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/materialized/MaterializedMailboxStore.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/materialized/MaterializedMailboxStore.java
@@ -1,0 +1,530 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.mailbox.materialized;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.SocketTimeoutException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import java.util.function.LongSupplier;
+import java.util.stream.Stream;
+import org.apache.pinot.common.proto.Worker;
+
+
+/// Thread-safe producer-local store for consumer-independent materialized partitions.
+///
+/// Writers publish with an atomic rename. Readers wait for that publication until their absolute deadline, then
+/// stream framed records and delete the committed file only after reaching a clean end of file.
+public final class MaterializedMailboxStore implements AutoCloseable {
+  // Query work is deadline-bounded. One hour keeps stale callbacks rejected well beyond the default query timeout
+  // without retaining canceled request IDs for the process lifetime.
+  static final long CLEANED_REQUEST_RETENTION_MS = TimeUnit.HOURS.toMillis(1);
+  private static final String DATA_FILE_SUFFIX = ".data";
+  private static final String TEMPORARY_FILE_SUFFIX = ".part";
+
+  private final Path _root;
+  private final String _hostname;
+  private final int _port;
+  private final OutputStreamFactory _outputStreamFactory;
+  private final LongSupplier _currentTimeMillis;
+  private final Object _lifecycleLock = new Object();
+  private final Map<MaterializedMailboxKey, Entry> _entries = new HashMap<>();
+  private final LinkedHashMap<Long, Long> _cleanedRequests = new LinkedHashMap<>();
+  private boolean _closed;
+
+  public MaterializedMailboxStore(Path root, String hostname, int port)
+      throws IOException {
+    this(root, hostname, port, Files::newOutputStream, System::currentTimeMillis);
+  }
+
+  @VisibleForTesting
+  MaterializedMailboxStore(Path root, String hostname, int port, OutputStreamFactory outputStreamFactory)
+      throws IOException {
+    this(root, hostname, port, outputStreamFactory, System::currentTimeMillis);
+  }
+
+  @VisibleForTesting
+  MaterializedMailboxStore(Path root, String hostname, int port, LongSupplier currentTimeMillis)
+      throws IOException {
+    this(root, hostname, port, Files::newOutputStream, currentTimeMillis);
+  }
+
+  private MaterializedMailboxStore(Path root, String hostname, int port, OutputStreamFactory outputStreamFactory,
+      LongSupplier currentTimeMillis)
+      throws IOException {
+    _root = root;
+    _hostname = hostname;
+    _port = port;
+    _outputStreamFactory = outputStreamFactory;
+    _currentTimeMillis = currentTimeMillis;
+    Files.createDirectories(root);
+  }
+
+  /// Returns the default process-local root, namespaced by the mailbox endpoint.
+  public static Path defaultRoot(String hostname, int port) {
+    String safeHostname = hostname.replaceAll("[^A-Za-z0-9._-]", "_");
+    return Path.of(System.getProperty("java.io.tmpdir"), "pinot-materialized-mailbox",
+        safeHostname + "-" + port);
+  }
+
+  /// Creates the sole writer for a partition. A reader may already be waiting for the same key.
+  public MaterializedMailboxWriter createWriter(MaterializedMailboxKey key,
+      Consumer<Worker.MaterializedPartitionHandle> onCommit)
+      throws IOException {
+    Path temporaryPath = getTemporaryPath(key);
+    Consumer<Worker.MaterializedPartitionHandle> commitConsumer = Objects.requireNonNull(onCommit);
+    synchronized (_lifecycleLock) {
+      ensureRequestActive(key.getRequestId());
+      Entry entry = _entries.computeIfAbsent(key, ignored -> new Entry());
+      if (entry._writerCreated) {
+        throw new IllegalStateException("Materialized partition already has a writer: " + key);
+      }
+      entry._writerCreated = true;
+      try {
+        Files.createDirectories(temporaryPath.getParent());
+        Files.deleteIfExists(temporaryPath);
+        return new MaterializedMailboxWriter(this, key, temporaryPath,
+            _outputStreamFactory.open(temporaryPath), commitConsumer);
+      } catch (IOException | RuntimeException e) {
+        deleteAfterFailedWriteOpen(temporaryPath, e);
+        failEntryLocked(key, entry, e);
+        throw e;
+      }
+    }
+  }
+
+  /// Waits for commit and returns an iterator over serialized data-block records.
+  public RecordIterator read(MaterializedMailboxKey key, long deadlineMs)
+      throws IOException {
+    Entry entry;
+    synchronized (_lifecycleLock) {
+      ensureRequestActive(key.getRequestId());
+      entry = _entries.computeIfAbsent(key, ignored -> new Entry());
+      entry._waitingReaders++;
+    }
+    try {
+      awaitCommit(key, entry, deadlineMs);
+    } finally {
+      synchronized (_lifecycleLock) {
+        entry._waitingReaders--;
+      }
+    }
+    synchronized (_lifecycleLock) {
+      ensureRequestActive(key.getRequestId());
+      if (_entries.get(key) != entry) {
+        throw new IOException("Materialized partition was cleaned up before read: " + key);
+      }
+      FramedRecordIterator iterator = new FramedRecordIterator(key, entry, getCommittedPath(key));
+      entry._readers.add(iterator);
+      return iterator;
+    }
+  }
+
+  /// Cancels pending readers and deletes every temporary or committed file for one request.
+  public void cleanupRequest(long requestId) {
+    CancellationException cancellation =
+        new CancellationException("Materialized mailbox request was cleaned up: " + requestId);
+    synchronized (_lifecycleLock) {
+      if (_closed) {
+        return;
+      }
+      rememberCleanedRequestLocked(requestId);
+      List<MaterializedMailboxKey> requestKeys = new ArrayList<>();
+      for (MaterializedMailboxKey key : _entries.keySet()) {
+        if (key.getRequestId() == requestId) {
+          requestKeys.add(key);
+        }
+      }
+      for (MaterializedMailboxKey key : requestKeys) {
+        Entry entry = _entries.remove(key);
+        if (entry != null) {
+          cancelEntryLocked(entry, cancellation);
+        }
+      }
+    }
+    deleteRecursively(_root.resolve(Long.toString(requestId)));
+  }
+
+  @Override
+  public void close() {
+    synchronized (_lifecycleLock) {
+      if (_closed) {
+        return;
+      }
+      _closed = true;
+      CancellationException cancellation = new CancellationException("Materialized mailbox store is closed");
+      _entries.values().forEach(entry -> cancelEntryLocked(entry, cancellation));
+      _entries.clear();
+      _cleanedRequests.clear();
+    }
+    deleteRecursively(_root);
+  }
+
+  Worker.MaterializedPartitionHandle commit(MaterializedMailboxKey key, Path temporaryPath, long rowCount,
+      Consumer<Worker.MaterializedPartitionHandle> onCommit)
+      throws IOException {
+    Path committedPath = getCommittedPath(key);
+    synchronized (_lifecycleLock) {
+      ensureRequestActive(key.getRequestId());
+      Entry entry = _entries.get(key);
+      if (entry == null || !entry._writerCreated) {
+        throw new IOException("Materialized partition was cleaned up before commit: " + key);
+      }
+      try {
+        try {
+          Files.move(temporaryPath, committedPath, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException e) {
+          throw new IOException("Materialized mailbox root does not support atomic commit: " + _root, e);
+        }
+        Worker.MaterializedPartitionHandle handle = Worker.MaterializedPartitionHandle.newBuilder()
+            .setRequestId(key.getRequestId())
+            .setProducerStageId(key.getProducerStageId())
+            .setProducerWorkerId(key.getProducerWorkerId())
+            .setLogicalPartitionId(key.getLogicalPartitionId())
+            .setHost(_hostname)
+            .setTransferPort(_port)
+            .setOpaqueFileId(key.toOpaqueFileId())
+            .setRowCount(rowCount)
+            .setByteCount(Files.size(committedPath))
+            .build();
+        onCommit.accept(handle);
+        if (!entry._committed.complete(handle)) {
+          throw new IOException("Materialized partition was cleaned up before commit: " + key);
+        }
+        return handle;
+      } catch (IOException | RuntimeException e) {
+        deleteAfterFailedCommit(temporaryPath, committedPath, e);
+        failEntryLocked(key, entry, e);
+        if (e instanceof IOException) {
+          throw (IOException) e;
+        }
+        throw new IOException("Failed to publish materialized partition: " + key, e);
+      }
+    }
+  }
+
+  void abort(MaterializedMailboxKey key, Path temporaryPath)
+      throws IOException {
+    IOException deletionFailure = null;
+    try {
+      Files.deleteIfExists(temporaryPath);
+    } catch (IOException e) {
+      deletionFailure = e;
+    }
+    synchronized (_lifecycleLock) {
+      Entry entry = _entries.remove(key);
+      if (entry != null) {
+        cancelEntryLocked(entry,
+            new CancellationException("Materialized partition was aborted: " + key));
+      }
+    }
+    deleteEmptyParents(temporaryPath.getParent());
+    if (deletionFailure != null) {
+      throw deletionFailure;
+    }
+  }
+
+  @VisibleForTesting
+  public Path getCommittedPath(MaterializedMailboxKey key) {
+    return partitionDirectory(key).resolve(key.getLogicalPartitionId() + DATA_FILE_SUFFIX);
+  }
+
+  @VisibleForTesting
+  Path getTemporaryPath(MaterializedMailboxKey key) {
+    return partitionDirectory(key).resolve(key.getLogicalPartitionId() + TEMPORARY_FILE_SUFFIX);
+  }
+
+  @VisibleForTesting
+  int getWaitingReaderCount(MaterializedMailboxKey key) {
+    synchronized (_lifecycleLock) {
+      Entry entry = _entries.get(key);
+      return entry != null ? entry._waitingReaders : 0;
+    }
+  }
+
+  @VisibleForTesting
+  int getCleanedRequestCount() {
+    synchronized (_lifecycleLock) {
+      pruneCleanedRequestsLocked(_currentTimeMillis.getAsLong());
+      return _cleanedRequests.size();
+    }
+  }
+
+  private Path partitionDirectory(MaterializedMailboxKey key) {
+    return _root.resolve(Long.toString(key.getRequestId()))
+        .resolve(Integer.toString(key.getProducerStageId()))
+        .resolve(Integer.toString(key.getProducerWorkerId()));
+  }
+
+  private void awaitCommit(MaterializedMailboxKey key, Entry entry, long deadlineMs)
+      throws IOException {
+    long remainingMs = deadlineMs - System.currentTimeMillis();
+    if (remainingMs <= 0) {
+      throw timeout(key);
+    }
+    try {
+      entry._committed.get(remainingMs, TimeUnit.MILLISECONDS);
+    } catch (TimeoutException e) {
+      throw timeout(key);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted while waiting for materialized partition: " + key, e);
+    } catch (ExecutionException | CancellationException e) {
+      throw new IOException("Materialized partition is unavailable: " + key, e);
+    }
+  }
+
+  private void ensureRequestActive(long requestId)
+      throws IOException {
+    if (_closed) {
+      throw new IOException("Materialized mailbox store is closed");
+    }
+    pruneCleanedRequestsLocked(_currentTimeMillis.getAsLong());
+    if (_cleanedRequests.containsKey(requestId)) {
+      throw new IOException("Materialized mailbox request was cleaned up: " + requestId);
+    }
+  }
+
+  private static SocketTimeoutException timeout(MaterializedMailboxKey key) {
+    return new SocketTimeoutException("Timed out waiting for materialized partition commit: " + key);
+  }
+
+  private void consume(MaterializedMailboxKey key, Entry entry, Path path, FramedRecordIterator reader)
+      throws IOException {
+    synchronized (_lifecycleLock) {
+      entry._readers.remove(reader);
+      Files.deleteIfExists(path);
+      _entries.remove(key, entry);
+      deleteEmptyParents(path.getParent());
+    }
+  }
+
+  private void unregisterReader(Entry entry, FramedRecordIterator reader) {
+    synchronized (_lifecycleLock) {
+      entry._readers.remove(reader);
+    }
+  }
+
+  private void rememberCleanedRequestLocked(long requestId) {
+    long nowMs = _currentTimeMillis.getAsLong();
+    pruneCleanedRequestsLocked(nowMs);
+    _cleanedRequests.put(requestId, nowMs + CLEANED_REQUEST_RETENTION_MS);
+  }
+
+  private void pruneCleanedRequestsLocked(long nowMs) {
+    _cleanedRequests.entrySet().removeIf(entry -> entry.getValue() <= nowMs);
+  }
+
+  private void cancelEntryLocked(Entry entry, CancellationException cancellation) {
+    for (FramedRecordIterator reader : List.copyOf(entry._readers)) {
+      reader.closeWithoutConsume();
+    }
+    entry._committed.completeExceptionally(cancellation);
+  }
+
+  private void failEntryLocked(MaterializedMailboxKey key, Entry entry, Throwable failure) {
+    entry._committed.completeExceptionally(failure);
+    _entries.remove(key, entry);
+  }
+
+  private static void deleteAfterFailedCommit(Path temporaryPath, Path committedPath, Throwable failure) {
+    try {
+      Files.deleteIfExists(temporaryPath);
+      Files.deleteIfExists(committedPath);
+    } catch (IOException cleanupFailure) {
+      failure.addSuppressed(cleanupFailure);
+    }
+  }
+
+  private static void deleteAfterFailedWriteOpen(Path temporaryPath, Throwable failure) {
+    try {
+      Files.deleteIfExists(temporaryPath);
+    } catch (IOException cleanupFailure) {
+      failure.addSuppressed(cleanupFailure);
+    }
+  }
+
+  private void deleteEmptyParents(Path directory) {
+    Path current = directory;
+    while (current != null && !current.equals(_root)) {
+      try (Stream<Path> children = Files.list(current)) {
+        if (children.findAny().isPresent()) {
+          return;
+        }
+        Files.deleteIfExists(current);
+      } catch (IOException e) {
+        return;
+      }
+      current = current.getParent();
+    }
+  }
+
+  private static void deleteRecursively(Path path) {
+    if (!Files.exists(path)) {
+      return;
+    }
+    try (Stream<Path> paths = Files.walk(path)) {
+      paths.sorted(Comparator.reverseOrder()).forEach(current -> {
+        try {
+          Files.deleteIfExists(current);
+        } catch (IOException ignored) {
+          // Best-effort cleanup; query execution has already ended.
+        }
+      });
+    } catch (IOException ignored) {
+      // Best-effort cleanup; query execution has already ended.
+    }
+  }
+
+  private static final class Entry {
+    private final CompletableFuture<Worker.MaterializedPartitionHandle> _committed = new CompletableFuture<>();
+    private final HashSet<FramedRecordIterator> _readers = new HashSet<>();
+    private boolean _writerCreated;
+    private int _waitingReaders;
+  }
+
+  /// Closeable iterator over one committed partition. Explicit close abandons the read without consuming the file.
+  public interface RecordIterator extends Iterator<byte[]>, AutoCloseable {
+    @Override
+    void close()
+        throws IOException;
+  }
+
+  @FunctionalInterface
+  interface OutputStreamFactory {
+    OutputStream open(Path path)
+        throws IOException;
+  }
+
+  private final class FramedRecordIterator implements RecordIterator {
+    private final MaterializedMailboxKey _key;
+    private final Entry _entry;
+    private final Path _path;
+    private final DataInputStream _input;
+    private byte[] _next;
+    private boolean _finished;
+
+    private FramedRecordIterator(MaterializedMailboxKey key, Entry entry, Path path)
+        throws IOException {
+      _key = key;
+      _entry = entry;
+      _path = path;
+      _input = new DataInputStream(new BufferedInputStream(Files.newInputStream(path)));
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (_next != null) {
+        return true;
+      }
+      if (_finished) {
+        return false;
+      }
+      try {
+        int length;
+        try {
+          length = _input.readInt();
+        } catch (EOFException e) {
+          finish();
+          return false;
+        }
+        if (length < 0) {
+          throw new IOException("Negative materialized record length " + length + " in " + _path);
+        }
+        _next = new byte[length];
+        _input.readFully(_next);
+        return true;
+      } catch (IOException e) {
+        closeWithoutDelete();
+        throw new java.io.UncheckedIOException(e);
+      }
+    }
+
+    @Override
+    public byte[] next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      byte[] next = _next;
+      _next = null;
+      return next;
+    }
+
+    private void finish()
+        throws IOException {
+      _finished = true;
+      try {
+        _input.close();
+      } catch (IOException e) {
+        unregisterReader(_entry, this);
+        throw e;
+      }
+      consume(_key, _entry, _path, this);
+    }
+
+    private void closeWithoutDelete() {
+      closeWithoutConsume();
+    }
+
+    @Override
+    public void close()
+        throws IOException {
+      if (_finished) {
+        return;
+      }
+      _finished = true;
+      try {
+        _input.close();
+      } finally {
+        unregisterReader(_entry, this);
+      }
+    }
+
+    private void closeWithoutConsume() {
+      try {
+        close();
+      } catch (IOException ignored) {
+        // Cancellation and read failures preserve their original cause.
+      }
+    }
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/materialized/MaterializedMailboxWriter.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/materialized/MaterializedMailboxWriter.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.mailbox.materialized;
+
+import java.io.BufferedOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Consumer;
+import org.apache.pinot.common.datablock.DataBlock;
+import org.apache.pinot.common.proto.Worker;
+
+
+/// Writes framed serialized data blocks and atomically publishes one materialized partition.
+///
+/// This class is not thread-safe. Closing it before a successful commit aborts the partition.
+public final class MaterializedMailboxWriter implements AutoCloseable {
+  private final MaterializedMailboxStore _store;
+  private final MaterializedMailboxKey _key;
+  private final Path _temporaryPath;
+  private final DataOutputStream _output;
+  private final Consumer<Worker.MaterializedPartitionHandle> _onCommit;
+
+  private long _rowCount;
+  private boolean _finished;
+
+  MaterializedMailboxWriter(MaterializedMailboxStore store, MaterializedMailboxKey key, Path temporaryPath,
+      OutputStream output, Consumer<Worker.MaterializedPartitionHandle> onCommit) {
+    _store = store;
+    _key = key;
+    _temporaryPath = temporaryPath;
+    _output = new DataOutputStream(new BufferedOutputStream(output));
+    _onCommit = onCommit;
+  }
+
+  /// Appends one length-prefixed serialized [DataBlock] record and returns its serialized payload size.
+  public int write(DataBlock dataBlock)
+      throws IOException {
+    ensureOpen();
+    List<ByteBuffer> buffers = dataBlock.serialize();
+    int payloadSize = 0;
+    for (ByteBuffer buffer : buffers) {
+      payloadSize = Math.addExact(payloadSize, buffer.remaining());
+    }
+    _output.writeInt(payloadSize);
+    byte[] copyBuffer = new byte[Math.min(Math.max(payloadSize, 1), 8192)];
+    for (ByteBuffer buffer : buffers) {
+      while (buffer.hasRemaining()) {
+        int length = Math.min(buffer.remaining(), copyBuffer.length);
+        buffer.get(copyBuffer, 0, length);
+        _output.write(copyBuffer, 0, length);
+      }
+    }
+    _rowCount = Math.addExact(_rowCount, dataBlock.getNumberOfRows());
+    return payloadSize;
+  }
+
+  /// Closes the temporary file, atomically publishes it, and returns its wire-ready output handle.
+  public Worker.MaterializedPartitionHandle commit()
+      throws IOException {
+    ensureOpen();
+    _finished = true;
+    try {
+      _output.close();
+      return _store.commit(_key, _temporaryPath, _rowCount, _onCommit);
+    } catch (IOException | RuntimeException e) {
+      abortAfterFailure(e);
+      throw e;
+    }
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    if (!_finished) {
+      _finished = true;
+      IOException failure = null;
+      try {
+        _output.close();
+      } catch (IOException e) {
+        failure = e;
+      }
+      try {
+        _store.abort(_key, _temporaryPath);
+      } catch (IOException e) {
+        if (failure == null) {
+          failure = e;
+        } else {
+          failure.addSuppressed(e);
+        }
+      }
+      if (failure != null) {
+        throw failure;
+      }
+    }
+  }
+
+  private void abortAfterFailure(Throwable failure) {
+    try {
+      _store.abort(_key, _temporaryPath);
+    } catch (IOException abortFailure) {
+      failure.addSuppressed(abortFailure);
+    }
+  }
+
+  private void ensureOpen() {
+    if (_finished) {
+      throw new IllegalStateException("Materialized mailbox writer is already finished: " + _key);
+    }
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/materialized/MaterializedSendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/materialized/MaterializedSendingMailbox.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.mailbox.materialized;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.function.Consumer;
+import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.common.proto.Worker;
+import org.apache.pinot.query.mailbox.SendingMailbox;
+import org.apache.pinot.query.runtime.blocks.MseBlock;
+import org.apache.pinot.query.runtime.operator.MailboxSendOperator;
+import org.apache.pinot.segment.spi.memory.DataBuffer;
+
+
+/// A producer-local [SendingMailbox] that commits its partition only on successful EOS.
+///
+/// The writer is opened lazily, including for an empty partition whose first message is EOS. This class is not
+/// thread-safe.
+public final class MaterializedSendingMailbox implements SendingMailbox {
+  private final MaterializedMailboxStore _store;
+  private final MaterializedMailboxKey _key;
+  private final StatMap<MailboxSendOperator.StatKey> _statMap;
+  private final Consumer<Worker.MaterializedPartitionHandle> _onCommit;
+
+  private MaterializedMailboxWriter _writer;
+  private boolean _terminated;
+
+  public MaterializedSendingMailbox(MaterializedMailboxStore store, MaterializedMailboxKey key,
+      StatMap<MailboxSendOperator.StatKey> statMap, Consumer<Worker.MaterializedPartitionHandle> onCommit) {
+    _store = store;
+    _key = key;
+    _statMap = statMap;
+    _onCommit = onCommit;
+  }
+
+  @Override
+  public boolean isLocal() {
+    return true;
+  }
+
+  @Override
+  public void send(MseBlock.Data data) {
+    ensureActive();
+    long startMs = System.currentTimeMillis();
+    try {
+      int serializedBytes = writer().write(data.asSerialized().getDataBlock());
+      _statMap.merge(MailboxSendOperator.StatKey.RAW_MESSAGES, 1);
+      _statMap.merge(MailboxSendOperator.StatKey.SERIALIZED_BYTES, serializedBytes);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to materialize partition " + _key, e);
+    } finally {
+      _statMap.merge(MailboxSendOperator.StatKey.SERIALIZATION_TIME_MS, System.currentTimeMillis() - startMs);
+    }
+  }
+
+  @Override
+  public void send(MseBlock.Eos block, List<DataBuffer> serializedStats) {
+    ensureActive();
+    if (block.isError()) {
+      cancel(new IllegalStateException("Materialized exchange received error EOS"));
+      return;
+    }
+    try {
+      writer().commit();
+      _terminated = true;
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to commit materialized partition " + _key, e);
+    }
+  }
+
+  @Override
+  public void cancel(Throwable t) {
+    terminate();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return _terminated;
+  }
+
+  @Override
+  public boolean isEarlyTerminated() {
+    return false;
+  }
+
+  @Override
+  public void close() {
+    terminate();
+  }
+
+  private void terminate() {
+    if (_terminated) {
+      return;
+    }
+    _terminated = true;
+    if (_writer != null) {
+      try {
+        _writer.close();
+      } catch (IOException e) {
+        throw new UncheckedIOException("Failed to abort materialized partition " + _key, e);
+      }
+    }
+  }
+
+  private MaterializedMailboxWriter writer()
+      throws IOException {
+    if (_writer == null) {
+      _writer = _store.createWriter(_key, _onCommit);
+    }
+    return _writer;
+  }
+
+  private void ensureActive() {
+    if (_terminated) {
+      throw new IllegalStateException("Materialized sending mailbox is terminated: " + _key);
+    }
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -572,7 +572,11 @@ public class QueryRunner {
   /// stream (`QueryServer.handleCancel`), so stats from opchains finishing _after_ the cancel are not
   /// delivered — error-path coverage is whatever was already reported or in flight when the cancel landed.
   public void cancel(long requestId) {
-    _opChainScheduler.cancel(requestId);
+    try {
+      _opChainScheduler.cancel(requestId);
+    } finally {
+      _mailboxService.cleanupMaterializedMailboxRequest(requestId);
+    }
   }
 
   /// Registers an opchain completion listener for the given request id. Used by the stream-mode stats reporting path

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -25,6 +25,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.metrics.MseMetrics;
@@ -163,6 +164,18 @@ public class MailboxSendOperator extends MultiStageOperator {
     List<RoutingInfo> routingInfos =
         MailboxIdUtils.toRoutingInfos(requestId, context.getStageId(), context.getWorkerId(), receiverStageId,
             mailboxInfos);
+    if (node.isMaterialized()) {
+      Preconditions.checkState(distributionType == RelDistribution.Type.HASH_DISTRIBUTED,
+          "Materialized exchange only supports HASH_DISTRIBUTED, got: %s", distributionType);
+      List<SendingMailbox> sendingMailboxes = IntStream.range(0, routingInfos.size())
+          .mapToObj(logicalPartitionId -> mailboxService.getMaterializedSendingMailbox(requestId,
+              context.getStageId(), context.getWorkerId(), logicalPartitionId, statMap,
+              context::recordMaterializedOutput))
+          .collect(Collectors.toList());
+      statMap.merge(StatKey.FAN_OUT, sendingMailboxes.size());
+      return BlockExchange.getExchange(sendingMailboxes, distributionType, node.getKeys(), splitter,
+          node.getHashFunction());
+    }
     List<SendingMailbox> sendingMailboxes = routingInfos.stream()
         .map(v -> mailboxService.getSendingMailbox(v.getHostname(), v.getPort(), v.getMailboxId(), deadlineMs, statMap))
         .collect(Collectors.toList());

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MaterializedMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MaterializedMailboxReceiveOperator.java
@@ -1,0 +1,159 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
+import org.apache.pinot.query.routing.MailboxInfo;
+import org.apache.pinot.query.routing.MailboxInfos;
+import org.apache.pinot.query.runtime.blocks.MseBlock;
+import org.apache.pinot.query.runtime.blocks.SuccessMseBlock;
+import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/// Reads one logical materialized HASH partition from every worker of the completed producer stage.
+///
+/// The static materialized-exchange phase keeps the existing worker assignment, so consumer worker `p` owns logical
+/// partition `p`. Producer identity remains independent of the consumer, which lets later phases replace this
+/// implicit binding with broker-provided handles. This class is not thread-safe.
+public final class MaterializedMailboxReceiveOperator extends MultiStageOperator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MaterializedMailboxReceiveOperator.class);
+  private static final String EXPLAIN_NAME = "MATERIALIZED_MAILBOX_RECEIVE";
+
+  private final MailboxService _mailboxService;
+  private final int _senderStageId;
+  private final List<PartitionSource> _sources;
+  private final StatMap<BaseMailboxReceiveOperator.StatKey> _statMap =
+      new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
+
+  private int _sourceIndex;
+  private Iterator<MseBlock.Data> _current = List.<MseBlock.Data>of().iterator();
+
+  public MaterializedMailboxReceiveOperator(OpChainExecutionContext context, MailboxReceiveNode node) {
+    super(context);
+    Preconditions.checkState(node.getDistributionType() == RelDistribution.Type.HASH_DISTRIBUTED,
+        "Materialized exchange only supports HASH_DISTRIBUTED, got: %s", node.getDistributionType());
+    _mailboxService = context.getMailboxService();
+    _senderStageId = node.getSenderStageId();
+    _sources = getSources(context, _senderStageId);
+    _statMap.merge(BaseMailboxReceiveOperator.StatKey.FAN_IN, _sources.size());
+  }
+
+  @Override
+  public Type getOperatorType() {
+    return Type.MAILBOX_RECEIVE;
+  }
+
+  @Override
+  public void registerExecution(long time, int numRows, long memoryUsedBytes, long gcTimeMs) {
+    _statMap.merge(BaseMailboxReceiveOperator.StatKey.EXECUTION_TIME_MS, time);
+    _statMap.merge(BaseMailboxReceiveOperator.StatKey.EMITTED_ROWS, numRows);
+    _statMap.merge(BaseMailboxReceiveOperator.StatKey.ALLOCATED_MEMORY_BYTES, memoryUsedBytes);
+    _statMap.merge(BaseMailboxReceiveOperator.StatKey.GC_TIME_MS, gcTimeMs);
+  }
+
+  @Override
+  public List<MultiStageOperator> getChildOperators() {
+    return List.of();
+  }
+
+  @Override
+  public StatMap<BaseMailboxReceiveOperator.StatKey> copyStatMaps() {
+    StatMap<BaseMailboxReceiveOperator.StatKey> statMap = new StatMap<>(_statMap);
+    if (statMap.getLong(BaseMailboxReceiveOperator.StatKey.EMITTED_ROWS) == 0) {
+      statMap.merge(BaseMailboxReceiveOperator.StatKey.NON_ACTIVE_WORKERS, 1);
+    }
+    return statMap;
+  }
+
+  @Override
+  public MultiStageQueryStats calculateUpstreamStats() {
+    return MultiStageQueryStats.emptyStats(_context.getStageId());
+  }
+
+  @Override
+  public String toExplainString() {
+    return EXPLAIN_NAME;
+  }
+
+  @Override
+  protected Logger logger() {
+    return LOGGER;
+  }
+
+  @Override
+  protected long getDeadlineMs() {
+    return _context.getPassiveDeadlineMs();
+  }
+
+  @Override
+  protected MseBlock getNextBlock() {
+    while (true) {
+      if (_current.hasNext()) {
+        MseBlock.Data block = _current.next();
+        if (!_isEarlyTerminated) {
+          checkTerminationAndSampleUsage();
+          return block;
+        }
+        continue;
+      }
+      if (_sourceIndex == _sources.size()) {
+        return SuccessMseBlock.INSTANCE;
+      }
+      PartitionSource source = _sources.get(_sourceIndex++);
+      _current = _mailboxService.readMaterializedPartition(source._hostname, source._port, _context.getRequestId(),
+          _senderStageId, source._producerWorkerId, _context.getWorkerId(), _context.getPassiveDeadlineMs());
+    }
+  }
+
+  private static List<PartitionSource> getSources(OpChainExecutionContext context, int senderStageId) {
+    MailboxInfos mailboxInfos = context.getWorkerMetadata().getMailboxInfosMap().get(senderStageId);
+    if (mailboxInfos == null) {
+      return List.of();
+    }
+    List<PartitionSource> sources = new ArrayList<>();
+    for (MailboxInfo mailboxInfo : mailboxInfos.getMailboxInfos()) {
+      for (int producerWorkerId : mailboxInfo.getWorkerIds()) {
+        sources.add(new PartitionSource(mailboxInfo.getHostname(), mailboxInfo.getPort(), producerWorkerId));
+      }
+    }
+    return sources;
+  }
+
+  private static final class PartitionSource {
+    private final String _hostname;
+    private final int _port;
+    private final int _producerWorkerId;
+
+    private PartitionSource(String hostname, int port, int producerWorkerId) {
+      _hostname = hostname;
+      _port = port;
+      _producerWorkerId = producerWorkerId;
+    }
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
@@ -19,11 +19,13 @@
 package org.apache.pinot.query.runtime.plan;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.proto.Worker;
 import org.apache.pinot.core.instance.context.BrokerContext;
 import org.apache.pinot.core.instance.context.ServerContext;
 import org.apache.pinot.query.mailbox.MailboxService;
@@ -86,6 +88,7 @@ public class OpChainExecutionContext {
   /// Identity-based for the same reason as [#_operatorToPlanNodes]; lazily allocated for the same reason too.
   @Nullable
   private Map<PlanNode, Integer> _planNodeIds;
+  private final List<Worker.MaterializedPartitionHandle> _materializedOutputHandles = new ArrayList<>();
 
   @VisibleForTesting
   public OpChainExecutionContext(MailboxService mailboxService, long requestId, String cid, long activeDeadlineMs,
@@ -239,6 +242,14 @@ public class OpChainExecutionContext {
 
   public boolean isKeepPipelineBreakerStats() {
     return _keepPipelineBreakerStats;
+  }
+
+  public void recordMaterializedOutput(Worker.MaterializedPartitionHandle handle) {
+    _materializedOutputHandles.add(handle);
+  }
+
+  public List<Worker.MaterializedPartitionHandle> getMaterializedOutputHandles() {
+    return List.copyOf(_materializedOutputHandles);
   }
 
   /// Records which PlanNodes compiled down to the given MultiStageOperator. Should be called once per operator as the

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanNodeToOpChain.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanNodeToOpChain.java
@@ -50,6 +50,7 @@ import org.apache.pinot.query.runtime.operator.LeafOperator;
 import org.apache.pinot.query.runtime.operator.LiteralValueOperator;
 import org.apache.pinot.query.runtime.operator.MailboxReceiveOperator;
 import org.apache.pinot.query.runtime.operator.MailboxSendOperator;
+import org.apache.pinot.query.runtime.operator.MaterializedMailboxReceiveOperator;
 import org.apache.pinot.query.runtime.operator.MultiStageOperator;
 import org.apache.pinot.query.runtime.operator.OpChain;
 import org.apache.pinot.query.runtime.operator.RepeatOperator;
@@ -193,7 +194,9 @@ public class PlanNodeToOpChain {
     @Override
     public MultiStageOperator visitMailboxReceive(MailboxReceiveNode node, OpChainExecutionContext context) {
       try {
-        if (node.isSort()) {
+        if (node.isMaterialized()) {
+          return new MaterializedMailboxReceiveOperator(context, node);
+        } else if (node.isSort()) {
           return new SortedMailboxReceiveOperator(context, node);
         } else {
           return new MailboxReceiveOperator(context, node);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -69,6 +69,7 @@ import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.planner.PlanFragment;
 import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
 import org.apache.pinot.query.planner.physical.DispatchableSubPlan;
+import org.apache.pinot.query.planner.plannode.MailboxSendNode;
 import org.apache.pinot.query.planner.plannode.PlanNode;
 import org.apache.pinot.query.planner.serde.PlanNodeDeserializer;
 import org.apache.pinot.query.planner.serde.PlanNodeSerializer;
@@ -204,7 +205,8 @@ public class QueryDispatcher {
   public QueryResult submitAndReduce(RequestContext context, DispatchableSubPlan dispatchableSubPlan, long timeoutMs,
       Map<String, String> queryOptions, @Nullable ServerRoutingStatsManager statsManager)
       throws Exception {
-    if (QueryOptionsUtils.isStreamStats(queryOptions, _streamStatsDefault)) {
+    if (QueryOptionsUtils.isMaterializedExchange(queryOptions)
+        || QueryOptionsUtils.isStreamStats(queryOptions, _streamStatsDefault)) {
       return submitAndReduceWithStream(context, dispatchableSubPlan, timeoutMs, queryOptions, statsManager);
     }
     long requestId = context.getRequestId();
@@ -317,6 +319,10 @@ public class QueryDispatcher {
       if (!fullCoverage) {
         LOGGER.warn("Stream-mode request {} timed out waiting for stats after mailbox EOS; coverage may be partial",
             requestId);
+      } else if (brokerResult.getProcessingException() == null
+          && QueryOptionsUtils.isMaterializedExchange(queryOptions)) {
+        validateMaterializedOutputs(requestId, expectedMaterializedOutputs(dispatchableSubPlan),
+            session.getMaterializedOutputs());
       }
       return mergeSessionStatsIntoResult(brokerResult, session, expectedByStage);
     } catch (Exception ex) {
@@ -334,6 +340,55 @@ public class QueryDispatcher {
         _serversByQuery.remove(requestId);
       }
     }
+  }
+
+  private static Set<String> expectedMaterializedOutputs(DispatchableSubPlan dispatchableSubPlan) {
+    Set<String> expected = new HashSet<>();
+    Map<Integer, DispatchablePlanFragment> stages = dispatchableSubPlan.getQueryStageMap();
+    for (DispatchablePlanFragment producer : stages.values()) {
+      PlanNode root = producer.getPlanFragment().getFragmentRoot();
+      if (!(root instanceof MailboxSendNode) || !((MailboxSendNode) root).isMaterialized()) {
+        continue;
+      }
+      MailboxSendNode send = (MailboxSendNode) root;
+      int consumerStageId = send.getReceiverStageIds().iterator().next();
+      int partitionCount = stages.get(consumerStageId).getWorkerMetadataList().size();
+      int producerStageId = producer.getPlanFragment().getFragmentId();
+      for (WorkerMetadata producerWorker : producer.getWorkerMetadataList()) {
+        for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
+          expected.add(materializedOutputIdentity(producerStageId, producerWorker.getWorkerId(), partitionId));
+        }
+      }
+    }
+    return expected;
+  }
+
+  @VisibleForTesting
+  static void validateMaterializedOutputs(long requestId, Set<String> expected,
+      List<Worker.MaterializedPartitionHandle> actual) {
+    Set<String> actualIdentities = new HashSet<>();
+    for (Worker.MaterializedPartitionHandle handle : actual) {
+      if (handle.getRequestId() != requestId) {
+        throw new IllegalStateException("Unexpected materialized output request id: " + handle.getRequestId());
+      }
+      String identity = materializedOutputIdentity(handle.getProducerStageId(), handle.getProducerWorkerId(),
+          handle.getLogicalPartitionId());
+      if (!actualIdentities.add(identity)) {
+        throw new IllegalStateException("Duplicate materialized output: " + identity);
+      }
+    }
+    if (!actualIdentities.equals(expected)) {
+      Set<String> missing = new HashSet<>(expected);
+      missing.removeAll(actualIdentities);
+      Set<String> unexpected = new HashSet<>(actualIdentities);
+      unexpected.removeAll(expected);
+      throw new IllegalStateException(
+          "Incomplete materialized output coverage; missing=" + missing + ", unexpected=" + unexpected);
+    }
+  }
+
+  private static String materializedOutputIdentity(int stageId, int workerId, int partitionId) {
+    return stageId + "/" + workerId + "/" + partitionId;
   }
 
   /// Streaming variant of [#submit]: opens one `SubmitWithStream` bidi RPC per server, registers each

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -205,6 +205,9 @@ public class QueryDispatcher {
   public QueryResult submitAndReduce(RequestContext context, DispatchableSubPlan dispatchableSubPlan, long timeoutMs,
       Map<String, String> queryOptions, @Nullable ServerRoutingStatsManager statsManager)
       throws Exception {
+    if (isStagedDispatch(queryOptions)) {
+      return submitAndReduceStaged(context, dispatchableSubPlan, timeoutMs, queryOptions, statsManager);
+    }
     if (QueryOptionsUtils.isMaterializedExchange(queryOptions)
         || QueryOptionsUtils.isStreamStats(queryOptions, _streamStatsDefault)) {
       return submitAndReduceWithStream(context, dispatchableSubPlan, timeoutMs, queryOptions, statsManager);
@@ -246,6 +249,129 @@ public class QueryDispatcher {
         _serversByQuery.remove(requestId);
       }
     }
+  }
+
+  @VisibleForTesting
+  static boolean isStagedDispatch(Map<String, String> queryOptions) {
+    return QueryOptionsUtils.isStagedDispatch(queryOptions);
+  }
+
+  private QueryResult submitAndReduceStaged(RequestContext context, DispatchableSubPlan dispatchableSubPlan,
+      long timeoutMs, Map<String, String> queryOptions, @Nullable ServerRoutingStatsManager statsManager)
+      throws Exception {
+    long requestId = context.getRequestId();
+    long deadlineMs = System.currentTimeMillis() + timeoutMs;
+    Deadline deadline = Deadline.after(timeoutMs, TimeUnit.MILLISECONDS);
+    Set<QueryServerInstance> servers = new HashSet<>();
+    Set<QueryServerInstance> incrementedServers = new HashSet<>();
+    Set<DispatchablePlanFragment> stagePlansWithoutRoot = dispatchableSubPlan.getQueryStagesWithoutRoot();
+    Map<Integer, Set<Integer>> expectedWorkersByStage = expectedWorkersByStage(stagePlansWithoutRoot);
+    Map<Integer, Integer> expectedByStage = new HashMap<>();
+    int totalExpected = 0;
+    for (Map.Entry<Integer, Set<Integer>> entry : expectedWorkersByStage.entrySet()) {
+      int expected = entry.getValue().size();
+      expectedByStage.put(entry.getKey(), expected);
+      totalExpected += expected;
+    }
+    StreamingQuerySession session =
+        new StreamingQuerySession(requestId, totalExpected, expectedWorkersByStage);
+    StageDispatchGraph dispatchGraph = StageDispatchGraph.create(dispatchableSubPlan);
+    QueryResult brokerResult = null;
+
+    try {
+      while (!dispatchGraph.isComplete()) {
+        List<Set<Integer>> readyGroups = dispatchGraph.getReadyGroups();
+        if (readyGroups.isEmpty()) {
+          throw new IllegalStateException("Stage dispatch graph is incomplete but has no ready group");
+        }
+        for (Set<Integer> group : readyGroups) {
+          dispatchGraph.markDispatched(group);
+          Set<Integer> remoteStageIds = new HashSet<>(group);
+          remoteStageIds.remove(0);
+          Set<DispatchablePlanFragment> readyStagePlans =
+              selectStagePlans(stagePlansWithoutRoot, remoteStageIds);
+          submitWithStream(requestId, readyStagePlans, deadline, servers, queryOptions, session);
+
+          if (statsManager != null) {
+            for (QueryServerInstance server : servers) {
+              if (incrementedServers.add(server)) {
+                statsManager.recordStatsForQuerySubmission(requestId, server.getInstanceId());
+              }
+            }
+          }
+
+          if (group.contains(0)) {
+            brokerResult = runReducer(dispatchableSubPlan, queryOptions, _mailboxService);
+            if (brokerResult.getProcessingException() != null) {
+              session.fanOutCancel();
+              long statsWaitMs = Math.min(_statsDrainMs, remainingTimeMs(deadline));
+              session.awaitCompletion(statsWaitMs, TimeUnit.MILLISECONDS);
+              return mergeSessionStatsIntoResult(brokerResult, session, expectedByStage);
+            }
+          }
+
+          if (!remoteStageIds.isEmpty()) {
+            session.awaitSuccessfulStages(remoteStageIds, remainingTimeMs(deadline), TimeUnit.MILLISECONDS);
+            session.awaitStreamsClosed(remainingTimeMs(deadline), TimeUnit.MILLISECONDS);
+          }
+          dispatchGraph.markCompleted(group);
+        }
+      }
+
+      if (brokerResult == null) {
+        throw new IllegalStateException("Stage dispatch graph completed without executing root stage 0");
+      }
+      if (QueryOptionsUtils.isMaterializedExchange(queryOptions)) {
+        validateMaterializedOutputs(requestId, expectedMaterializedOutputs(dispatchableSubPlan),
+            session.getMaterializedOutputs());
+      }
+      return mergeSessionStatsIntoResult(brokerResult, session, expectedByStage);
+    } catch (Exception ex) {
+      return tryRecoverWithStream(session, expectedByStage, deadlineMs, ex);
+    } catch (Throwable e) {
+      session.fanOutCancel();
+      throw e;
+    } finally {
+      if (statsManager != null) {
+        for (QueryServerInstance server : incrementedServers) {
+          statsManager.recordStatsUponResponseArrival(requestId, server.getInstanceId(), -1);
+        }
+      }
+      if (isQueryCancellationEnabled()) {
+        _serversByQuery.remove(requestId);
+      }
+    }
+  }
+
+  private static long remainingTimeMs(Deadline deadline) {
+    return Math.max(0L, deadline.timeRemaining(TimeUnit.MILLISECONDS));
+  }
+
+  private static Map<Integer, Set<Integer>> expectedWorkersByStage(
+      Set<DispatchablePlanFragment> stagePlans) {
+    Map<Integer, Set<Integer>> expectedWorkersByStage = new HashMap<>();
+    for (DispatchablePlanFragment stagePlan : stagePlans) {
+      Set<Integer> workerIds = new HashSet<>();
+      for (List<Integer> serverWorkerIds : stagePlan.getServerInstanceToWorkerIdMap().values()) {
+        workerIds.addAll(serverWorkerIds);
+      }
+      expectedWorkersByStage.put(stagePlan.getPlanFragment().getFragmentId(), workerIds);
+    }
+    return expectedWorkersByStage;
+  }
+
+  private static Set<DispatchablePlanFragment> selectStagePlans(
+      Set<DispatchablePlanFragment> stagePlans, Set<Integer> stageIds) {
+    Set<DispatchablePlanFragment> selected = new HashSet<>();
+    for (DispatchablePlanFragment stagePlan : stagePlans) {
+      if (stageIds.contains(stagePlan.getPlanFragment().getFragmentId())) {
+        selected.add(stagePlan);
+      }
+    }
+    if (selected.size() != stageIds.size()) {
+      throw new IllegalStateException("Unknown non-root stage ids: " + stageIds);
+    }
+    return selected;
   }
 
   /// Streaming variant of [#submitAndReduce]: opens one `SubmitWithStream` bidi RPC per server, runs the
@@ -398,11 +524,19 @@ public class QueryDispatcher {
   void submitWithStream(long requestId, DispatchableSubPlan dispatchableSubPlan, long timeoutMs,
       Set<QueryServerInstance> serversOut, Map<String, String> queryOptions, StreamingQuerySession session)
       throws Exception {
-    Deadline deadline = Deadline.after(timeoutMs, TimeUnit.MILLISECONDS);
+    submitWithStream(requestId, dispatchableSubPlan.getQueryStagesWithoutRoot(),
+        Deadline.after(timeoutMs, TimeUnit.MILLISECONDS), serversOut, queryOptions, session);
+  }
 
-    Set<DispatchablePlanFragment> plansWithoutRoot = dispatchableSubPlan.getQueryStagesWithoutRoot();
-    Map<DispatchablePlanFragment, StageInfo> stageInfos = serializePlanFragments(plansWithoutRoot, serversOut);
-    if (serversOut.isEmpty()) {
+  @VisibleForTesting
+  void submitWithStream(long requestId, Set<DispatchablePlanFragment> stagePlans, Deadline deadline,
+      Set<QueryServerInstance> serversOut, Map<String, String> queryOptions, StreamingQuerySession session)
+      throws Exception {
+    Set<QueryServerInstance> participatingServers = new HashSet<>();
+    Map<DispatchablePlanFragment, StageInfo> stageInfos =
+        serializePlanFragments(stagePlans, participatingServers);
+    serversOut.addAll(participatingServers);
+    if (participatingServers.isEmpty()) {
       return;
     }
 
@@ -413,11 +547,12 @@ public class QueryDispatcher {
     // Per-server expected opchain count = sum across the server's non-root stages of (workers on this server in
     // that stage). The streaming observer uses this to drain the session latch correctly when its stream errors
     // before all opchains have responded.
-    BlockingQueue<AsyncResponse<Worker.QueryResponse>> ackQueue = new ArrayBlockingQueue<>(serversOut.size());
-    for (QueryServerInstance server : serversOut) {
+    BlockingQueue<AsyncResponse<Worker.QueryResponse>> ackQueue =
+        new ArrayBlockingQueue<>(participatingServers.size());
+    for (QueryServerInstance server : participatingServers) {
       Worker.QueryRequest request = createRequest(server, stageInfos, protoRequestMetadata);
       int expectedForServer = 0;
-      for (DispatchablePlanFragment stagePlan : plansWithoutRoot) {
+      for (DispatchablePlanFragment stagePlan : stagePlans) {
         List<Integer> workerIds = stagePlan.getServerInstanceToWorkerIdMap().get(server);
         if (workerIds != null) {
           expectedForServer += workerIds.size();
@@ -437,7 +572,7 @@ public class QueryDispatcher {
       }
     }
 
-    processResults(requestId, serversOut.size(), (response, server) -> {
+    processResults(requestId, participatingServers.size(), (response, server) -> {
       if (response.containsMetadata(ServerResponseStatus.STATUS_ERROR)) {
         session.fanOutCancel();
         throw new RuntimeException(
@@ -447,7 +582,7 @@ public class QueryDispatcher {
     }, deadline, ackQueue);
 
     if (isQueryCancellationEnabled()) {
-      _serversByQuery.put(requestId, serversOut);
+      _serversByQuery.put(requestId, Set.copyOf(serversOut));
     }
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/StageDispatchGraph.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/StageDispatchGraph.java
@@ -1,0 +1,269 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.service.dispatch;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import org.apache.pinot.calcite.rel.logical.PinotRelExchangeType;
+import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
+import org.apache.pinot.query.planner.physical.DispatchableSubPlan;
+import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+
+
+/// Dependency graph for dispatch groups. Streaming edges are dispatched together; materialized edges form barriers.
+final class StageDispatchGraph {
+  private final List<Group> _groups;
+  private final Map<Set<Integer>, Group> _groupsByStages;
+
+  private StageDispatchGraph(List<Group> groups) {
+    _groups = groups;
+    Map<Set<Integer>, Group> groupsByStages = new HashMap<>();
+    for (Group group : groups) {
+      groupsByStages.put(group._stages, group);
+    }
+    _groupsByStages = Map.copyOf(groupsByStages);
+  }
+
+  static StageDispatchGraph create(DispatchableSubPlan subPlan) {
+    Map<Integer, DispatchablePlanFragment> stages = subPlan.getQueryStageMap();
+    UnionFind unionFind = new UnionFind(stages.keySet());
+    List<Edge> edges = collectEdges(stages);
+
+    for (Edge edge : edges) {
+      if (!edge._materialized) {
+        if (edge._exchangeType != PinotRelExchangeType.STREAMING
+            && edge._exchangeType != PinotRelExchangeType.PIPELINE_BREAKER) {
+          throw new IllegalArgumentException("Unsupported stage exchange type: " + edge._exchangeType);
+        }
+        unionFind.union(edge._senderStageId, edge._receiverStageId);
+      }
+    }
+
+    Map<Integer, Set<Integer>> stagesByRoot = new TreeMap<>();
+    for (int stageId : new TreeSet<>(stages.keySet())) {
+      stagesByRoot.computeIfAbsent(unionFind.find(stageId), ignored -> new TreeSet<>()).add(stageId);
+    }
+
+    List<Group> groups = new ArrayList<>(stagesByRoot.size());
+    Map<Integer, Group> groupByStage = new HashMap<>();
+    for (Set<Integer> stageIds : stagesByRoot.values()) {
+      Group group = new Group(stageIds);
+      groups.add(group);
+      for (int stageId : stageIds) {
+        groupByStage.put(stageId, group);
+      }
+    }
+
+    for (Edge edge : edges) {
+      if (edge._materialized) {
+        Group sender = groupByStage.get(edge._senderStageId);
+        Group receiver = groupByStage.get(edge._receiverStageId);
+        if (sender == receiver) {
+          throw new IllegalArgumentException("Materialized dependency forms a cycle within group " + sender._stages);
+        }
+        receiver._dependencies.add(sender);
+      }
+    }
+    rejectCycles(groups);
+    return new StageDispatchGraph(List.copyOf(groups));
+  }
+
+  synchronized List<Set<Integer>> getReadyGroups() {
+    List<Set<Integer>> ready = new ArrayList<>();
+    for (Group group : _groups) {
+      if (!group._dispatched && dependenciesComplete(group)) {
+        ready.add(group._stages);
+      }
+    }
+    return List.copyOf(ready);
+  }
+
+  synchronized void markDispatched(Set<Integer> stages) {
+    Group group = getGroup(stages);
+    if (group._dispatched) {
+      throw new IllegalStateException("Dispatch group already dispatched: " + stages);
+    }
+    if (!dependenciesComplete(group)) {
+      throw new IllegalStateException("Dispatch group is not ready: " + stages);
+    }
+    group._dispatched = true;
+  }
+
+  synchronized void markCompleted(Set<Integer> stages) {
+    Group group = getGroup(stages);
+    if (!group._dispatched) {
+      throw new IllegalStateException("Dispatch group was not dispatched: " + stages);
+    }
+    if (group._completed) {
+      throw new IllegalStateException("Dispatch group already completed: " + stages);
+    }
+    group._completed = true;
+  }
+
+  synchronized boolean isComplete() {
+    for (Group group : _groups) {
+      if (!group._completed) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private Group getGroup(Set<Integer> stages) {
+    Group group = _groupsByStages.get(stages);
+    if (group == null) {
+      throw new IllegalArgumentException("Unknown dispatch group: " + stages);
+    }
+    return group;
+  }
+
+  private static boolean dependenciesComplete(Group group) {
+    for (Group dependency : group._dependencies) {
+      if (!dependency._completed) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static List<Edge> collectEdges(Map<Integer, DispatchablePlanFragment> stages) {
+    List<Edge> edges = new ArrayList<>();
+    for (int stageId : new TreeSet<>(stages.keySet())) {
+      PlanNode root = stages.get(stageId).getPlanFragment().getFragmentRoot();
+      Deque<PlanNode> pending = new ArrayDeque<>();
+      pending.push(root);
+      while (!pending.isEmpty()) {
+        PlanNode node = pending.pop();
+        if (node instanceof MailboxReceiveNode) {
+          MailboxReceiveNode receive = (MailboxReceiveNode) node;
+          int senderStageId = receive.getSenderStageId();
+          if (!stages.containsKey(senderStageId)) {
+            throw new IllegalArgumentException("Unknown sender stage: " + senderStageId);
+          }
+          edges.add(new Edge(senderStageId, stageId, receive.getExchangeType(), receive.isMaterialized()));
+        }
+        List<PlanNode> inputs = node.getInputs();
+        for (int i = inputs.size() - 1; i >= 0; i--) {
+          pending.push(inputs.get(i));
+        }
+      }
+    }
+    return edges;
+  }
+
+  private static void rejectCycles(List<Group> groups) {
+    Map<Group, Integer> remainingDependencies = new HashMap<>();
+    Map<Group, List<Group>> dependents = new HashMap<>();
+    PriorityQueue<Group> ready = new PriorityQueue<>((left, right) ->
+        Integer.compare(left._stages.iterator().next(), right._stages.iterator().next()));
+    for (Group group : groups) {
+      int dependencyCount = group._dependencies.size();
+      remainingDependencies.put(group, dependencyCount);
+      if (dependencyCount == 0) {
+        ready.add(group);
+      }
+      for (Group dependency : group._dependencies) {
+        dependents.computeIfAbsent(dependency, ignored -> new ArrayList<>()).add(group);
+      }
+    }
+
+    int visited = 0;
+    while (!ready.isEmpty()) {
+      Group group = ready.remove();
+      visited++;
+      for (Group dependent : dependents.getOrDefault(group, List.of())) {
+        int remaining = remainingDependencies.compute(dependent, (ignored, count) -> count - 1);
+        if (remaining == 0) {
+          ready.add(dependent);
+        }
+      }
+    }
+    if (visited != groups.size()) {
+      throw new IllegalArgumentException("Stage dispatch graph contains a cycle");
+    }
+  }
+
+  private static final class Group {
+    private final Set<Integer> _stages;
+    private final Set<Group> _dependencies = new HashSet<>();
+    private boolean _dispatched;
+    private boolean _completed;
+
+    private Group(Set<Integer> stages) {
+      _stages = Collections.unmodifiableSet(new TreeSet<>(stages));
+    }
+  }
+
+  private static final class Edge {
+    private final int _senderStageId;
+    private final int _receiverStageId;
+    private final PinotRelExchangeType _exchangeType;
+    private final boolean _materialized;
+
+    private Edge(int senderStageId, int receiverStageId, PinotRelExchangeType exchangeType, boolean materialized) {
+      _senderStageId = senderStageId;
+      _receiverStageId = receiverStageId;
+      _exchangeType = exchangeType;
+      _materialized = materialized;
+    }
+  }
+
+  private static final class UnionFind {
+    private final Map<Integer, Integer> _parents = new HashMap<>();
+
+    private UnionFind(Set<Integer> stageIds) {
+      for (int stageId : stageIds) {
+        _parents.put(stageId, stageId);
+      }
+    }
+
+    private int find(int stageId) {
+      Integer parent = _parents.get(stageId);
+      if (parent == null) {
+        throw new IllegalArgumentException("Unknown stage: " + stageId);
+      }
+      if (parent != stageId) {
+        parent = find(parent);
+        _parents.put(stageId, parent);
+      }
+      return parent;
+    }
+
+    private void union(int firstStageId, int secondStageId) {
+      int firstRoot = find(firstStageId);
+      int secondRoot = find(secondStageId);
+      if (firstRoot != secondRoot) {
+        int root = Math.min(firstRoot, secondRoot);
+        _parents.put(firstRoot, root);
+        _parents.put(secondRoot, root);
+      }
+    }
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/streaming/StreamingDispatchObserver.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/streaming/StreamingDispatchObserver.java
@@ -150,9 +150,8 @@ public class StreamingDispatchObserver
           // Advance the reported counter so a subsequent onError (stream reset after DONE) sees remaining==0
           // and does not double-drain the latch.
           _opChainsReportedForThisServer = _expectedOpChainsForThisServer;
-        } else {
-          _session.unregisterStream(this);
         }
+        _session.unregisterStream(this);
         break;
       case PAYLOAD_NOT_SET:
       default:

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/streaming/StreamingQuerySession.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/streaming/StreamingQuerySession.java
@@ -18,10 +18,12 @@
  */
 package org.apache.pinot.query.service.dispatch.streaming;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -71,6 +73,8 @@ public class StreamingQuerySession {
   private final Map<Integer, Integer> _respondedByStage = new HashMap<>();
   /// Per-stage count of opchains that responded but the broker couldn't merge their payload.
   private final Map<Integer, Integer> _mergeFailedByStage = new HashMap<>();
+  /// Materialized outputs reported by successful producer opchains. Mutated under [#_lock].
+  private final List<Worker.MaterializedPartitionHandle> _materializedOutputs = new ArrayList<>();
   /// Stages whose accumulator hit a shape mismatch. A mismatch means the workers of this stage disagree on the tree
   /// shape (typically version skew), so no merged result for the stage can be trusted: the partially-merged tree is
   /// dropped, and every subsequent report for the stage is counted as `mergeFailed` rather than being allowed
@@ -165,6 +169,8 @@ public class StreamingQuerySession {
           _peerErrorObserved = true;
           shouldFanOutCancel = true;
         }
+      } else {
+        _materializedOutputs.addAll(message.getMaterializedOutputList());
       }
       if (decodeError != null) {
         LOGGER.warn("Decode failed for opchain stage={} worker={} on request {}: {}",
@@ -311,6 +317,16 @@ public class StreamingQuerySession {
   public boolean awaitCompletion(long timeout, TimeUnit unit)
       throws InterruptedException {
     return _completionLatch.await(timeout, unit);
+  }
+
+  /// Returns an immutable snapshot of materialized output descriptors received so far.
+  public List<Worker.MaterializedPartitionHandle> getMaterializedOutputs() {
+    _lock.lock();
+    try {
+      return List.copyOf(_materializedOutputs);
+    } finally {
+      _lock.unlock();
+    }
   }
 
   /// Returns a snapshot of the per-stage coverage. Stage ids that received any responses (successful or

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/streaming/StreamingQuerySession.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/streaming/StreamingQuerySession.java
@@ -25,9 +25,11 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.metrics.BrokerMeter;
@@ -58,14 +60,18 @@ public class StreamingQuerySession {
   private final long _requestId;
   private final int _expectedOpChains;
   private final CountDownLatch _completionLatch;
+  private final boolean _trackExpectedWorkers;
+  private final Map<Integer, Set<Integer>> _expectedWorkerIdsByStage;
   /// Guards [#_stageAccumulator], [#_respondedByStage], [#_mergeFailedByStage],
-  /// [#_openStreams], and [#_peerErrorObserved]. Lock hold time is proportional to the merge work (a few
-  /// map operations), not to proto decode; see [#recordOpChainComplete] for why decode is done outside.
+  /// [#_successfulWorkerIdsByStage], [#_openStreams], [#_barrierFailure], and [#_peerErrorObserved].
+  /// Lock hold time is proportional to the merge work (a few map operations), not to proto decode; see
+  /// [#recordOpChainComplete] for why decode is done outside.
   ///
   /// If lock contention becomes a bottleneck at high QPS, a virtual-thread actor (one VT per query draining from
   /// an `ArrayBlockingQueue`, with gRPC I/O threads simply enqueuing) would eliminate the lock entirely and
   /// avoid any contention between concurrent inbound callbacks.
   private final ReentrantLock _lock = new ReentrantLock();
+  private final Condition _barrierChanged = _lock.newCondition();
 
   /// Per-stage merged accumulator. Mutated under [#_lock].
   private final Map<Integer, StageStatsTreeNode> _stageAccumulator = new HashMap<>();
@@ -75,6 +81,8 @@ public class StreamingQuerySession {
   private final Map<Integer, Integer> _mergeFailedByStage = new HashMap<>();
   /// Materialized outputs reported by successful producer opchains. Mutated under [#_lock].
   private final List<Worker.MaterializedPartitionHandle> _materializedOutputs = new ArrayList<>();
+  /// Unique workers that have successfully completed each stage. Mutated under [#_lock].
+  private final Map<Integer, Set<Integer>> _successfulWorkerIdsByStage = new HashMap<>();
   /// Stages whose accumulator hit a shape mismatch. A mismatch means the workers of this stage disagree on the tree
   /// shape (typically version skew), so no merged result for the stage can be trusted: the partially-merged tree is
   /// dropped, and every subsequent report for the stage is counted as `mergeFailed` rather than being allowed
@@ -88,6 +96,9 @@ public class StreamingQuerySession {
   /// True after the first peer error (success=false OpChainComplete or stream onError). Used to trigger fan-out
   /// cancel idempotently.
   private boolean _peerErrorObserved = false;
+  /// First execution or transport failure observed by an exact stage/stream barrier.
+  @Nullable
+  private IllegalStateException _barrierFailure;
 
   /// Set once [#snapshotCoverage()] has been taken (the broker has stopped waiting for stats). After this, late
   /// [#recordOpChainComplete] reports are ignored: the broker is about to flatten/serialize the snapshot on its
@@ -96,9 +107,26 @@ public class StreamingQuerySession {
   private boolean _finalized = false;
 
   public StreamingQuerySession(long requestId, int expectedOpChains) {
+    this(requestId, expectedOpChains, null);
+  }
+
+  public StreamingQuerySession(long requestId, int expectedOpChains,
+      Map<Integer, Set<Integer>> expectedWorkerIdsByStage) {
     _requestId = requestId;
     _expectedOpChains = expectedOpChains;
     _completionLatch = new CountDownLatch(expectedOpChains);
+    _trackExpectedWorkers = expectedWorkerIdsByStage != null;
+    _expectedWorkerIdsByStage =
+        expectedWorkerIdsByStage == null ? Map.of() : copyExpectedWorkerIds(expectedWorkerIdsByStage);
+  }
+
+  private static Map<Integer, Set<Integer>> copyExpectedWorkerIds(
+      Map<Integer, Set<Integer>> expectedWorkerIdsByStage) {
+    Map<Integer, Set<Integer>> copy = new HashMap<>(expectedWorkerIdsByStage.size());
+    for (Map.Entry<Integer, Set<Integer>> entry : expectedWorkerIdsByStage.entrySet()) {
+      copy.put(Objects.requireNonNull(entry.getKey()), Set.copyOf(Objects.requireNonNull(entry.getValue())));
+    }
+    return Collections.unmodifiableMap(copy);
   }
 
   public long getRequestId() {
@@ -115,6 +143,7 @@ public class StreamingQuerySession {
     _lock.lock();
     try {
       _openStreams.add(stream);
+      _barrierChanged.signalAll();
     } finally {
       _lock.unlock();
     }
@@ -126,6 +155,7 @@ public class StreamingQuerySession {
     _lock.lock();
     try {
       _openStreams.remove(stream);
+      _barrierChanged.signalAll();
     } finally {
       _lock.unlock();
     }
@@ -164,11 +194,20 @@ public class StreamingQuerySession {
         // awaitCompletion, so there is nothing left to count down.
         return;
       }
-      if (!isSuccess) {
-        if (!_peerErrorObserved) {
-          _peerErrorObserved = true;
-          shouldFanOutCancel = true;
+      int workerId = message.getWorkerId();
+      if (_trackExpectedWorkers) {
+        Set<Integer> expectedWorkerIds = _expectedWorkerIdsByStage.get(stageId);
+        if (expectedWorkerIds == null || !expectedWorkerIds.contains(workerId)) {
+          shouldFanOutCancel = recordBarrierFailureLocked("Unexpected OpChainComplete stage=" + stageId
+              + " worker=" + workerId + " on request " + _requestId);
+        } else if (isSuccess) {
+          _successfulWorkerIdsByStage.computeIfAbsent(stageId, ignored -> new HashSet<>()).add(workerId);
+          _barrierChanged.signalAll();
         }
+      }
+      if (!isSuccess) {
+        shouldFanOutCancel |= recordBarrierFailureLocked("OpChainComplete reported failure for stage=" + stageId
+            + " worker=" + workerId + " on request " + _requestId + ": " + message.getErrorMsg());
       } else {
         _materializedOutputs.addAll(message.getMaterializedOutputList());
       }
@@ -202,6 +241,18 @@ public class StreamingQuerySession {
     if (shouldFanOutCancel) {
       fanOutCancel();
     }
+  }
+
+  private boolean recordBarrierFailureLocked(String message) {
+    if (_barrierFailure == null) {
+      _barrierFailure = new IllegalStateException(message);
+    }
+    _barrierChanged.signalAll();
+    if (!_peerErrorObserved) {
+      _peerErrorObserved = true;
+      return true;
+    }
+    return false;
   }
 
   /// Merges `incoming` into the accumulator for `stageId`. Returns `true` if it was stored or merged
@@ -263,6 +314,10 @@ public class StreamingQuerySession {
     _lock.lock();
     try {
       _openStreams.remove(stream);
+      if (_barrierFailure == null) {
+        _barrierFailure = new IllegalStateException("Stream failed on request " + _requestId, error);
+      }
+      _barrierChanged.signalAll();
       if (!_peerErrorObserved) {
         _peerErrorObserved = true;
         shouldFanOutCancel = true;
@@ -317,6 +372,72 @@ public class StreamingQuerySession {
   public boolean awaitCompletion(long timeout, TimeUnit unit)
       throws InterruptedException {
     return _completionLatch.await(timeout, unit);
+  }
+
+  /// Waits until every expected worker for all requested stages reports successful execution.
+  public void awaitSuccessfulStages(Set<Integer> stageIds, long timeout, TimeUnit unit)
+      throws InterruptedException {
+    long remainingNanos = unit.toNanos(timeout);
+    _lock.lockInterruptibly();
+    try {
+      for (int stageId : stageIds) {
+        if (!_expectedWorkerIdsByStage.containsKey(stageId)) {
+          throw new IllegalStateException("No expected workers registered for stage=" + stageId
+              + " on request " + _requestId);
+        }
+      }
+      while (true) {
+        throwIfBarrierFailedLocked();
+        if (areStagesSuccessfulLocked(stageIds)) {
+          return;
+        }
+        if (remainingNanos <= 0) {
+          throw new IllegalStateException("Timed out waiting for stages " + stageIds
+              + " on request " + _requestId);
+        }
+        remainingNanos = _barrierChanged.awaitNanos(remainingNanos);
+      }
+    } finally {
+      _lock.unlock();
+    }
+  }
+
+  private boolean areStagesSuccessfulLocked(Set<Integer> stageIds) {
+    for (int stageId : stageIds) {
+      Set<Integer> successfulWorkerIds = _successfulWorkerIdsByStage.get(stageId);
+      if (successfulWorkerIds == null
+          || !successfulWorkerIds.containsAll(_expectedWorkerIdsByStage.get(stageId))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Waits until every registered server stream has closed.
+  public void awaitStreamsClosed(long timeout, TimeUnit unit)
+      throws InterruptedException {
+    long remainingNanos = unit.toNanos(timeout);
+    _lock.lockInterruptibly();
+    try {
+      while (true) {
+        throwIfBarrierFailedLocked();
+        if (_openStreams.isEmpty()) {
+          return;
+        }
+        if (remainingNanos <= 0) {
+          throw new IllegalStateException("Timed out waiting for server streams to close on request " + _requestId);
+        }
+        remainingNanos = _barrierChanged.awaitNanos(remainingNanos);
+      }
+    } finally {
+      _lock.unlock();
+    }
+  }
+
+  private void throwIfBarrierFailedLocked() {
+    if (_barrierFailure != null) {
+      throw _barrierFailure;
+    }
   }
 
   /// Returns an immutable snapshot of materialized output descriptors received so far.

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
@@ -663,7 +663,8 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
       Worker.OpChainComplete.Builder builder = Worker.OpChainComplete.newBuilder()
           .setStageId(opChainId.getStageId())
           .setWorkerId(opChainId.getVirtualServerId())
-          .setSuccess(error == null);
+          .setSuccess(error == null)
+          .addAllMaterializedOutput(context.getMaterializedOutputHandles());
       if (error != null) {
         builder.setErrorMsg(error.getMessage() == null ? error.getClass().getSimpleName() : error.getMessage());
       }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/MaterializedMailboxServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/MaterializedMailboxServiceTest.java
@@ -1,0 +1,180 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.mailbox;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.common.proto.Worker;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.query.runtime.blocks.MseBlock;
+import org.apache.pinot.query.runtime.blocks.SuccessMseBlock;
+import org.apache.pinot.query.runtime.operator.MailboxSendOperator;
+import org.apache.pinot.query.runtime.operator.OperatorTestUtil;
+import org.apache.pinot.query.testutils.QueryTestUtils;
+import org.apache.pinot.spi.config.instance.InstanceType;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+/// End-to-end tests for materialized mailbox storage and server-streaming transport.
+public class MaterializedMailboxServiceTest {
+  private static final DataSchema DATA_SCHEMA =
+      new DataSchema(new String[]{"value"}, new ColumnDataType[]{ColumnDataType.STRING});
+  private static final long REQUEST_ID = 41L;
+  private static final int PRODUCER_STAGE_ID = 3;
+  private static final int PRODUCER_WORKER_ID = 2;
+  private static final int LOGICAL_PARTITION_ID = 1;
+
+  @Test
+  public void testConstructionDoesNotTouchMaterializedRoot()
+      throws Exception {
+    Path rootParent = Files.createTempFile("invalid-materialized-mailbox-root", null);
+    Path invalidRoot = rootParent.resolve("mailboxes");
+    MailboxService service = new MailboxService("localhost", QueryTestUtils.getAvailablePort(), InstanceType.SERVER,
+        new PinotConfiguration(Map.of()), null, null, invalidRoot);
+    service.start();
+    try {
+      assertFalse(Files.exists(invalidRoot));
+    } finally {
+      service.shutdown();
+      Files.deleteIfExists(rootParent);
+    }
+  }
+
+  @DataProvider(name = "readCases")
+  public Object[][] readCases() {
+    return new Object[][]{
+        {true, 2},
+        {false, 2},
+        {false, 0}
+    };
+  }
+
+  @Test(dataProvider = "readCases")
+  public void testReadRoundTripsAndDeletesAfterExhaustion(boolean localRead, int numRows)
+      throws Exception {
+    MailboxService producer = createService("localhost", QueryTestUtils.getAvailablePort());
+    MailboxService consumer = createService("localhost", QueryTestUtils.getAvailablePort());
+    producer.start();
+    consumer.start();
+    try {
+      StatMap<MailboxSendOperator.StatKey> stats = new StatMap<>(MailboxSendOperator.StatKey.class);
+      AtomicReference<Worker.MaterializedPartitionHandle> committed = new AtomicReference<>();
+      SendingMailbox sendingMailbox = producer.getMaterializedSendingMailbox(
+          REQUEST_ID, PRODUCER_STAGE_ID, PRODUCER_WORKER_ID, LOGICAL_PARTITION_ID, stats, committed::set);
+      if (numRows > 0) {
+        sendingMailbox.send(OperatorTestUtil.block(DATA_SCHEMA, rows(numRows)));
+      }
+      sendingMailbox.send(SuccessMseBlock.INSTANCE, List.of());
+
+      Worker.MaterializedPartitionHandle handle = committed.get();
+      assertEquals(handle.getRowCount(), numRows);
+      assertEquals(handle.getHost(), producer.getHostname());
+      assertEquals(handle.getTransferPort(), producer.getPort());
+      assertTrue(handle.getByteCount() >= 0);
+
+      MailboxService reader = localRead ? producer : consumer;
+      Iterator<MseBlock.Data> blocks = reader.readMaterializedPartition(
+          handle.getHost(), handle.getTransferPort(), handle.getRequestId(), handle.getProducerStageId(),
+          handle.getProducerWorkerId(), handle.getLogicalPartitionId(), deadlineMs(10_000L));
+      List<String> actualValues = new ArrayList<>();
+      while (blocks.hasNext()) {
+        for (Object[] row : blocks.next().asRowHeap().getRows()) {
+          actualValues.add((String) row[0]);
+        }
+      }
+      assertEquals(actualValues, values(numRows));
+      assertFalse(blocks.hasNext());
+      assertEquals(stats.getInt(MailboxSendOperator.StatKey.RAW_MESSAGES), numRows > 0 ? 1 : 0);
+
+      assertThrows(RuntimeException.class, () -> reader.readMaterializedPartition(
+          handle.getHost(), handle.getTransferPort(), handle.getRequestId(), handle.getProducerStageId(),
+          handle.getProducerWorkerId(), handle.getLogicalPartitionId(), deadlineMs(50L)).hasNext());
+    } finally {
+      consumer.shutdown();
+      producer.shutdown();
+    }
+  }
+
+  @DataProvider(name = "cleanupCases")
+  public Object[][] cleanupCases() {
+    return new Object[][]{
+        {true},
+        {false}
+    };
+  }
+
+  @Test(dataProvider = "cleanupCases")
+  public void testCleanupRejectsLocalAndRemoteReads(boolean localRead)
+      throws Exception {
+    MailboxService producer = createService("localhost", QueryTestUtils.getAvailablePort());
+    MailboxService consumer = createService("localhost", QueryTestUtils.getAvailablePort());
+    producer.start();
+    consumer.start();
+    try {
+      producer.cleanupMaterializedMailboxRequest(REQUEST_ID);
+      MailboxService reader = localRead ? producer : consumer;
+      assertThrows(RuntimeException.class, () -> reader.readMaterializedPartition(
+          producer.getHostname(), producer.getPort(), REQUEST_ID, PRODUCER_STAGE_ID, PRODUCER_WORKER_ID,
+          LOGICAL_PARTITION_ID, deadlineMs(1_000L)).hasNext());
+    } finally {
+      consumer.shutdown();
+      producer.shutdown();
+    }
+  }
+
+  private static MailboxService createService(String hostname, int port)
+      throws Exception {
+    return new MailboxService(hostname, port, InstanceType.SERVER, new PinotConfiguration(Map.of()), null, null,
+        Files.createTempDirectory("materialized-mailbox-service"));
+  }
+
+  private static Object[][] rows(int numRows) {
+    Object[][] rows = new Object[numRows][];
+    for (int i = 0; i < numRows; i++) {
+      rows[i] = new Object[]{"value-" + i};
+    }
+    return rows;
+  }
+
+  private static List<String> values(int numRows) {
+    List<String> values = new ArrayList<>(numRows);
+    for (int i = 0; i < numRows; i++) {
+      values.add("value-" + i);
+    }
+    return values;
+  }
+
+  private static long deadlineMs(long delayMs) {
+    return System.currentTimeMillis() + delayMs;
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/channel/GrpcMailboxServerMaterializedStreamingTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/channel/GrpcMailboxServerMaterializedStreamingTest.java
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.mailbox.channel;
+
+import io.grpc.Status;
+import io.grpc.stub.ServerCallStreamObserver;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pinot.common.proto.Mailbox;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+/// Tests backpressure and terminal cleanup for materialized partition server streaming.
+public class GrpcMailboxServerMaterializedStreamingTest {
+
+  @Test
+  public void testPumpStopsWhenStreamBecomesNotReady() {
+    AtomicBoolean ready = new AtomicBoolean();
+    AtomicReference<Runnable> onReady = new AtomicReference<>();
+    ServerCallStreamObserver<Mailbox.MaterializedPartitionContent> observer = observer(ready, onReady, null);
+    doAnswer(invocation -> {
+      ready.set(false);
+      return null;
+    }).when(observer).onNext(any());
+
+    GrpcMailboxServer.MaterializedPartitionPump pump =
+        new GrpcMailboxServer.MaterializedPartitionPump(List.of(new byte[]{1, 2, 3, 4}).iterator(), observer, 2);
+    pump.start();
+    verify(observer, never()).onNext(any());
+
+    ready.set(true);
+    onReady.get().run();
+    verify(observer, times(1)).onNext(any());
+    verify(observer, never()).onCompleted();
+
+    ready.set(true);
+    onReady.get().run();
+    verify(observer, times(2)).onNext(any());
+    verify(observer, never()).onCompleted();
+
+    ready.set(true);
+    onReady.get().run();
+    verify(observer, times(1)).onCompleted();
+  }
+
+  @Test
+  public void testCancellationClosesReaderWithoutSignalingCompletion() {
+    AtomicBoolean ready = new AtomicBoolean();
+    AtomicReference<Runnable> onReady = new AtomicReference<>();
+    AtomicReference<Runnable> onCancel = new AtomicReference<>();
+    ServerCallStreamObserver<Mailbox.MaterializedPartitionContent> observer = observer(ready, onReady, onCancel);
+    CloseableIterator records = new CloseableIterator(List.of(new byte[]{1}).iterator());
+
+    new GrpcMailboxServer.MaterializedPartitionPump(records, observer, 1).start();
+    onCancel.get().run();
+    onCancel.get().run();
+    onReady.get().run();
+
+    assertTrue(records._closed);
+    assertEquals(records._closeCount, 1);
+    verify(observer, never()).onNext(any());
+    verify(observer, never()).onCompleted();
+    verify(observer, never()).onError(any());
+  }
+
+  @Test
+  public void testReadFailureClosesReaderAndSignalsErrorOnce() {
+    AtomicBoolean ready = new AtomicBoolean(true);
+    AtomicReference<Runnable> onReady = new AtomicReference<>();
+    ServerCallStreamObserver<Mailbox.MaterializedPartitionContent> observer = observer(ready, onReady, null);
+    CloseableIterator records = new CloseableIterator(List.of(new byte[]{1}).iterator());
+    records._fail = true;
+
+    new GrpcMailboxServer.MaterializedPartitionPump(records, observer, 1).start();
+    onReady.get().run();
+
+    assertTrue(records._closed);
+    assertEquals(records._closeCount, 1);
+    ArgumentCaptor<Throwable> error = ArgumentCaptor.forClass(Throwable.class);
+    verify(observer, times(1)).onError(error.capture());
+    assertEquals(Status.fromThrowable(error.getValue()).getCode(), Status.Code.INTERNAL);
+    verify(observer, never()).onCompleted();
+  }
+
+  @Test
+  public void testSuccessfulReadDoesNotAbortReader() {
+    AtomicBoolean ready = new AtomicBoolean(true);
+    AtomicReference<Runnable> onReady = new AtomicReference<>();
+    ServerCallStreamObserver<Mailbox.MaterializedPartitionContent> observer =
+        observer(ready, onReady, null);
+    CloseableIterator records = new CloseableIterator(List.of(new byte[]{1}).iterator());
+
+    new GrpcMailboxServer.MaterializedPartitionPump(records, observer, 1).start();
+    onReady.get().run();
+
+    assertFalse(records._closed);
+    verify(observer, times(1)).onCompleted();
+    verify(observer, never()).onError(any());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ServerCallStreamObserver<Mailbox.MaterializedPartitionContent> observer(AtomicBoolean ready,
+      AtomicReference<Runnable> onReady, AtomicReference<Runnable> onCancel) {
+    ServerCallStreamObserver<Mailbox.MaterializedPartitionContent> observer = mock(ServerCallStreamObserver.class);
+    when(observer.isReady()).thenAnswer(invocation -> ready.get());
+    when(observer.isCancelled()).thenReturn(false);
+    doAnswer(invocation -> {
+      onReady.set(invocation.getArgument(0));
+      return null;
+    }).when(observer).setOnReadyHandler(any());
+    if (onCancel != null) {
+      doAnswer(invocation -> {
+        onCancel.set(invocation.getArgument(0));
+        return null;
+      }).when(observer).setOnCancelHandler(any());
+    }
+    return observer;
+  }
+
+  private static final class CloseableIterator implements Iterator<byte[]>, AutoCloseable {
+    private final Iterator<byte[]> _delegate;
+    private boolean _closed;
+    private boolean _fail;
+    private int _closeCount;
+
+    private CloseableIterator(Iterator<byte[]> delegate) {
+      _delegate = delegate;
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (_fail) {
+        throw new IllegalStateException("read failed");
+      }
+      return _delegate.hasNext();
+    }
+
+    @Override
+    public byte[] next() {
+      return _delegate.next();
+    }
+
+    @Override
+    public void close() {
+      _closed = true;
+      _closeCount++;
+    }
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/materialized/MaterializedMailboxStoreTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/materialized/MaterializedMailboxStoreTest.java
@@ -1,0 +1,366 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.mailbox.materialized;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pinot.common.datablock.DataBlock;
+import org.apache.pinot.common.datablock.DataBlockEquals;
+import org.apache.pinot.common.datablock.DataBlockUtils;
+import org.apache.pinot.common.proto.Worker;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.common.datablock.DataBlockBuilder;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+/// Behavioral tests for the producer-local materialized mailbox store.
+public class MaterializedMailboxStoreTest {
+  private static final DataSchema DATA_SCHEMA =
+      new DataSchema(new String[]{"value"}, new ColumnDataType[]{ColumnDataType.INT});
+  private static final long REQUEST_ID = 17L;
+  private static final int STAGE_ID = 3;
+  private static final int WORKER_ID = 2;
+  private static final long DEADLINE_DELAY_MS = 10_000L;
+
+  @DataProvider(name = "partitionContents")
+  public Object[][] partitionContents() {
+    return new Object[][]{
+        {0, 0},
+        {2, 3}
+    };
+  }
+
+  @Test(dataProvider = "partitionContents")
+  public void testCommitPublishesExactDescriptorAndRoundTrips(int numBlocks, int rowsPerBlock)
+      throws Exception {
+    Path root = Files.createTempDirectory("materialized-mailbox-store");
+    MaterializedMailboxStore store = new MaterializedMailboxStore(root, "producer", 1234);
+    MaterializedMailboxKey key = new MaterializedMailboxKey(REQUEST_ID, STAGE_ID, WORKER_ID, numBlocks);
+    List<DataBlock> expectedBlocks = createBlocks(numBlocks, rowsPerBlock);
+    AtomicReference<Worker.MaterializedPartitionHandle> committed = new AtomicReference<>();
+
+    try (MaterializedMailboxWriter writer = store.createWriter(key, committed::set)) {
+      for (DataBlock block : expectedBlocks) {
+        writer.write(block);
+      }
+      Worker.MaterializedPartitionHandle descriptor = writer.commit();
+
+      assertEquals(committed.get(), descriptor);
+      assertEquals(descriptor.getRequestId(), key.getRequestId());
+      assertEquals(descriptor.getProducerStageId(), key.getProducerStageId());
+      assertEquals(descriptor.getProducerWorkerId(), key.getProducerWorkerId());
+      assertEquals(descriptor.getLogicalPartitionId(), key.getLogicalPartitionId());
+      assertEquals(descriptor.getHost(), "producer");
+      assertEquals(descriptor.getTransferPort(), 1234);
+      assertEquals(descriptor.getRowCount(), (long) numBlocks * rowsPerBlock);
+      assertEquals(descriptor.getByteCount(), Files.size(store.getCommittedPath(key)));
+
+      List<DataBlock> actualBlocks = new ArrayList<>();
+      try (MaterializedMailboxStore.RecordIterator records = store.read(key, deadlineMs())) {
+        IteratorUtils.forEachRemaining(records, payload ->
+            actualBlocks.add(DataBlockUtils.deserialize(List.of(ByteBuffer.wrap(payload)))));
+      }
+      assertDataBlocks(expectedBlocks, actualBlocks);
+      assertFalse(Files.exists(store.getCommittedPath(key)));
+    } finally {
+      store.close();
+    }
+  }
+
+  @Test
+  public void testReadWaitsForAtomicCommit()
+      throws Exception {
+    Path root = Files.createTempDirectory("materialized-mailbox-wait");
+    MaterializedMailboxStore store = new MaterializedMailboxStore(root, "producer", 1234);
+    MaterializedMailboxKey key = new MaterializedMailboxKey(REQUEST_ID, STAGE_ID, WORKER_ID, 0);
+    DataBlock block = createBlocks(1, 1).get(0);
+    CountDownLatch readerStarted = new CountDownLatch(1);
+    CompletableFuture<List<byte[]>> read = CompletableFuture.supplyAsync(() -> {
+      List<byte[]> records = new ArrayList<>();
+      readerStarted.countDown();
+      try (MaterializedMailboxStore.RecordIterator iterator = store.read(key, deadlineMs())) {
+        iterator.forEachRemaining(records::add);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+      return records;
+    });
+
+    try {
+      assertTrue(readerStarted.await(DEADLINE_DELAY_MS, TimeUnit.MILLISECONDS));
+      awaitWaitingReader(store, key);
+      assertFalse(read.isDone());
+      try (MaterializedMailboxWriter writer = store.createWriter(key, descriptor -> {
+      })) {
+        writer.write(block);
+        writer.commit();
+      }
+      assertEquals(read.get(DEADLINE_DELAY_MS, TimeUnit.MILLISECONDS).size(), 1);
+    } finally {
+      store.close();
+    }
+  }
+
+  @DataProvider(name = "cleanupOperations")
+  public Object[][] cleanupOperations() {
+    return new Object[][]{
+        {"request"},
+        {"shutdown"}
+    };
+  }
+
+  @Test(dataProvider = "cleanupOperations")
+  public void testCleanupRemovesCommittedAndRejectsPendingReads(String cleanupOperation)
+      throws Exception {
+    Path root = Files.createTempDirectory("materialized-mailbox-cleanup");
+    MaterializedMailboxStore store = new MaterializedMailboxStore(root, "producer", 1234);
+    MaterializedMailboxKey committedKey = new MaterializedMailboxKey(REQUEST_ID, STAGE_ID, WORKER_ID, 0);
+    MaterializedMailboxKey pendingKey = new MaterializedMailboxKey(REQUEST_ID, STAGE_ID, WORKER_ID, 1);
+    try (MaterializedMailboxWriter writer = store.createWriter(committedKey, descriptor -> {
+    })) {
+      writer.commit();
+    }
+    MaterializedMailboxStore.RecordIterator committedRead = store.read(committedKey, deadlineMs());
+    CompletableFuture<Void> pendingRead = CompletableFuture.runAsync(() -> {
+      try (MaterializedMailboxStore.RecordIterator records = store.read(pendingKey, deadlineMs())) {
+        records.forEachRemaining(payload -> {
+        });
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+    awaitWaitingReader(store, pendingKey);
+
+    if ("request".equals(cleanupOperation)) {
+      store.cleanupRequest(REQUEST_ID);
+    } else {
+      store.close();
+    }
+
+    assertThrows(Exception.class, () -> pendingRead.get(DEADLINE_DELAY_MS, TimeUnit.MILLISECONDS));
+    assertFalse(committedRead.hasNext());
+    assertFalse(Files.exists(store.getCommittedPath(committedKey)));
+    assertEquals(Files.exists(root), "request".equals(cleanupOperation));
+    store.close();
+  }
+
+  @Test
+  public void testCleanupRejectsRegisteredWriterAndReader()
+      throws Exception {
+    Path root = Files.createTempDirectory("materialized-mailbox-cleanup-race");
+    MaterializedMailboxStore store = new MaterializedMailboxStore(root, "producer", 1234);
+    MaterializedMailboxKey writerKey = new MaterializedMailboxKey(REQUEST_ID, STAGE_ID, WORKER_ID, 0);
+    MaterializedMailboxKey readerKey = new MaterializedMailboxKey(REQUEST_ID, STAGE_ID, WORKER_ID, 1);
+    MaterializedMailboxWriter writer = store.createWriter(writerKey, descriptor -> {
+    });
+    CompletableFuture<Void> pendingRead = CompletableFuture.runAsync(() -> {
+      try (MaterializedMailboxStore.RecordIterator records = store.read(readerKey, deadlineMs())) {
+        records.forEachRemaining(payload -> {
+        });
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+    awaitWaitingReader(store, readerKey);
+
+    store.cleanupRequest(REQUEST_ID);
+
+    assertThrows(Exception.class, () -> pendingRead.get(DEADLINE_DELAY_MS, TimeUnit.MILLISECONDS));
+    assertThrows(IOException.class, writer::commit);
+    assertThrows(IOException.class, () -> store.createWriter(writerKey, descriptor -> {
+    }));
+    assertThrows(IOException.class, () -> store.read(readerKey, deadlineMs()));
+    assertFalse(Files.exists(root.resolve(Long.toString(REQUEST_ID))));
+    store.close();
+  }
+
+  @Test
+  public void testOutputCloseFailureAbortsAndNotifiesReader()
+      throws Exception {
+    Path root = Files.createTempDirectory("materialized-mailbox-close-failure");
+    MaterializedMailboxStore store = new MaterializedMailboxStore(root, "producer", 1234,
+        path -> new FilterOutputStream(Files.newOutputStream(path)) {
+          @Override
+          public void close()
+              throws IOException {
+            super.close();
+            throw new IOException("injected close failure");
+          }
+        });
+    MaterializedMailboxKey key = new MaterializedMailboxKey(REQUEST_ID, STAGE_ID, WORKER_ID, 0);
+    AtomicReference<Worker.MaterializedPartitionHandle> committed = new AtomicReference<>();
+    MaterializedMailboxWriter writer = store.createWriter(key, committed::set);
+    CompletableFuture<Void> pendingRead = CompletableFuture.runAsync(() -> {
+      try (MaterializedMailboxStore.RecordIterator records = store.read(key, deadlineMs())) {
+        records.forEachRemaining(payload -> {
+        });
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+    awaitWaitingReader(store, key);
+
+    assertThrows(IOException.class, writer::commit);
+
+    assertThrows(Exception.class, () -> pendingRead.get(DEADLINE_DELAY_MS, TimeUnit.MILLISECONDS));
+    assertNull(committed.get());
+    assertFalse(Files.exists(store.getTemporaryPath(key)));
+    store.close();
+  }
+
+  @Test
+  public void testCommitCallbackFailureAbortsAndNotifiesReader()
+      throws Exception {
+    Path root = Files.createTempDirectory("materialized-mailbox-commit-failure");
+    MaterializedMailboxStore store = new MaterializedMailboxStore(root, "producer", 1234);
+    MaterializedMailboxKey key = new MaterializedMailboxKey(REQUEST_ID, STAGE_ID, WORKER_ID, 0);
+    MaterializedMailboxWriter writer = store.createWriter(key, descriptor -> {
+      throw new IllegalStateException("injected commit failure");
+    });
+    CompletableFuture<Void> pendingRead = CompletableFuture.runAsync(() -> {
+      try (MaterializedMailboxStore.RecordIterator records = store.read(key, deadlineMs())) {
+        records.forEachRemaining(payload -> {
+        });
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+    awaitWaitingReader(store, key);
+
+    assertThrows(IOException.class, writer::commit);
+
+    assertThrows(Exception.class, () -> pendingRead.get(DEADLINE_DELAY_MS, TimeUnit.MILLISECONDS));
+    assertFalse(Files.exists(store.getCommittedPath(key)));
+    store.close();
+  }
+
+  @Test
+  public void testExplicitReaderCloseDoesNotConsumePartition()
+      throws Exception {
+    Path root = Files.createTempDirectory("materialized-mailbox-reader-close");
+    MaterializedMailboxStore store = new MaterializedMailboxStore(root, "producer", 1234);
+    MaterializedMailboxKey key = new MaterializedMailboxKey(REQUEST_ID, STAGE_ID, WORKER_ID, 0);
+    try (MaterializedMailboxWriter writer = store.createWriter(key, descriptor -> {
+    })) {
+      writer.write(createBlocks(1, 1).get(0));
+      writer.commit();
+    }
+
+    MaterializedMailboxStore.RecordIterator abandoned = store.read(key, deadlineMs());
+    abandoned.close();
+    assertTrue(Files.exists(store.getCommittedPath(key)));
+
+    try (MaterializedMailboxStore.RecordIterator records = store.read(key, deadlineMs())) {
+      assertTrue(records.hasNext());
+      records.next();
+      assertFalse(records.hasNext());
+    }
+    assertFalse(Files.exists(store.getCommittedPath(key)));
+    store.close();
+  }
+
+  @Test
+  public void testCleanedRequestTrackingExpires()
+      throws Exception {
+    AtomicLong currentTimeMs = new AtomicLong();
+    MaterializedMailboxStore store = new MaterializedMailboxStore(
+        Files.createTempDirectory("materialized-mailbox-expiry"), "producer", 1234, currentTimeMs::get);
+    try {
+      store.cleanupRequest(REQUEST_ID);
+      assertEquals(store.getCleanedRequestCount(), 1);
+
+      currentTimeMs.addAndGet(MaterializedMailboxStore.CLEANED_REQUEST_RETENTION_MS + 1);
+      assertEquals(store.getCleanedRequestCount(), 0);
+    } finally {
+      store.close();
+    }
+  }
+
+  private static List<DataBlock> createBlocks(int numBlocks, int rowsPerBlock)
+      throws Exception {
+    List<DataBlock> blocks = new ArrayList<>(numBlocks);
+    int value = 0;
+    for (int blockId = 0; blockId < numBlocks; blockId++) {
+      List<Object[]> rows = new ArrayList<>(rowsPerBlock);
+      for (int rowId = 0; rowId < rowsPerBlock; rowId++) {
+        rows.add(new Object[]{value++});
+      }
+      blocks.add(DataBlockBuilder.buildFromRows(rows, DATA_SCHEMA));
+    }
+    return blocks;
+  }
+
+  private static void assertDataBlocks(List<DataBlock> expected, List<DataBlock> actual) {
+    assertEquals(actual.size(), expected.size());
+    for (int i = 0; i < expected.size(); i++) {
+      DataBlockEquals.checkSameContent(actual.get(i), expected.get(i), "Unexpected block at index " + i);
+    }
+  }
+
+  private static long deadlineMs() {
+    return System.currentTimeMillis() + DEADLINE_DELAY_MS;
+  }
+
+  private static void awaitWaitingReader(MaterializedMailboxStore store, MaterializedMailboxKey key)
+      throws Exception {
+    long deadlineNs = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(DEADLINE_DELAY_MS);
+    while (store.getWaitingReaderCount(key) == 0) {
+      if (System.nanoTime() >= deadlineNs) {
+        throw new AssertionError("Reader did not start waiting for " + key);
+      }
+      Thread.onSpinWait();
+    }
+  }
+
+  private static final class IteratorUtils {
+    private IteratorUtils() {
+    }
+
+    private static <T> void forEachRemaining(java.util.Iterator<T> iterator, ConsumerWithException<T> consumer)
+        throws Exception {
+      while (iterator.hasNext()) {
+        consumer.accept(iterator.next());
+      }
+    }
+  }
+
+  @FunctionalInterface
+  private interface ConsumerWithException<T> {
+    void accept(T value)
+        throws Exception;
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MaterializedMailboxOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MaterializedMailboxOperatorTest.java
@@ -1,0 +1,204 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.pinot.calcite.rel.logical.PinotRelExchangeType;
+import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.mailbox.SendingMailbox;
+import org.apache.pinot.query.planner.partitioning.HashFunctionSelector;
+import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
+import org.apache.pinot.query.planner.plannode.MailboxSendNode;
+import org.apache.pinot.query.routing.MailboxInfo;
+import org.apache.pinot.query.routing.MailboxInfos;
+import org.apache.pinot.query.routing.SharedMailboxInfos;
+import org.apache.pinot.query.routing.StageMetadata;
+import org.apache.pinot.query.routing.WorkerMetadata;
+import org.apache.pinot.query.runtime.blocks.MseBlock;
+import org.apache.pinot.query.runtime.blocks.SuccessMseBlock;
+import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryExecutionContext.QueryType;
+import org.mockito.Mock;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+
+/// Tests materialized mailbox send and receive operator behavior.
+public class MaterializedMailboxOperatorTest {
+  private static final long REQUEST_ID = 0L;
+  private static final int PRODUCER_STAGE_ID = 1;
+  private static final int CONSUMER_STAGE_ID = 2;
+  private static final DataSchema DATA_SCHEMA =
+      new DataSchema(new String[]{"key"}, new ColumnDataType[]{ColumnDataType.INT});
+
+  private AutoCloseable _mocks;
+  @Mock
+  private MailboxService _mailboxService;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = openMocks(this);
+    when(_mailboxService.getHostname()).thenReturn("consumer");
+    when(_mailboxService.getPort()).thenReturn(1234);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void testMaterializedSendCreatesOneLocalPartitionPerConsumerWorker() {
+    SendingMailbox partition0 = mock(SendingMailbox.class);
+    SendingMailbox partition1 = mock(SendingMailbox.class);
+    when(partition0.isLocal()).thenReturn(true);
+    when(partition1.isLocal()).thenReturn(true);
+    when(_mailboxService.getMaterializedSendingMailbox(eq(REQUEST_ID), eq(PRODUCER_STAGE_ID), eq(0), eq(0),
+        any(), any())).thenReturn(partition0);
+    when(_mailboxService.getMaterializedSendingMailbox(eq(REQUEST_ID), eq(PRODUCER_STAGE_ID), eq(0), eq(1),
+        any(), any())).thenReturn(partition1);
+
+    WorkerMetadata worker = new WorkerMetadata(0,
+        Map.of(CONSUMER_STAGE_ID,
+            new SharedMailboxInfos(new MailboxInfo("consumer", 1234, List.of(0, 1)))),
+        Map.of());
+    StageMetadata stage = new StageMetadata(PRODUCER_STAGE_ID, List.of(worker), Map.of());
+    OpChainExecutionContext context = context(stage, worker);
+    MultiStageOperator input = mock(MultiStageOperator.class);
+    when(input.nextBlock()).thenReturn(SuccessMseBlock.INSTANCE);
+    when(input.calculateStats()).thenReturn(MultiStageQueryStats.emptyStats(PRODUCER_STAGE_ID));
+    MailboxSendNode node = new MailboxSendNode(PRODUCER_STAGE_ID, DATA_SCHEMA, List.of(), CONSUMER_STAGE_ID,
+        PinotRelExchangeType.STREAMING, RelDistribution.Type.HASH_DISTRIBUTED, List.of(0), false, List.of(), false,
+        HashFunctionSelector.MURMUR2);
+    node.setMaterialized(true);
+
+    MseBlock result = new MailboxSendOperator(context, input, node).nextBlock();
+
+    assertTrue(result.isSuccess());
+    verify(partition0).send(any(MseBlock.Eos.class), eq(List.of()));
+    verify(partition1).send(any(MseBlock.Eos.class), eq(List.of()));
+  }
+
+  @Test
+  public void testMaterializedReceiveReadsItsLogicalPartitionFromEveryProducer() {
+    MseBlock.Data block0 = OperatorTestUtil.block(DATA_SCHEMA, new Object[]{10});
+    MseBlock.Data block1 = OperatorTestUtil.block(DATA_SCHEMA, new Object[]{11});
+    MseBlock.Data block2 = OperatorTestUtil.block(DATA_SCHEMA, new Object[]{12});
+    when(_mailboxService.readMaterializedPartition("producer-a", 1111, REQUEST_ID, PRODUCER_STAGE_ID, 0, 1,
+        Long.MAX_VALUE)).thenReturn(List.of(block0).iterator());
+    when(_mailboxService.readMaterializedPartition("producer-a", 1111, REQUEST_ID, PRODUCER_STAGE_ID, 2, 1,
+        Long.MAX_VALUE)).thenReturn(List.of(block1).iterator());
+    when(_mailboxService.readMaterializedPartition("producer-b", 2222, REQUEST_ID, PRODUCER_STAGE_ID, 1, 1,
+        Long.MAX_VALUE)).thenReturn(List.of(block2).iterator());
+
+    MaterializedMailboxReceiveOperator operator = receiveOperator(1, Long.MAX_VALUE);
+
+    assertSame(operator.nextBlock(), block0);
+    assertSame(operator.nextBlock(), block1);
+    assertSame(operator.nextBlock(), block2);
+    assertTrue(operator.nextBlock().isSuccess());
+    StatMap<BaseMailboxReceiveOperator.StatKey> stats = operator.copyStatMaps();
+    assertEquals(stats.getInt(BaseMailboxReceiveOperator.StatKey.FAN_IN), 3);
+    assertEquals(stats.getLong(BaseMailboxReceiveOperator.StatKey.EMITTED_ROWS), 3L);
+  }
+
+  @Test
+  public void testEarlyTerminationDrainsUnreadPartitions() {
+    @SuppressWarnings("unchecked")
+    Iterator<MseBlock.Data> first = mock(Iterator.class);
+    @SuppressWarnings("unchecked")
+    Iterator<MseBlock.Data> second = mock(Iterator.class);
+    MseBlock.Data firstBlock = OperatorTestUtil.block(DATA_SCHEMA, new Object[]{10});
+    MseBlock.Data droppedBlock = OperatorTestUtil.block(DATA_SCHEMA, new Object[]{11});
+    when(first.hasNext()).thenReturn(true, true, false);
+    when(first.next()).thenReturn(firstBlock, droppedBlock);
+    when(second.hasNext()).thenReturn(false);
+    when(_mailboxService.readMaterializedPartition("producer-a", 1111, REQUEST_ID, PRODUCER_STAGE_ID, 0, 0,
+        Long.MAX_VALUE)).thenReturn(first);
+    when(_mailboxService.readMaterializedPartition("producer-a", 1111, REQUEST_ID, PRODUCER_STAGE_ID, 2, 0,
+        Long.MAX_VALUE)).thenReturn(second);
+    when(_mailboxService.readMaterializedPartition("producer-b", 2222, REQUEST_ID, PRODUCER_STAGE_ID, 1, 0,
+        Long.MAX_VALUE)).thenReturn(List.<MseBlock.Data>of().iterator());
+
+    MaterializedMailboxReceiveOperator operator = receiveOperator(0, Long.MAX_VALUE);
+    assertSame(operator.nextBlock(), firstBlock);
+    operator.earlyTerminate();
+
+    assertTrue(operator.nextBlock().isSuccess());
+    verify(first, times(2)).next();
+    verify(_mailboxService).readMaterializedPartition("producer-b", 2222, REQUEST_ID, PRODUCER_STAGE_ID, 1, 0,
+        Long.MAX_VALUE);
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class,
+      expectedExceptionsMessageRegExp = ".*only supports HASH_DISTRIBUTED.*")
+  public void testMaterializedReceiveRejectsNonHashDistribution() {
+    WorkerMetadata worker = new WorkerMetadata(0, Map.of(), Map.of());
+    StageMetadata stage = new StageMetadata(CONSUMER_STAGE_ID, List.of(worker), Map.of());
+    MailboxReceiveNode node = receiveNode(RelDistribution.Type.SINGLETON);
+    new MaterializedMailboxReceiveOperator(context(stage, worker), node);
+  }
+
+  private MaterializedMailboxReceiveOperator receiveOperator(int workerId, long deadlineMs) {
+    MailboxInfos producers = new SharedMailboxInfos(List.of(
+        new MailboxInfo("producer-a", 1111, List.of(0, 2)),
+        new MailboxInfo("producer-b", 2222, List.of(1))));
+    WorkerMetadata worker = new WorkerMetadata(workerId, Map.of(PRODUCER_STAGE_ID, producers), Map.of());
+    StageMetadata stage = new StageMetadata(CONSUMER_STAGE_ID, List.of(worker), Map.of());
+    return new MaterializedMailboxReceiveOperator(context(stage, worker, deadlineMs),
+        receiveNode(RelDistribution.Type.HASH_DISTRIBUTED));
+  }
+
+  private static MailboxReceiveNode receiveNode(RelDistribution.Type distributionType) {
+    return new MailboxReceiveNode(CONSUMER_STAGE_ID, DATA_SCHEMA, PRODUCER_STAGE_ID,
+        PinotRelExchangeType.STREAMING, distributionType, List.of(0), List.of(), false, false, null, true);
+  }
+
+  private OpChainExecutionContext context(StageMetadata stage, WorkerMetadata worker) {
+    return context(stage, worker, Long.MAX_VALUE);
+  }
+
+  private OpChainExecutionContext context(StageMetadata stage, WorkerMetadata worker, long deadlineMs) {
+    QueryExecutionContext queryContext = new QueryExecutionContext(QueryType.MSE, REQUEST_ID, "cid", "default",
+        System.currentTimeMillis(), deadlineMs, deadlineMs, "broker", "instance", "");
+    return OpChainExecutionContext.fromQueryContext(_mailboxService, Map.of(), stage, worker, null, false, false,
+        queryContext);
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
@@ -52,10 +52,16 @@ import org.apache.pinot.spi.trace.RequestContext;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.util.TestUtils;
 import org.mockito.Mockito;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 
 public class QueryDispatcherTest extends QueryTestSet {
@@ -66,6 +72,23 @@ public class QueryDispatcherTest extends QueryTestSet {
 
   private QueryEnvironment _queryEnvironment;
   private QueryDispatcher _queryDispatcher;
+
+  @Test
+  public void testValidateMaterializedOutputs() {
+    Worker.MaterializedPartitionHandle partition0 = materializedHandle(7L, 1, 2, 0);
+    Worker.MaterializedPartitionHandle partition1 = materializedHandle(7L, 1, 2, 1);
+
+    QueryDispatcher.validateMaterializedOutputs(7L, Set.of("1/2/0", "1/2/1"),
+        List.of(partition1, partition0));
+
+    assertThrows(IllegalStateException.class,
+        () -> QueryDispatcher.validateMaterializedOutputs(7L, Set.of("1/2/0"), List.of(partition0, partition0)));
+    assertThrows(IllegalStateException.class,
+        () -> QueryDispatcher.validateMaterializedOutputs(7L, Set.of("1/2/0", "1/2/1"), List.of(partition0)));
+    assertThrows(IllegalStateException.class,
+        () -> QueryDispatcher.validateMaterializedOutputs(7L, Set.of("1/2/0"),
+            List.of(partition0.toBuilder().setRequestId(8L).build())));
+  }
 
   @BeforeClass
   public void setUp()
@@ -96,6 +119,16 @@ public class QueryDispatcherTest extends QueryTestSet {
     }
   }
 
+  private static Worker.MaterializedPartitionHandle materializedHandle(long requestId, int stageId, int workerId,
+      int partitionId) {
+    return Worker.MaterializedPartitionHandle.newBuilder()
+        .setRequestId(requestId)
+        .setProducerStageId(stageId)
+        .setProducerWorkerId(workerId)
+        .setLogicalPartitionId(partitionId)
+        .build();
+  }
+
   @Test(dataProvider = "testSql")
   public void testQueryDispatcherCanSendCorrectPayload(String sql)
       throws Exception {
@@ -115,9 +148,9 @@ public class QueryDispatcherTest extends QueryTestSet {
     try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
       _queryDispatcher.submit(REQUEST_ID_GEN.getAndIncrement(), dispatchableSubPlan, 10_000L, new HashSet<>(),
           Map.of());
-      Assert.fail("Method call above should have failed");
+      fail("Method call above should have failed");
     } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Error dispatching query"));
+      assertTrue(e.getMessage().contains("Error dispatching query"));
     }
     Mockito.reset(failingQueryServer);
   }
@@ -138,9 +171,9 @@ public class QueryDispatcherTest extends QueryTestSet {
     DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(sql);
     try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
       _queryDispatcher.submitAndReduce(context, dispatchableSubPlan, 10_000L, Map.of());
-      Assert.fail("Method call above should have failed");
+      fail("Method call above should have failed");
     } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Error dispatching query"));
+      assertTrue(e.getMessage().contains("Error dispatching query"));
     }
     // wait just a little, until the cancel is being called.
     Thread.sleep(50);
@@ -164,7 +197,7 @@ public class QueryDispatcherTest extends QueryTestSet {
       QueryDispatcher.QueryResult queryResult =
           _queryDispatcher.submitAndReduce(context, dispatchableSubPlan, 10_000L, Map.of());
       if (queryResult.getProcessingException() == null) {
-        Assert.fail("Method call above should have failed");
+        fail("Method call above should have failed");
       }
     } catch (NullPointerException e) {
       // Expected
@@ -190,9 +223,9 @@ public class QueryDispatcherTest extends QueryTestSet {
     try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
       _queryDispatcher.submit(REQUEST_ID_GEN.getAndIncrement(), dispatchableSubPlan, 10_000L, new HashSet<>(),
           Map.of());
-      Assert.fail("Method call above should have failed");
+      fail("Method call above should have failed");
     } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Error dispatching query"));
+      assertTrue(e.getMessage().contains("Error dispatching query"));
     }
     Mockito.reset(failingQueryServer);
   }
@@ -211,10 +244,10 @@ public class QueryDispatcherTest extends QueryTestSet {
     DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(sql);
     try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
       _queryDispatcher.submit(REQUEST_ID_GEN.getAndIncrement(), dispatchableSubPlan, 200L, new HashSet<>(), Map.of());
-      Assert.fail("Method call above should have failed");
+      fail("Method call above should have failed");
     } catch (Exception e) {
       String message = e.getMessage();
-      Assert.assertTrue(
+      assertTrue(
           message.contains("Timed out waiting for response") || message.contains("Error dispatching query"));
     }
     neverClosingLatch.countDown();
@@ -247,9 +280,9 @@ public class QueryDispatcherTest extends QueryTestSet {
     DispatchableSubPlan plan = _queryEnvironment.planQuery(sql);
     try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
       _queryDispatcher.submitAndReduce(context, plan, 10_000L, Map.of(), statsManager);
-      Assert.fail("Should have thrown");
+      fail("Should have thrown");
     } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Error dispatching query"));
+      assertTrue(e.getMessage().contains("Error dispatching query"));
     }
 
     Mockito.verifyNoInteractions(statsManager);
@@ -294,7 +327,7 @@ public class QueryDispatcherTest extends QueryTestSet {
         expectedInstanceIds.add(server.getInstanceId());
       }
     }
-    Assert.assertFalse(expectedInstanceIds.isEmpty());
+    assertFalse(expectedInstanceIds.isEmpty());
 
     try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
       _queryDispatcher.submitAndReduce(context, plan, 10_000L, Map.of(), statsManager);
@@ -312,8 +345,8 @@ public class QueryDispatcherTest extends QueryTestSet {
     try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
       for (String instanceId : expectedInstanceIds) {
         Integer numInFlight = statsManager.fetchNumInFlightRequestsForServer(instanceId);
-        Assert.assertNotNull(numInFlight, "Expected stats entry for " + instanceId);
-        Assert.assertEquals(numInFlight.intValue(), 0,
+        assertNotNull(numInFlight, "Expected stats entry for " + instanceId);
+        assertEquals(numInFlight.intValue(), 0,
             "Expected 0 in-flight requests for " + instanceId + " after submitAndReduce returns");
       }
     }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.service.dispatch;
 
+import io.grpc.Deadline;
 import io.grpc.stub.StreamObserver;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -26,7 +27,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.pinot.common.failuredetector.FailureDetector;
@@ -40,7 +43,10 @@ import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
 import org.apache.pinot.query.planner.physical.DispatchableSubPlan;
 import org.apache.pinot.query.routing.QueryServerInstance;
+import org.apache.pinot.query.routing.StagePlan;
+import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.QueryRunner;
+import org.apache.pinot.query.service.dispatch.streaming.StreamingQuerySession;
 import org.apache.pinot.query.service.server.QueryServer;
 import org.apache.pinot.query.testutils.QueryTestUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -51,6 +57,7 @@ import org.apache.pinot.spi.trace.DefaultRequestContext;
 import org.apache.pinot.spi.trace.RequestContext;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.util.TestUtils;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -69,6 +76,7 @@ public class QueryDispatcherTest extends QueryTestSet {
   private static final int QUERY_SERVER_COUNT = 2;
 
   private final Map<Integer, QueryServer> _queryServerMap = new HashMap<>();
+  private final Map<Integer, QueryRunner> _queryRunnerMap = new HashMap<>();
 
   private QueryEnvironment _queryEnvironment;
   private QueryDispatcher _queryDispatcher;
@@ -96,9 +104,12 @@ public class QueryDispatcherTest extends QueryTestSet {
     for (int i = 0; i < QUERY_SERVER_COUNT; i++) {
       int availablePort = QueryTestUtils.getAvailablePort();
       QueryRunner queryRunner = Mockito.mock(QueryRunner.class);
+      Mockito.when(queryRunner.processQuery(Mockito.any(), Mockito.any(), Mockito.any()))
+          .thenReturn(CompletableFuture.completedFuture(null));
       QueryServer queryServer = Mockito.spy(new QueryServer(availablePort, queryRunner));
       queryServer.start();
       _queryServerMap.put(availablePort, queryServer);
+      _queryRunnerMap.put(availablePort, queryRunner);
     }
     List<Integer> portList = new ArrayList<>(_queryServerMap.keySet());
 
@@ -117,6 +128,61 @@ public class QueryDispatcherTest extends QueryTestSet {
     for (QueryServer worker : _queryServerMap.values()) {
       worker.shutdown();
     }
+  }
+
+  @Test
+  public void testStagedDispatchOption() {
+    assertFalse(QueryDispatcher.isStagedDispatch(Map.of()));
+    assertFalse(QueryDispatcher.isStagedDispatch(Map.of("stagedDispatch", "false")));
+    assertTrue(QueryDispatcher.isStagedDispatch(Map.of("stagedDispatch", "TrUe")));
+  }
+
+  @Test
+  public void testSubmitWithStreamDispatchesOnlySelectedStages()
+      throws Exception {
+    DispatchableSubPlan dispatchableSubPlan =
+        _queryEnvironment.planQuery("SELECT a.col1 FROM a JOIN b ON a.col1 = b.col1");
+    List<DispatchablePlanFragment> nonRootStages =
+        new ArrayList<>(dispatchableSubPlan.getQueryStagesWithoutRoot());
+    assertTrue(nonRootStages.size() > 1);
+    DispatchablePlanFragment selectedStage = nonRootStages.get(nonRootStages.size() - 1);
+    int selectedStageId = selectedStage.getPlanFragment().getFragmentId();
+    long requestId = REQUEST_ID_GEN.getAndIncrement();
+    StreamingQuerySession session =
+        new StreamingQuerySession(requestId, selectedStage.getWorkerMetadataList().size());
+
+    for (QueryRunner queryRunner : _queryRunnerMap.values()) {
+      Mockito.clearInvocations(queryRunner);
+    }
+    try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
+      _queryDispatcher.submitWithStream(requestId, Set.of(selectedStage),
+          Deadline.after(10_000L, TimeUnit.MILLISECONDS), new HashSet<>(), Map.of(), session);
+    } finally {
+      session.fanOutCancel();
+    }
+
+    Set<Integer> actualWorkerIds = new HashSet<>();
+    int actualCalls = 0;
+    for (QueryRunner queryRunner : _queryRunnerMap.values()) {
+      ArgumentCaptor<WorkerMetadata> workerCaptor = ArgumentCaptor.forClass(WorkerMetadata.class);
+      ArgumentCaptor<StagePlan> stagePlanCaptor = ArgumentCaptor.forClass(StagePlan.class);
+      Mockito.verify(queryRunner, Mockito.atLeast(0))
+          .processQuery(workerCaptor.capture(), stagePlanCaptor.capture(), Mockito.any());
+      for (StagePlan stagePlan : stagePlanCaptor.getAllValues()) {
+        assertEquals(stagePlan.getStageMetadata().getStageId(), selectedStageId);
+      }
+      for (WorkerMetadata workerMetadata : workerCaptor.getAllValues()) {
+        actualWorkerIds.add(workerMetadata.getWorkerId());
+        actualCalls++;
+      }
+    }
+
+    Set<Integer> expectedWorkerIds = new HashSet<>();
+    for (WorkerMetadata workerMetadata : selectedStage.getWorkerMetadataList()) {
+      expectedWorkerIds.add(workerMetadata.getWorkerId());
+    }
+    assertEquals(actualCalls, selectedStage.getWorkerMetadataList().size());
+    assertEquals(actualWorkerIds, expectedWorkerIds);
   }
 
   private static Worker.MaterializedPartitionHandle materializedHandle(long requestId, int stageId, int workerId,

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/StageDispatchGraphTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/StageDispatchGraphTest.java
@@ -1,0 +1,182 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.service.dispatch;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.runtime.PairList;
+import org.apache.pinot.calcite.rel.logical.PinotRelExchangeType;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
+import org.apache.pinot.query.planner.PlanFragment;
+import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
+import org.apache.pinot.query.planner.physical.DispatchableSubPlan;
+import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.apache.pinot.query.planner.plannode.SetOpNode;
+import org.apache.pinot.query.planner.plannode.ValueNode;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+/// Tests deterministic grouping and lifecycle transitions for staged dispatch.
+public class StageDispatchGraphTest {
+  private static final DataSchema DATA_SCHEMA =
+      new DataSchema(new String[]{"col"}, new ColumnDataType[]{ColumnDataType.INT});
+
+  @Test
+  public void testStagedDispatchOptionDefaultsOff() {
+    assertFalse(QueryOptionsUtils.isStagedDispatch(Map.of()));
+    assertTrue(QueryOptionsUtils.isStagedDispatch(Map.of(QueryOptionKey.STAGED_DISPATCH, "true")));
+  }
+
+  @Test
+  public void testLinearMaterializedChain() {
+    StageDispatchGraph graph = StageDispatchGraph.create(plan(List.of(0, 1, 2),
+        materialized(2, 1), materialized(1, 0)));
+
+    assertEquals(graph.getReadyGroups(), List.of(Set.of(2)));
+    dispatchAndComplete(graph, Set.of(2));
+    assertEquals(graph.getReadyGroups(), List.of(Set.of(1)));
+    dispatchAndComplete(graph, Set.of(1));
+    assertEquals(graph.getReadyGroups(), List.of(Set.of(0)));
+    assertFalse(graph.isComplete());
+    dispatchAndComplete(graph, Set.of(0));
+    assertTrue(graph.isComplete());
+  }
+
+  @Test
+  public void testMaterializedFanInWaitsForEveryProducer() {
+    StageDispatchGraph graph = StageDispatchGraph.create(plan(List.of(0, 2, 1),
+        materialized(2, 0), materialized(1, 0)));
+
+    assertEquals(graph.getReadyGroups(), List.of(Set.of(1), Set.of(2)));
+    dispatchAndComplete(graph, Set.of(2));
+    assertEquals(graph.getReadyGroups(), List.of(Set.of(1)));
+    dispatchAndComplete(graph, Set.of(1));
+    assertEquals(graph.getReadyGroups(), List.of(Set.of(0)));
+  }
+
+  @Test
+  public void testStreamingAndPipelineBreakerEdgesContractIntoOneGroup() {
+    StageDispatchGraph graph = StageDispatchGraph.create(plan(List.of(0, 1, 2, 3),
+        materialized(1, 0), streaming(2, 1), pipelineBreaker(3, 2)));
+
+    assertEquals(graph.getReadyGroups(), List.of(Set.of(1, 2, 3)));
+    dispatchAndComplete(graph, Set.of(1, 2, 3));
+    assertEquals(graph.getReadyGroups(), List.of(Set.of(0)));
+  }
+
+  @Test
+  public void testReadyGroupOrderIsDeterministic() {
+    List<Edge> edges = List.of(materialized(4, 0), materialized(2, 0), materialized(3, 0));
+
+    StageDispatchGraph first = StageDispatchGraph.create(plan(List.of(0, 4, 2, 3), edges.toArray(Edge[]::new)));
+    StageDispatchGraph second = StageDispatchGraph.create(plan(List.of(3, 2, 4, 0), edges.toArray(Edge[]::new)));
+
+    List<Set<Integer>> expected = List.of(Set.of(2), Set.of(3), Set.of(4));
+    assertEquals(first.getReadyGroups(), expected);
+    assertEquals(second.getReadyGroups(), expected);
+  }
+
+  @Test
+  public void testCycleAndStateGuards() {
+    assertThrows(IllegalArgumentException.class, () -> StageDispatchGraph.create(plan(List.of(0, 1),
+        materialized(0, 1), materialized(1, 0))));
+
+    StageDispatchGraph graph = StageDispatchGraph.create(plan(List.of(0, 1), materialized(1, 0)));
+    assertThrows(IllegalStateException.class, () -> graph.markCompleted(Set.of(1)));
+    assertThrows(IllegalStateException.class, () -> graph.markDispatched(Set.of(0)));
+    assertThrows(IllegalArgumentException.class, () -> graph.markDispatched(Set.of(42)));
+
+    graph.markDispatched(Set.of(1));
+    assertThrows(IllegalStateException.class, () -> graph.markDispatched(Set.of(1)));
+    graph.markCompleted(Set.of(1));
+    assertThrows(IllegalStateException.class, () -> graph.markCompleted(Set.of(1)));
+  }
+
+  private static void dispatchAndComplete(StageDispatchGraph graph, Set<Integer> group) {
+    graph.markDispatched(group);
+    graph.markCompleted(group);
+  }
+
+  private static DispatchableSubPlan plan(List<Integer> stageOrder, Edge... edges) {
+    Map<Integer, List<PlanNode>> receivesByStage = new LinkedHashMap<>();
+    for (int stageId : stageOrder) {
+      receivesByStage.put(stageId, new ArrayList<>());
+    }
+    for (Edge edge : edges) {
+      receivesByStage.get(edge._receiverStageId).add(new MailboxReceiveNode(edge._receiverStageId, DATA_SCHEMA,
+          edge._senderStageId, edge._exchangeType, RelDistribution.Type.HASH_DISTRIBUTED, List.of(), List.of(), false,
+          false, null, edge._materialized));
+    }
+
+    Map<Integer, DispatchablePlanFragment> fragments = new LinkedHashMap<>();
+    for (Map.Entry<Integer, List<PlanNode>> entry : receivesByStage.entrySet()) {
+      int stageId = entry.getKey();
+      List<PlanNode> receives = entry.getValue();
+      PlanNode root;
+      if (receives.isEmpty()) {
+        root = new ValueNode(stageId, DATA_SCHEMA, PlanNode.NodeHint.EMPTY, List.of(), List.of());
+      } else if (receives.size() == 1) {
+        root = receives.get(0);
+      } else {
+        root = new SetOpNode(stageId, DATA_SCHEMA, PlanNode.NodeHint.EMPTY, receives, SetOpNode.SetOpType.UNION, true);
+      }
+      fragments.put(stageId, new DispatchablePlanFragment(new PlanFragment(stageId, root, List.of())));
+    }
+    return new DispatchableSubPlan(PairList.of(0, "col"), fragments, Set.of(), Map.of(), 0);
+  }
+
+  private static Edge materialized(int senderStageId, int receiverStageId) {
+    return new Edge(senderStageId, receiverStageId, PinotRelExchangeType.STREAMING, true);
+  }
+
+  private static Edge streaming(int senderStageId, int receiverStageId) {
+    return new Edge(senderStageId, receiverStageId, PinotRelExchangeType.STREAMING, false);
+  }
+
+  private static Edge pipelineBreaker(int senderStageId, int receiverStageId) {
+    return new Edge(senderStageId, receiverStageId, PinotRelExchangeType.PIPELINE_BREAKER, false);
+  }
+
+  private static final class Edge {
+    private final int _senderStageId;
+    private final int _receiverStageId;
+    private final PinotRelExchangeType _exchangeType;
+    private final boolean _materialized;
+
+    private Edge(int senderStageId, int receiverStageId, PinotRelExchangeType exchangeType, boolean materialized) {
+      _senderStageId = senderStageId;
+      _receiverStageId = receiverStageId;
+      _exchangeType = exchangeType;
+      _materialized = materialized;
+    }
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/streaming/StreamingDispatchObserverTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/streaming/StreamingDispatchObserverTest.java
@@ -23,6 +23,7 @@ import io.grpc.stub.StreamObserver;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -41,6 +42,44 @@ import org.testng.annotations.Test;
 /// [StreamObserver#onNext] on a real [StreamingQuerySession] and verifies the right session methods are
 /// called and the session completes when expected.
 public class StreamingDispatchObserverTest {
+
+  @Test
+  public void testDoneAndOnCompletedCloseStreamBarrier()
+      throws Exception {
+    StreamingQuerySession doneSession = new StreamingQuerySession(1L, 0, Map.of());
+    StreamingDispatchObserver doneObserver =
+        new StreamingDispatchObserver(mockServer(), doneSession, 0, (resp, err) -> { });
+    doneSession.registerStream(doneObserver);
+
+    doneObserver.onNext(Worker.ServerToBroker.newBuilder()
+        .setDone(Worker.ServerDone.getDefaultInstance())
+        .build());
+    doneSession.awaitStreamsClosed(1, TimeUnit.SECONDS);
+
+    StreamingQuerySession completedSession = new StreamingQuerySession(2L, 0, Map.of());
+    StreamingDispatchObserver completedObserver =
+        new StreamingDispatchObserver(mockServer(), completedSession, 0, (resp, err) -> { });
+    completedSession.registerStream(completedObserver);
+
+    completedObserver.onCompleted();
+    completedSession.awaitStreamsClosed(1, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void testUnexpectedWorkerFailsExactStageBarrier()
+      throws Exception {
+    StreamingQuerySession session =
+        new StreamingQuerySession(1L, 1, Map.of(1, java.util.Set.of(0)));
+    StreamingDispatchObserver observer =
+        new StreamingDispatchObserver(mockServer(), session, 1, (resp, err) -> { });
+
+    observer.onNext(Worker.ServerToBroker.newBuilder()
+        .setOpchain(buildOpChainComplete(1, 1, 5))
+        .build());
+
+    Assert.assertThrows(IllegalStateException.class,
+        () -> session.awaitSuccessfulStages(java.util.Set.of(1), 1, TimeUnit.SECONDS));
+  }
 
   /// Happy path: submit_ack, then 2 OpChainCompletes, then ServerDone. ackCallback fires once with the response, the
   /// session's latch drains to zero, and the stream is unregistered.

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/streaming/StreamingQuerySessionTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/streaming/StreamingQuerySessionTest.java
@@ -31,14 +31,45 @@ import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.proto.Worker;
 import org.apache.pinot.query.runtime.operator.AggregateOperator;
 import org.apache.pinot.query.runtime.operator.MultiStageOperator;
-import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 
 /// Unit tests for [StreamingQuerySession]. Covers the broker-side accumulator, early completion (returns true
 /// as soon as all expected opchains have reported, without waiting for the timeout), timeout fall-through, and
 /// fan-out cancel behaviour.
 public class StreamingQuerySessionTest {
+
+  @Test
+  public void testCollectsMaterializedOutputsFromSuccessfulOpChains() {
+    Worker.MaterializedPartitionHandle handle = Worker.MaterializedPartitionHandle.newBuilder()
+        .setRequestId(1L)
+        .setProducerStageId(2)
+        .setProducerWorkerId(3)
+        .setLogicalPartitionId(4)
+        .build();
+    StreamingQuerySession session = new StreamingQuerySession(1L, 2);
+
+    session.recordOpChainComplete(Worker.OpChainComplete.newBuilder()
+        .setStageId(2)
+        .setWorkerId(3)
+        .setSuccess(true)
+        .addMaterializedOutput(handle)
+        .build());
+    session.recordOpChainComplete(Worker.OpChainComplete.newBuilder()
+        .setStageId(2)
+        .setWorkerId(4)
+        .setSuccess(false)
+        .addMaterializedOutput(handle.toBuilder().setProducerWorkerId(4))
+        .build());
+
+    assertEquals(session.getMaterializedOutputs(), List.of(handle));
+  }
 
   /// Early completion: when all expected opchains report before the wait window, awaitCompletion returns true
   /// immediately rather than burning the full timeout.
@@ -54,9 +85,9 @@ public class StreamingQuerySessionTest {
     boolean done = session.awaitCompletion(10, TimeUnit.SECONDS);
     long elapsedMs = (System.nanoTime() - start) / 1_000_000;
 
-    Assert.assertTrue(done, "expected early completion");
-    Assert.assertTrue(elapsedMs < 1000, "expected immediate return, took " + elapsedMs + "ms");
-    Assert.assertEquals(session.getOutstandingCount(), 0L);
+    assertTrue(done, "expected early completion");
+    assertTrue(elapsedMs < 1000, "expected immediate return, took " + elapsedMs + "ms");
+    assertEquals(session.getOutstandingCount(), 0L);
   }
 
   /// Timeout fall-through: awaitCompletion returns false when the timeout fires before all opchains have reported,
@@ -68,12 +99,12 @@ public class StreamingQuerySessionTest {
     session.recordOpChainComplete(buildOpChainComplete(0, 0, 1, 5));
     // Only 1 of 3 reports.
     boolean done = session.awaitCompletion(50, TimeUnit.MILLISECONDS);
-    Assert.assertFalse(done, "expected timeout, not early completion");
-    Assert.assertEquals(session.getOutstandingCount(), 2L);
+    assertFalse(done, "expected timeout, not early completion");
+    assertEquals(session.getOutstandingCount(), 2L);
 
     StreamingQuerySession.Coverage coverage = session.snapshotCoverage();
-    Assert.assertEquals((int) coverage.getRespondedByStage().getOrDefault(0, 0), 1);
-    Assert.assertEquals((int) coverage.getMergeFailedByStage().getOrDefault(0, 0), 0);
+    assertEquals((int) coverage.getRespondedByStage().getOrDefault(0, 0), 1);
+    assertEquals((int) coverage.getMergeFailedByStage().getOrDefault(0, 0), 0);
   }
 
   /// Cross-worker stats sum: two opchains for the same stage merge into one accumulator entry by tree-shape match.
@@ -84,13 +115,13 @@ public class StreamingQuerySessionTest {
     session.recordOpChainComplete(buildOpChainComplete(0, 0, 1, 5));
     session.recordOpChainComplete(buildOpChainComplete(0, 1, 1, 7));
 
-    Assert.assertTrue(session.awaitCompletion(1, TimeUnit.SECONDS));
+    assertTrue(session.awaitCompletion(1, TimeUnit.SECONDS));
     StreamingQuerySession.Coverage coverage = session.snapshotCoverage();
-    Assert.assertEquals((int) coverage.getRespondedByStage().get(0), 2);
+    assertEquals((int) coverage.getRespondedByStage().get(0), 2);
     @SuppressWarnings("unchecked")
     StatMap<AggregateOperator.StatKey> merged =
         (StatMap<AggregateOperator.StatKey>) coverage.getStageAccumulator().get(0).getStatMap();
-    Assert.assertEquals(merged.getLong(AggregateOperator.StatKey.EMITTED_ROWS), 12);
+    assertEquals(merged.getLong(AggregateOperator.StatKey.EMITTED_ROWS), 12);
   }
 
   /// Regression for the snapshot data race: [StreamingQuerySession#snapshotCoverage()] must hand back a snapshot
@@ -110,23 +141,23 @@ public class StreamingQuerySessionTest {
     StreamingQuerySession.Coverage snapshot = session.snapshotCoverage();
     StatMap<AggregateOperator.StatKey> snapshotStat =
         (StatMap<AggregateOperator.StatKey>) snapshot.getStageAccumulator().get(0).getStatMap();
-    Assert.assertEquals(snapshotStat.getLong(AggregateOperator.StatKey.EMITTED_ROWS), 5);
+    assertEquals(snapshotStat.getLong(AggregateOperator.StatKey.EMITTED_ROWS), 5);
 
     // A late worker reports another 7 rows for the same stage AFTER the snapshot was taken. With the old shallow copy
     // + no finalize guard this merged into the snapshot's StatMap (5 -> 12).
     session.recordOpChainComplete(buildOpChainComplete(0, 1, 1, 7));
 
     // The already-handed-out snapshot must be untouched...
-    Assert.assertEquals(snapshotStat.getLong(AggregateOperator.StatKey.EMITTED_ROWS), 5,
+    assertEquals(snapshotStat.getLong(AggregateOperator.StatKey.EMITTED_ROWS), 5,
         "snapshot StatMap must not be mutated by a post-snapshot report");
     // ...and the late report must have been dropped entirely (session finalized), so a fresh snapshot also shows 5
     // and the responded counter did not advance.
     StreamingQuerySession.Coverage after = session.snapshotCoverage();
     StatMap<AggregateOperator.StatKey> afterStat =
         (StatMap<AggregateOperator.StatKey>) after.getStageAccumulator().get(0).getStatMap();
-    Assert.assertEquals(afterStat.getLong(AggregateOperator.StatKey.EMITTED_ROWS), 5,
+    assertEquals(afterStat.getLong(AggregateOperator.StatKey.EMITTED_ROWS), 5,
         "late report after finalize must be ignored");
-    Assert.assertEquals((int) after.getRespondedByStage().getOrDefault(0, 0), 1,
+    assertEquals((int) after.getRespondedByStage().getOrDefault(0, 0), 1,
         "responded count must not advance after finalize");
   }
 
@@ -147,11 +178,11 @@ public class StreamingQuerySessionTest {
     // Server B reports an error; should fan-out cancel to A and C (and B itself, since fan-out walks all open
     // streams — they're best-effort anyway).
     session.recordOpChainComplete(buildErrorOpChainComplete(0, 1, "boom"));
-    Assert.assertEquals(cancelCalls.get(), 3);
+    assertEquals(cancelCalls.get(), 3);
 
     // A second error does not re-fire fan-out (idempotent).
     session.recordOpChainComplete(buildErrorOpChainComplete(0, 2, "boom2"));
-    Assert.assertEquals(cancelCalls.get(), 3);
+    assertEquals(cancelCalls.get(), 3);
   }
 
   /// Stream onError (transport failure) drains the latch and triggers fan-out cancel; the dispatcher's
@@ -171,8 +202,8 @@ public class StreamingQuerySessionTest {
     // 'other' delivered its 1 opchain.
     session.recordOpChainComplete(buildOpChainComplete(0, 0, 1, 1));
 
-    Assert.assertTrue(session.awaitCompletion(1, TimeUnit.SECONDS), "expected completion after dead drained");
-    Assert.assertEquals(cancelCalls.get(), 1, "fan-out cancel should hit only 'other' (dead removed first)");
+    assertTrue(session.awaitCompletion(1, TimeUnit.SECONDS), "expected completion after dead drained");
+    assertEquals(cancelCalls.get(), 1, "fan-out cancel should hit only 'other' (dead removed first)");
   }
 
   /// Concurrent opchain reports across many threads: latch drains correctly with no lost updates.
@@ -200,16 +231,16 @@ public class StreamingQuerySessionTest {
       threads.add(t);
     }
     start.countDown();
-    Assert.assertTrue(session.awaitCompletion(5, TimeUnit.SECONDS));
+    assertTrue(session.awaitCompletion(5, TimeUnit.SECONDS));
     for (Thread t : threads) {
       t.join();
     }
     StreamingQuerySession.Coverage coverage = session.snapshotCoverage();
-    Assert.assertEquals((int) coverage.getRespondedByStage().get(0), n);
+    assertEquals((int) coverage.getRespondedByStage().get(0), n);
     @SuppressWarnings("unchecked")
     StatMap<AggregateOperator.StatKey> merged =
         (StatMap<AggregateOperator.StatKey>) coverage.getStageAccumulator().get(0).getStatMap();
-    Assert.assertEquals(merged.getLong(AggregateOperator.StatKey.EMITTED_ROWS), n);
+    assertEquals(merged.getLong(AggregateOperator.StatKey.EMITTED_ROWS), n);
   }
 
   /// An opchain whose stats tree contains an operator type id absent from
@@ -225,14 +256,14 @@ public class StreamingQuerySessionTest {
     // Type id 9999 is not in the registry — decode throws DecodeFailedException.
     session.recordOpChainComplete(buildOpChainCompleteWithTypeId(0, 1, 9999, ByteString.EMPTY));
 
-    Assert.assertTrue(session.awaitCompletion(1, TimeUnit.SECONDS),
+    assertTrue(session.awaitCompletion(1, TimeUnit.SECONDS),
         "query should complete despite unknown operator type id");
     StreamingQuerySession.Coverage coverage = session.snapshotCoverage();
-    Assert.assertEquals((int) coverage.getRespondedByStage().getOrDefault(0, 0), 1,
+    assertEquals((int) coverage.getRespondedByStage().getOrDefault(0, 0), 1,
         "only the successfully decoded opchain should be counted as responded");
-    Assert.assertEquals((int) coverage.getMergeFailedByStage().getOrDefault(0, 0), 1,
+    assertEquals((int) coverage.getMergeFailedByStage().getOrDefault(0, 0), 1,
         "the unknown-type opchain should be counted as merge-failed");
-    Assert.assertNotNull(coverage.getStageAccumulator().get(0),
+    assertNotNull(coverage.getStageAccumulator().get(0),
         "first worker's valid stats should remain in the accumulator");
   }
 
@@ -259,16 +290,16 @@ public class StreamingQuerySessionTest {
     session.recordOpChainComplete(
         buildOpChainCompleteWithTypeId(0, 1, MultiStageOperator.Type.HASH_JOIN.getId(), emptyStatBytes()));
 
-    Assert.assertTrue(session.awaitCompletion(1, TimeUnit.SECONDS),
+    assertTrue(session.awaitCompletion(1, TimeUnit.SECONDS),
         "query should complete despite shape mismatch");
     StreamingQuerySession.Coverage coverage = session.snapshotCoverage();
     // The mismatch drops the stage tree, so worker 0's cleanly-merged data is gone too: both workers count as
     // merge-failed and none as responded. responded + mergeFailed = 2 = expected (reconciles).
-    Assert.assertEquals((int) coverage.getRespondedByStage().getOrDefault(0, 0), 0,
+    assertEquals((int) coverage.getRespondedByStage().getOrDefault(0, 0), 0,
         "no worker counts as responded once the stage tree is dropped");
-    Assert.assertEquals((int) coverage.getMergeFailedByStage().getOrDefault(0, 0), 2,
+    assertEquals((int) coverage.getMergeFailedByStage().getOrDefault(0, 0), 2,
         "both the pre-mismatch and the mismatching worker should be counted as merge-failed");
-    Assert.assertNull(coverage.getStageAccumulator().get(0),
+    assertNull(coverage.getStageAccumulator().get(0),
         "the partially-merged stage entry should be discarded from the accumulator after the failed merge");
   }
 
@@ -287,13 +318,13 @@ public class StreamingQuerySessionTest {
     // Worker 2 decodes cleanly, but the stage is poisoned.
     session.recordOpChainComplete(buildOpChainComplete(0, 2, 1, 15));
 
-    Assert.assertTrue(session.awaitCompletion(1, TimeUnit.SECONDS));
+    assertTrue(session.awaitCompletion(1, TimeUnit.SECONDS));
     StreamingQuerySession.Coverage coverage = session.snapshotCoverage();
-    Assert.assertEquals((int) coverage.getRespondedByStage().getOrDefault(0, 0), 0,
+    assertEquals((int) coverage.getRespondedByStage().getOrDefault(0, 0), 0,
         "no worker counts as responded for a poisoned stage");
-    Assert.assertEquals((int) coverage.getMergeFailedByStage().getOrDefault(0, 0), 3,
+    assertEquals((int) coverage.getMergeFailedByStage().getOrDefault(0, 0), 3,
         "all reports for a poisoned stage count as merge-failed");
-    Assert.assertNull(coverage.getStageAccumulator().get(0),
+    assertNull(coverage.getStageAccumulator().get(0),
         "a poisoned stage must not be re-seeded by a later clean report");
   }
 
@@ -312,14 +343,14 @@ public class StreamingQuerySessionTest {
     session.recordOpChainComplete(
         buildOpChainCompleteWithTypeId(0, 1, MultiStageOperator.Type.AGGREGATE.getId(), ByteString.EMPTY));
 
-    Assert.assertTrue(session.awaitCompletion(1, TimeUnit.SECONDS),
+    assertTrue(session.awaitCompletion(1, TimeUnit.SECONDS),
         "query should complete despite corrupted stat bytes");
     StreamingQuerySession.Coverage coverage = session.snapshotCoverage();
-    Assert.assertEquals((int) coverage.getRespondedByStage().getOrDefault(0, 0), 1,
+    assertEquals((int) coverage.getRespondedByStage().getOrDefault(0, 0), 1,
         "only the successfully decoded opchain should be counted as responded");
-    Assert.assertEquals((int) coverage.getMergeFailedByStage().getOrDefault(0, 0), 1,
+    assertEquals((int) coverage.getMergeFailedByStage().getOrDefault(0, 0), 1,
         "the opchain with corrupted stat bytes should be counted as merge-failed");
-    Assert.assertNotNull(coverage.getStageAccumulator().get(0),
+    assertNotNull(coverage.getStageAccumulator().get(0),
         "first worker's valid stats should remain in the accumulator");
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/streaming/StreamingQuerySessionTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/streaming/StreamingQuerySessionTest.java
@@ -24,6 +24,8 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -37,6 +39,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 
@@ -44,6 +47,78 @@ import static org.testng.Assert.assertTrue;
 /// as soon as all expected opchains have reported, without waiting for the timeout), timeout fall-through, and
 /// fan-out cancel behaviour.
 public class StreamingQuerySessionTest {
+
+  @Test
+  public void testAwaitSuccessfulStagesRequiresEveryUniqueExpectedWorker()
+      throws Exception {
+    StreamingQuerySession session =
+        new StreamingQuerySession(1L, 3, Map.of(1, Set.of(0, 1), 2, Set.of(0)));
+
+    session.recordOpChainComplete(buildOpChainComplete(1, 0, 1, 5));
+    session.recordOpChainComplete(buildOpChainComplete(1, 0, 1, 5));
+    assertThrows(IllegalStateException.class,
+        () -> session.awaitSuccessfulStages(Set.of(1), 10, TimeUnit.MILLISECONDS));
+
+    session.recordOpChainComplete(buildOpChainComplete(1, 1, 1, 7));
+    session.awaitSuccessfulStages(Set.of(1), 1, TimeUnit.SECONDS);
+
+    assertThrows(IllegalStateException.class,
+        () -> session.awaitSuccessfulStages(Set.of(1, 2), 10, TimeUnit.MILLISECONDS));
+    session.recordOpChainComplete(buildOpChainComplete(2, 0, 1, 11));
+    session.awaitSuccessfulStages(Set.of(1, 2), 1, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void testAwaitSuccessfulStagesRejectsUnexpectedIdentity() {
+    StreamingQuerySession session =
+        new StreamingQuerySession(1L, 1, Map.of(1, Set.of(0)));
+
+    session.recordOpChainComplete(buildOpChainCompleteWithoutStats(1, 1, true));
+
+    assertThrows(IllegalStateException.class,
+        () -> session.awaitSuccessfulStages(Set.of(1), 1, TimeUnit.SECONDS));
+  }
+
+  @Test
+  public void testAwaitSuccessfulStagesRejectsExecutionFailure() {
+    StreamingQuerySession session =
+        new StreamingQuerySession(1L, 1, Map.of(1, Set.of(0)));
+
+    session.recordOpChainComplete(buildOpChainCompleteWithoutStats(1, 0, false));
+
+    assertThrows(IllegalStateException.class,
+        () -> session.awaitSuccessfulStages(Set.of(1), 1, TimeUnit.SECONDS));
+  }
+
+  @Test
+  public void testStatsDecodeFailureStillSatisfiesExecutionBarrier()
+      throws Exception {
+    StreamingQuerySession session =
+        new StreamingQuerySession(1L, 1, Map.of(1, Set.of(0)));
+
+    session.recordOpChainComplete(buildOpChainCompleteWithTypeId(1, 0, 9999, ByteString.EMPTY));
+
+    session.awaitSuccessfulStages(Set.of(1), 1, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void testAwaitStreamsClosedTracksRegistrationAndTransportFailure()
+      throws Exception {
+    StreamingQuerySession session = new StreamingQuerySession(1L, 0, Map.of());
+    StreamingServerHandle stream = requestId -> { };
+    session.registerStream(stream);
+
+    assertThrows(IllegalStateException.class,
+        () -> session.awaitStreamsClosed(10, TimeUnit.MILLISECONDS));
+
+    session.unregisterStream(stream);
+    session.awaitStreamsClosed(1, TimeUnit.SECONDS);
+
+    session.registerStream(stream);
+    session.recordStreamError(stream, new RuntimeException("transport"), 0);
+    assertThrows(IllegalStateException.class,
+        () -> session.awaitStreamsClosed(1, TimeUnit.SECONDS));
+  }
 
   @Test
   public void testCollectsMaterializedOutputsFromSuccessfulOpChains() {
@@ -382,6 +457,15 @@ public class StreamingQuerySessionTest {
         .setWorkerId(workerId)
         .setSuccess(false)
         .setErrorMsg(errorMsg)
+        .build();
+  }
+
+  private static Worker.OpChainComplete buildOpChainCompleteWithoutStats(
+      int stageId, int workerId, boolean success) {
+    return Worker.OpChainComplete.newBuilder()
+        .setStageId(stageId)
+        .setWorkerId(workerId)
+        .setSuccess(success)
         .build();
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -858,6 +858,9 @@ public class CommonConstants {
         /// other transport error) during dispatch, the broker cancels the query and surfaces the error to the
         /// client.
         public static final String STREAM_STATS = "streamStats";
+        /// Opts a query into the experimental file-backed HASH exchange. The feature is disabled by default and
+        /// implicitly uses the stream dispatch path so producer completion can report materialized output handles.
+        public static final String MATERIALIZED_EXCHANGE = "materializedExchange";
         /// If set, changes the explain behavior in multi-stage engine.
         ///
         /// `true` means to ask servers for the physical plan while false means to just use logical plan.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -861,6 +861,8 @@ public class CommonConstants {
         /// Opts a query into the experimental file-backed HASH exchange. The feature is disabled by default and
         /// implicitly uses the stream dispatch path so producer completion can report materialized output handles.
         public static final String MATERIALIZED_EXCHANGE = "materializedExchange";
+        /// Opts a query into dependency-ordered stage dispatch. The feature is disabled by default.
+        public static final String STAGED_DISPATCH = "stagedDispatch";
         /// If set, changes the explain behavior in multi-stage engine.
         ///
         /// `true` means to ask servers for the physical plan while false means to just use logical plan.


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Staged dispatch with materialized exchange: plan marked exchange, build dependency graph, dispatch groups when ready, serve via file\-backed mailbox, broker validates outputs\.

```mermaid
flowchart TD
  N0["Mark exchange as materialized #40;F5#44; F6#41;"]:::stModified
  N1["Build dispatch graph #40;barriers for materialized edges#41; #40;F22#41;"]:::stAdded
  N2["Check for ready groups #40;dependencies met#41; #40;F22#41;"]:::stAdded
  N3["Dispatch group #40;run reducer if stage 0 present#41; #40;F22#41;"]:::stModified
  N4["Server#58; Create materialized sending mailbox per partition #40;F18#41;"]:::stModified
  N5["Server#58; Commit partition on EOS and return handle #40;F16#41;"]:::stAdded
  N6["Server#58; Include handle in OpChainComplete #40;F26#41;"]:::stModified
  N7["Broker#58; Collect handle and wait for workers#47;streams #40;F25#41;"]:::stModified
  N8["Broker#58; Mark group as completed #40;F22#41;"]:::stAdded
  N9["Broker#58; Validate materialized outputs #40;after all groups#41; #40;F22#41;"]:::stModified
  N0 -->|"materialized edge input"| N1
  N1 -->|"graph used for readiness"| N2
  N2 -->|"dispatch ready group"| N3
  N3 -->|"materialized send node #45;#62; create mailbox"| N4
  N4 -->|"send data #45;#62; commit on EOS"| N5
  N5 -->|"commit #45;#62; include handle in OpChainComplete"| N6
  N6 -->|"broker collects handle and waits"| N7
  N7 -->|"workers#47;streams done #45;#62; mark group completed"| N8
  N8 -->|"completed group may enable others"| N2
  N8 -->|"after all groups#58; validate outputs"| N9
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

Partial evidence: 3 file patches omitted; 0 truncated.

<details>
<summary>Diff evidence</summary>

- F5: pinot\-query\-planner/src/main/java/org/apache/pinot/query/QueryEnvironment\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java) · [after](https://github.com/apache/pinot/blob/22f5c59855128ec0ba7572dae4ace7b005a036ae/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java)
- F6: pinot\-query\-planner/src/main/java/org/apache/pinot/query/planner/physical/MaterializedExchangePlanner\.java — [after](https://github.com/apache/pinot/blob/22f5c59855128ec0ba7572dae4ace7b005a036ae/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/MaterializedExchangePlanner.java)
- F16: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/mailbox/materialized/MaterializedSendingMailbox\.java — [after](https://github.com/apache/pinot/blob/22f5c59855128ec0ba7572dae4ace7b005a036ae/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/materialized/MaterializedSendingMailbox.java)
- F18: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java) · [after](https://github.com/apache/pinot/blob/22f5c59855128ec0ba7572dae4ace7b005a036ae/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java)
- F22: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java) · [after](https://github.com/apache/pinot/blob/22f5c59855128ec0ba7572dae4ace7b005a036ae/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java)
- F25: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/service/dispatch/streaming/StreamingQuerySession\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/streaming/StreamingQuerySession.java) · [after](https://github.com/apache/pinot/blob/22f5c59855128ec0ba7572dae4ace7b005a036ae/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/streaming/StreamingQuerySession.java)
- F26: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java) · [after](https://github.com/apache/pinot/blob/22f5c59855128ec0ba7572dae4ace7b005a036ae/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImU2Nzg3ZTE3ODY0NWZkM2M1YTg4N2UyYWJhN2UwZGU4MzQzY2Q1MjQiLCJjb250ZXh0X2hhc2giOiI1ZWRjZjllMWNiYzU0OTBlNDY0ZTIwNjU5ZmM1OWQyMzAyODk4Y2I5NWM4ZjdkNDg1ODA5NWI1ZTQ0ZTRjMjViIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MjEyNTA3LCJoZWFkX3NoYSI6IjIyZjVjNTk4NTUxMjhlYzBiYTc1NzJkYWU0YWNlN2IwMDVhMDM2YWUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJlNjc4N2UxNzg2NDVmZDNjNWE4ODdlMmFiYTdlMGRlODM0M2NkNTI0IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 4f46ac7c97fe2e1d14dff2bf8561dc94a1b82155399df277b792882c43d62487 -->
<!-- pinot-pr-flow:end -->

## Summary

Adds Phase 2 of the AQE prerequisite stack: opt-in staged dispatch with unchanged worker assignments.

Depends on #19471.

## Design

```text
                    materialized dependency
producer group A  ----------------------------+
      | all unique workers complete            |
      | all streams emit ServerDone             v
      +----------------------------------> consumer group B
                                               |
                                      root group contains 0?
                                               |
                                    run reducer locally

streaming / pipeline-breaker edge:
    stage X ===== contracted dispatch group ===== stage Y
```

The broker builds a deterministic dispatch-group DAG. Materialized edges form completion barriers; streaming-connected stages are dispatched together. A group transitions only after every expected `(stageId, workerId)` reports success and every stream closes. Duplicate or unexpected reports cannot release the barrier.

## Invariants

- default OFF via `stagedDispatch=true`
- one absolute deadline across all waves
- assignments, stage IDs, and worker IDs remain immutable
- a failed worker or stream prevents downstream dispatch
- stage 0 participates in dependency ordering but executes locally
- no retries or running-stage replacement

## Test Plan

- graph/session/observer/dispatcher tests: 110 passed
- Spotless, Checkstyle, and license checks passed for `pinot-common`, `pinot-spi`, and `pinot-query-runtime`
