### PR TITLE
Share segment-derived FieldSpec instances across segments through a weak interner

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
@@ -18,10 +18,7 @@
  */
 package org.apache.pinot.segment.local.segment.index.column;
 
-import it.unimi.dsi.fastutil.shorts.ShortArrayList;
-import java.io.Closeable;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -41,14 +38,33 @@ import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.google.common.base.Preconditions.checkState;
 
+
+/// Index readers of one physical column of an immutable segment.
+///
+/// Readers are keyed by the numeric index id assigned by [IndexService#getNumericId(IndexType)] and stored as a
+/// presence bit mask plus a dense array holding only the readers that exist, ordered by id. A lookup is a shift, a
+/// mask and a popcount, so it stays O(1) on the query path while the per-column footprint is exactly one array slot
+/// per present reader. A server holding tens of thousands of wide segments creates one of these per (segment, column),
+/// which is why the layout matters: the mask replaces a nested map object and a reader array spanning the whole
+/// numeric-id range of the present readers.
+///
+/// Thread safety: immutable after construction except for the multi-column text reader reference, which is set
+/// once during segment load and cleared on [#close()].
 public final class PhysicalColumnIndexContainer implements ColumnIndexContainer {
   private static final Logger LOGGER = LoggerFactory.getLogger(PhysicalColumnIndexContainer.class);
 
   private static final Set<String> FORWARD_INDEX_ONLY_TYPES =
       Set.of(StandardIndexes.FORWARD_ID, StandardIndexes.DICTIONARY_ID, StandardIndexes.NULL_VALUE_VECTOR_ID);
+  private static final IndexReader[] EMPTY_READERS = new IndexReader[0];
 
-  private final IndexTypeMap _indexTypeMap;
+  // Bit i is set when the index type with numeric id i has a reader in this column. Numeric ids are validated to fit
+  // in the mask at construction time.
+  private final long _presentMask;
+  // Readers ordered by numeric index id, holding only the present ones: the reader for id i sits at the number of
+  // bits set in _presentMask below bit i.
+  private final IndexReader[] _readers;
   @Nullable
   private final VectorIndexConfig _vectorIndexConfig;
 
@@ -67,12 +83,18 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
     }
     _vectorIndexConfig = fieldIndexConfigs.getConfig(StandardIndexes.vector());
 
-    ArrayList<IndexType> indexTypes = new ArrayList<>();
-    ArrayList<IndexReader> readers = new ArrayList<>();
+    IndexService indexService = IndexService.getInstance();
+    List<IndexType<?, ?, ?>> allIndexes = indexService.getAllIndexes();
+    int numIndexTypes = allIndexes.size();
+    checkState(numIndexTypes <= Long.SIZE,
+        "Cannot track %s index types in a %s-bit presence mask, column: %s", numIndexTypes, Long.SIZE, columnName);
 
+    // Scratch array indexed by numeric id; compacted into the exactly-sized _readers below.
+    IndexReader[] readersById = new IndexReader[numIndexTypes];
+    long presentMask = 0L;
     boolean forwardIndexOnly = indexLoadingConfig.isForwardIndexOnly();
     try {
-      for (IndexType<?, ?, ?> indexType : IndexService.getInstance().getAllIndexes()) {
+      for (IndexType<?, ?, ?> indexType : allIndexes) {
         if (forwardIndexOnly && !FORWARD_INDEX_ONLY_TYPES.contains(indexType.getId())) {
           continue;
         }
@@ -81,8 +103,9 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
           try {
             IndexReader reader = readerProvider.createIndexReader(segmentReader, fieldIndexConfigs, metadata);
             if (reader != null) {
-              indexTypes.add(indexType);
-              readers.add(reader);
+              short indexId = indexService.getNumericId(indexType);
+              readersById[indexId] = reader;
+              presentMask |= 1L << indexId;
             }
           } catch (IndexReaderConstraintException ex) {
             LOGGER.warn("Constraint violation when indexing {} with {} index", columnName, indexType, ex);
@@ -90,23 +113,42 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
         }
       }
     } catch (Throwable t) {
-      for (IndexReader reader : readers) {
-        try {
-          reader.close();
-        } catch (Throwable ct) {
-          LOGGER.warn("Can't close reader on init error, column: " + columnName + " reader: " + reader.getClass(), ct);
+      for (IndexReader reader : readersById) {
+        if (reader != null) {
+          try {
+            reader.close();
+          } catch (Throwable ct) {
+            LOGGER.warn("Can't close reader on init error, column: " + columnName + " reader: " + reader.getClass(),
+                ct);
+          }
         }
       }
       throw t;
     }
 
-    _indexTypeMap = IndexTypeMap.get(indexTypes, readers);
+    _presentMask = presentMask;
+    int numReaders = Long.bitCount(presentMask);
+    if (numReaders == 0) {
+      _readers = EMPTY_READERS;
+    } else {
+      _readers = new IndexReader[numReaders];
+      int pos = 0;
+      for (IndexReader reader : readersById) {
+        if (reader != null) {
+          _readers[pos++] = reader;
+        }
+      }
+    }
   }
 
   @Nullable
   @Override
   public <I extends IndexReader, T extends IndexType<?, I, ?>> I getIndex(T indexType) {
-    return _indexTypeMap.getIndex(indexType);
+    short indexId = IndexService.getInstance().getNumericId(indexType);
+    if (((_presentMask >>> indexId) & 1L) == 0) {
+      return null;
+    }
+    return (I) _readers[Long.bitCount(_presentMask & ((1L << indexId) - 1))];
   }
 
   @Nullable
@@ -119,7 +161,9 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
   public void close()
       throws IOException {
     // TODO (index-spi): Verify that readers can be closed in any order
-    _indexTypeMap.close();
+    for (IndexReader reader : _readers) {
+      reader.close();
+    }
 
     // This reader is closed on segment destroy()
     _multiColTextReader = null;
@@ -132,71 +176,5 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
   public void setMultiColumnTextIndex(
       MultiColumnLuceneTextIndexReader multiColTextReader) {
     _multiColTextReader = multiColTextReader;
-  }
-
-  static class IndexTypeMap implements Closeable {
-    private static final IndexReader[] EMPTY_READERS = new IndexReader[0];
-
-    public static final IndexTypeMap EMPTY = new IndexTypeMap((short) 0, EMPTY_READERS);
-
-    private final short _shift;
-    //stores index readers ordered by index id, shifted by _shift to conserve memory
-    private final IndexReader[] _readers;
-
-    private IndexTypeMap(short shift, IndexReader[] readers) {
-      _shift = shift;
-      _readers = readers;
-    }
-
-    static IndexTypeMap get(List<IndexType> indexTypes, List<IndexReader> readers) {
-      if (indexTypes.isEmpty()) {
-        return EMPTY;
-      }
-
-      short min = Short.MAX_VALUE;
-      int max = -1;
-
-      ShortArrayList indexIds = new ShortArrayList(indexTypes.size());
-      IndexService indexService = IndexService.getInstance();
-
-      for (IndexType indexType : indexTypes) {
-        short indexId = indexService.getNumericId(indexType);
-        indexIds.add(indexId);
-        if (indexId < min) {
-          min = indexId;
-        }
-        if (indexId > max) {
-          max = indexId;
-        }
-      }
-
-      short shift = min;
-      int size = max - min + 1;
-      IndexReader[] indexReaders = new IndexReader[size];
-      for (int i = 0, n = indexIds.size(); i < n; i++) {
-        short indexId = indexIds.getShort(i);
-        indexReaders[indexId - shift] = readers.get(i);
-      }
-      return new IndexTypeMap(shift, indexReaders);
-    }
-
-    @Nullable
-    public <I extends IndexReader, T extends IndexType<?, I, ?>> I getIndex(T indexType) {
-      short indexId = IndexService.getInstance().getNumericId(indexType);
-      if (indexId >= _shift && indexId < _shift + _readers.length) {
-        return (I) _readers[indexId - _shift];
-      }
-      return null;
-    }
-
-    @Override
-    public void close()
-        throws IOException {
-      for (IndexReader index : _readers) {
-        if (index != null) {
-          index.close();
-        }
-      }
-    }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/ImmutableDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/ImmutableDataSource.java
@@ -34,87 +34,74 @@ public class ImmutableDataSource extends BaseDataSource {
     super(new ImmutableDataSourceMetadata(columnMetadata), columnIndexContainer);
   }
 
+  /// Exposes the segment's [ColumnMetadata] through the [DataSourceMetadata] view by delegating every accessor.
+  /// Holding a single reference instead of copying the ten fields the view exposes keeps this object at one
+  /// reference per column, which matters for wide segments where every loaded column retains one. The delegation
+  /// is observationally equivalent to a snapshot because every [ColumnMetadata] handed to an immutable data source
+  /// is itself immutable once built.
   private static class ImmutableDataSourceMetadata implements DataSourceMetadata {
-    final FieldSpec _fieldSpec;
-    final boolean _sorted;
-    final int _numDocs;
-    final int _numValues;
-    final int _maxNumValuesPerMVEntry;
-    final int _cardinality;
-    final Comparable _minValue;
-    final Comparable _maxValue;
-    final PartitionFunction _partitionFunction;
-    final Set<Integer> _partitions;
+    final ColumnMetadata _columnMetadata;
 
     ImmutableDataSourceMetadata(ColumnMetadata columnMetadata) {
-      _fieldSpec = columnMetadata.getFieldSpec();
-      _sorted = columnMetadata.isSorted();
-      _numDocs = columnMetadata.getTotalDocs();
-      _numValues = columnMetadata.getTotalNumberOfEntries();
-      if (_fieldSpec.isSingleValueField()) {
-        _maxNumValuesPerMVEntry = -1;
-      } else {
-        _maxNumValuesPerMVEntry = columnMetadata.getMaxNumberOfMultiValues();
-      }
-      _minValue = columnMetadata.getMinValue();
-      _maxValue = columnMetadata.getMaxValue();
-      _partitionFunction = columnMetadata.getPartitionFunction();
-      _partitions = columnMetadata.getPartitions();
-      _cardinality = columnMetadata.getCardinality();
+      _columnMetadata = columnMetadata;
     }
 
     @Override
     public FieldSpec getFieldSpec() {
-      return _fieldSpec;
+      return _columnMetadata.getFieldSpec();
     }
 
     @Override
     public boolean isSorted() {
-      return _sorted;
+      return _columnMetadata.isSorted();
     }
 
     @Override
     public int getNumDocs() {
-      return _numDocs;
+      return _columnMetadata.getTotalDocs();
     }
 
     @Override
     public int getNumValues() {
-      return _numValues;
+      return _columnMetadata.getTotalNumberOfEntries();
     }
 
     @Override
     public int getMaxNumValuesPerMVEntry() {
-      return _maxNumValuesPerMVEntry;
+      // DataSourceMetadata reports -1 for single-value columns, whereas ColumnMetadata reports 0
+      return _columnMetadata.getFieldSpec().isSingleValueField() ? -1 : _columnMetadata.getMaxNumberOfMultiValues();
     }
 
     @Nullable
     @Override
     public Comparable getMinValue() {
-      return _minValue;
+      return _columnMetadata.getMinValue();
     }
 
     @Nullable
     @Override
     public Comparable getMaxValue() {
-      return _maxValue;
+      return _columnMetadata.getMaxValue();
     }
 
     @Nullable
     @Override
     public PartitionFunction getPartitionFunction() {
-      return _partitionFunction;
+      return _columnMetadata.getPartitionFunction();
     }
 
     @Nullable
     @Override
     public Set<Integer> getPartitions() {
-      return _partitions;
+      return _columnMetadata.getPartitions();
     }
 
     @Override
     public int getCardinality() {
-      return _cardinality;
+      return _columnMetadata.getCardinality();
     }
+
+    // getMaxRowLengthInBytes() is deliberately not delegated: DataSourceMetadata defines it as -1 for immutable
+    // columns, while ColumnMetadata computes the serialized row length.
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/map/ImmutableMapDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/map/ImmutableMapDataSource.java
@@ -62,36 +62,19 @@ public class ImmutableMapDataSource extends BaseMapDataSource {
     return null;
   }
 
+  /// Exposes the MAP column's [ColumnMetadata] through the [DataSourceMetadata] view by delegating every accessor
+  /// through a single reference instead of copying the fields (see the equivalent adapter in `ImmutableDataSource`).
+  /// A MAP column is never reported as sorted and does not support the max row length.
   private static class ImmutableMapDataSourceMetadata implements DataSourceMetadata {
-    final FieldSpec _fieldSpec;
-    final int _numDocs;
-    final int _numValues;
-    final int _maxNumValuesPerMVEntry;
-    final int _cardinality;
-    final PartitionFunction _partitionFunction;
-    final Set<Integer> _partitions;
-    final Comparable _minValue;
-    final Comparable _maxValue;
+    final ColumnMetadata _columnMetadata;
 
     ImmutableMapDataSourceMetadata(ColumnMetadata columnMetadata) {
-      _fieldSpec = columnMetadata.getFieldSpec();
-      _numDocs = columnMetadata.getTotalDocs();
-      _numValues = columnMetadata.getTotalNumberOfEntries();
-      if (_fieldSpec.isSingleValueField()) {
-        _maxNumValuesPerMVEntry = -1;
-      } else {
-        _maxNumValuesPerMVEntry = columnMetadata.getMaxNumberOfMultiValues();
-      }
-      _minValue = columnMetadata.getMinValue();
-      _maxValue = columnMetadata.getMaxValue();
-      _partitionFunction = columnMetadata.getPartitionFunction();
-      _partitions = columnMetadata.getPartitions();
-      _cardinality = columnMetadata.getCardinality();
+      _columnMetadata = columnMetadata;
     }
 
     @Override
     public FieldSpec getFieldSpec() {
-      return _fieldSpec;
+      return _columnMetadata.getFieldSpec();
     }
 
     @Override
@@ -101,45 +84,47 @@ public class ImmutableMapDataSource extends BaseMapDataSource {
 
     @Override
     public int getNumDocs() {
-      return _numDocs;
+      return _columnMetadata.getTotalDocs();
     }
 
     @Override
     public int getNumValues() {
-      return _numValues;
+      return _columnMetadata.getTotalNumberOfEntries();
     }
 
     @Override
     public int getMaxNumValuesPerMVEntry() {
-      return _maxNumValuesPerMVEntry;
+      // DataSourceMetadata reports -1 for single-value columns, whereas ColumnMetadata reports 0
+      return _columnMetadata.getFieldSpec().isSingleValueField() ? -1 : _columnMetadata.getMaxNumberOfMultiValues();
     }
 
     @Nullable
     @Override
     public Comparable getMinValue() {
-      return _minValue;
+      return _columnMetadata.getMinValue();
     }
 
+    @Nullable
     @Override
     public Comparable getMaxValue() {
-      return _maxValue;
+      return _columnMetadata.getMaxValue();
     }
 
     @Nullable
     @Override
     public PartitionFunction getPartitionFunction() {
-      return _partitionFunction;
+      return _columnMetadata.getPartitionFunction();
     }
 
     @Nullable
     @Override
     public Set<Integer> getPartitions() {
-      return _partitions;
+      return _columnMetadata.getPartitions();
     }
 
     @Override
     public int getCardinality() {
-      return _cardinality;
+      return _columnMetadata.getCardinality();
     }
 
     @Override

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/SegmentMetadataImplTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/SegmentMetadataImplTest.java
@@ -63,6 +63,9 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertSame;
 
@@ -224,6 +227,60 @@ public class SegmentMetadataImplTest {
         assertSame(childSpec.getDefaultNullValue(),
             FieldSpec.getDefaultNullValue(childSpec.getFieldType(), childSpec.getDataType(), null));
       }
+    } finally {
+      FileUtils.deleteQuietly(segmentDir);
+    }
+  }
+
+  /// Every segment of a table parses the same column definitions, so the FieldSpecs are interned: two loads alias one
+  /// instance per column, in the column metadata and in the segment Schema alike, while the Schema object itself stays
+  /// per segment and the specs stay equal to the schema the segment was built from.
+  @Test
+  public void testFieldSpecsSharedAcrossLoads()
+      throws Exception {
+    SegmentMetadataImpl first = new SegmentMetadataImpl(_segmentDirectory);
+    SegmentMetadataImpl second = new SegmentMetadataImpl(_segmentDirectory);
+    assertEquals(first.getSchema(), second.getSchema());
+    assertNotSame(first.getSchema(), second.getSchema());
+    for (String column : first.getColumnMetadataMap().keySet()) {
+      FieldSpec fieldSpec = first.getColumnMetadataFor(column).getFieldSpec();
+      assertSame(second.getColumnMetadataFor(column).getFieldSpec(), fieldSpec, column);
+      assertSame(first.getSchema().getFieldSpecFor(column), fieldSpec, column);
+      assertSame(second.getSchema().getFieldSpecFor(column), fieldSpec, column);
+    }
+    Schema inputSchema = SegmentTestUtils.extractSchemaFromAvroWithoutTime(_avroFile);
+    for (FieldSpec inputFieldSpec : inputSchema.getAllFieldSpecs()) {
+      assertEquals(first.getSchema().getFieldSpecFor(inputFieldSpec.getName()), inputFieldSpec);
+    }
+
+    // Only the specs are shared: removing a column from one segment's schema leaves the other segment intact.
+    String column = first.getColumnMetadataMap().firstKey();
+    first.getSchema().removeField(column);
+    assertNull(first.getSchema().getFieldSpecFor(column));
+    assertNotNull(second.getSchema().getFieldSpecFor(column));
+    assertSame(second.getSchema().getFieldSpecFor(column), second.getColumnMetadataFor(column).getFieldSpec());
+  }
+
+  /// A COMPLEX parent is not interned (ComplexFieldSpec does not override equals, so two structs with different
+  /// children would alias), but its children and the materialized child columns are.
+  @Test
+  public void testOpenStructChildSpecsSharedButParentIsNot()
+      throws Exception {
+    String parent = "metrics";
+    File segmentDir = buildOpenStructSegment(parent);
+    try {
+      SegmentMetadataImpl first = new SegmentMetadataImpl(segmentDir);
+      SegmentMetadataImpl second = new SegmentMetadataImpl(segmentDir);
+      ComplexFieldSpec firstParent = (ComplexFieldSpec) first.getColumnMetadataFor(parent).getFieldSpec();
+      ComplexFieldSpec secondParent = (ComplexFieldSpec) second.getColumnMetadataFor(parent).getFieldSpec();
+      assertNotSame(secondParent, firstParent);
+      assertEquals(secondParent.getChildFieldSpecs(), firstParent.getChildFieldSpecs());
+      for (Map.Entry<String, FieldSpec> entry : firstParent.getChildFieldSpecs().entrySet()) {
+        assertSame(secondParent.getChildFieldSpec(entry.getKey()), entry.getValue(), entry.getKey());
+      }
+      String child = OpenStructNaming.materializedColumnName(parent, "cpu");
+      assertSame(second.getColumnMetadataFor(child).getFieldSpec(), first.getColumnMetadataFor(child).getFieldSpec());
+      assertSame(second.getColumnMetadataFor("dim").getFieldSpec(), first.getColumnMetadataFor("dim").getFieldSpec());
     } finally {
       FileUtils.deleteQuietly(segmentDir);
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainerTest.java
@@ -20,18 +20,39 @@ package org.apache.pinot.segment.local.segment.index.column;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.index.json.JsonIndexType;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.local.segment.index.readers.text.MultiColumnLuceneTextIndexReader;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.creator.IndexCreationContext;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
+import org.apache.pinot.segment.spi.index.IndexCreator;
+import org.apache.pinot.segment.spi.index.IndexHandler;
+import org.apache.pinot.segment.spi.index.IndexPlugin;
+import org.apache.pinot.segment.spi.index.IndexReader;
+import org.apache.pinot.segment.spi.index.IndexReaderConstraintException;
+import org.apache.pinot.segment.spi.index.IndexReaderFactory;
+import org.apache.pinot.segment.spi.index.IndexService;
+import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
-import org.apache.pinot.spi.config.table.FieldConfig.Builder;
-import org.apache.pinot.spi.config.table.FieldConfig.IndexType;
+import org.apache.pinot.segment.spi.index.creator.VectorIndexConfig;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.JsonIndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -41,9 +62,22 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 
 public class PhysicalColumnIndexContainerTest {
@@ -79,20 +113,46 @@ public class PhysicalColumnIndexContainerTest {
     TABLE_CONFIG =
         new TableConfigBuilder(TableType.OFFLINE)
             .setTableName(RAW_TABLE_NAME)
-            .addFieldConfig(new Builder(STR_COL)
+            .addFieldConfig(new FieldConfig.Builder(STR_COL)
                 .withIndexes(indexes)
                 .build())
-            .addFieldConfig(new Builder(INT_COL)
-                .withIndexTypes(List.of(IndexType.RANGE))
+            .addFieldConfig(new FieldConfig.Builder(INT_COL)
+                .withIndexTypes(List.of(FieldConfig.IndexType.RANGE))
                 .build())
-            .addFieldConfig(new Builder(LONG_COL)
-                .withIndexTypes(List.of(IndexType.RANGE))
+            .addFieldConfig(new FieldConfig.Builder(LONG_COL)
+                .withIndexTypes(List.of(FieldConfig.IndexType.RANGE))
                 .build())
-            .addFieldConfig(new Builder(FLOAT_COL)
-                .withIndexTypes(List.of(IndexType.RANGE, IndexType.SORTED))
+            .addFieldConfig(new FieldConfig.Builder(FLOAT_COL)
+                .withIndexTypes(List.of(FieldConfig.IndexType.RANGE, FieldConfig.IndexType.SORTED))
                 .build())
             .setRangeIndexColumns(List.of(LONG_COL, FLOAT_COL))
             .build();
+  }
+
+  private static final String COLUMN = "column";
+
+  // Every standard index id. IndexService assigns numeric ids by sorted id, so the order here is the numeric-id order:
+  // bloom_filter = 0, dictionary = 1, forward_index = 2, ..., nullvalue_vector = 8, ..., vector_index = 12.
+  private static final List<String> STANDARD_IDS =
+      List.of(StandardIndexes.BLOOM_FILTER_ID, StandardIndexes.DICTIONARY_ID, StandardIndexes.FORWARD_ID,
+          StandardIndexes.FST_ID, StandardIndexes.H3_ID, StandardIndexes.IFST_ID, StandardIndexes.INVERTED_ID,
+          StandardIndexes.JSON_ID, StandardIndexes.NULL_VALUE_VECTOR_ID, StandardIndexes.OPEN_STRUCT_ID,
+          StandardIndexes.RANGE_ID, StandardIndexes.TEXT_ID, StandardIndexes.VECTOR_ID);
+
+  private IndexService _originalIndexService;
+  private final Map<String, StubIndexType> _stubTypes = new HashMap<>();
+  private final Map<String, IndexReader> _stubReaders = new HashMap<>();
+
+  @BeforeClass
+  public void saveIndexService() {
+    _originalIndexService = IndexService.getInstance();
+  }
+
+  @AfterMethod
+  public void restoreIndexService() {
+    IndexService.setInstance(_originalIndexService);
+    _stubTypes.clear();
+    _stubReaders.clear();
   }
 
   @Test
@@ -129,21 +189,355 @@ public class PhysicalColumnIndexContainerTest {
       assertNotNull(segment.getIndex(STR_COL, StandardIndexes.json()));
       assertNotNull(segment.getIndex(STR_COL, StandardIndexes.dictionary()));
       assertNotNull(segment.getIndex(STR_COL, StandardIndexes.forward()));
+      assertNull(segment.getIndex(STR_COL, StandardIndexes.range()));
 
       assertNotNull(segment.getIndex(FLOAT_COL, StandardIndexes.dictionary()));
       assertNotNull(segment.getIndex(FLOAT_COL, StandardIndexes.forward()));
       assertNotNull(segment.getIndex(FLOAT_COL, StandardIndexes.range()));
+      assertNull(segment.getIndex(FLOAT_COL, StandardIndexes.json()));
 
       assertNotNull(segment.getIndex(DOUBLE_COL, StandardIndexes.dictionary()));
       assertNotNull(segment.getIndex(DOUBLE_COL, StandardIndexes.forward()));
+      assertNull(segment.getIndex(DOUBLE_COL, StandardIndexes.range()));
 
       assertNotNull(segment.getIndex(LONG_COL, StandardIndexes.dictionary()));
       assertNotNull(segment.getIndex(LONG_COL, StandardIndexes.forward()));
       assertNotNull(segment.getIndex(LONG_COL, StandardIndexes.range()));
+
+      // Index types that no column of this segment has resolve to null for every column. Every column of this
+      // fixture is sorted, so the inverted index resolves to the sorted reader rather than null.
+      for (String column : SCHEMA.getColumnNames()) {
+        assertNotNull(segment.getIndex(column, StandardIndexes.inverted()));
+        assertNull(segment.getIndex(column, StandardIndexes.bloomFilter()));
+        assertNull(segment.getIndex(column, StandardIndexes.nullValueVector()));
+        assertNull(segment.getIndex(column, StandardIndexes.text()));
+        assertNull(segment.getIndex(column, StandardIndexes.vector()));
+      }
     } finally {
       if (segment != null) {
         segment.destroy();
       }
+    }
+  }
+
+  @Test
+  public void testForwardOnlyColumn()
+      throws IOException {
+    installStandardStubs();
+    PhysicalColumnIndexContainer container = newContainer(Set.of(StandardIndexes.FORWARD_ID), false);
+    assertPresentExactly(container, Set.of(StandardIndexes.FORWARD_ID));
+  }
+
+  @Test
+  public void testForwardAndNullValueVector()
+      throws IOException {
+    // Numeric ids 2 and 8: the span array of the old layout would have held 7 slots for these 2 readers.
+    installStandardStubs();
+    Set<String> present = Set.of(StandardIndexes.FORWARD_ID, StandardIndexes.NULL_VALUE_VECTOR_ID);
+    assertPresentExactly(newContainer(present, false), present);
+  }
+
+  @Test
+  public void testLowestAndHighIds()
+      throws IOException {
+    // bloom_filter is numeric id 0 and vector_index is the highest standard id.
+    installStandardStubs();
+    Set<String> present =
+        Set.of(StandardIndexes.BLOOM_FILTER_ID, StandardIndexes.DICTIONARY_ID, StandardIndexes.FORWARD_ID,
+            StandardIndexes.JSON_ID, StandardIndexes.RANGE_ID, StandardIndexes.VECTOR_ID);
+    assertPresentExactly(newContainer(present, false), present);
+  }
+
+  @Test
+  public void testSparseNonAdjacentIds()
+      throws IOException {
+    installStandardStubs();
+    Set<String> present = Set.of(StandardIndexes.BLOOM_FILTER_ID, StandardIndexes.JSON_ID, StandardIndexes.VECTOR_ID);
+    assertPresentExactly(newContainer(present, false), present);
+  }
+
+  @Test
+  public void testAllIndexesPresent()
+      throws IOException {
+    installStandardStubs();
+    assertPresentExactly(newContainer(new HashSet<>(STANDARD_IDS), false), new HashSet<>(STANDARD_IDS));
+  }
+
+  @Test
+  public void testNoIndexes()
+      throws IOException {
+    installStandardStubs();
+    PhysicalColumnIndexContainer container = newContainer(Set.of(), false);
+    assertPresentExactly(container, Set.of());
+    container.close();
+    for (IndexReader reader : _stubReaders.values()) {
+      verify(reader, never()).close();
+    }
+  }
+
+  @Test
+  public void testForwardIndexOnlyFiltering()
+      throws IOException {
+    installStandardStubs();
+    SegmentDirectory.Reader segmentReader = mockSegmentReader(new HashSet<>(STANDARD_IDS));
+    PhysicalColumnIndexContainer container = newContainer(segmentReader, true);
+    Set<String> expected =
+        Set.of(StandardIndexes.FORWARD_ID, StandardIndexes.DICTIONARY_ID, StandardIndexes.NULL_VALUE_VECTOR_ID);
+    assertPresentExactly(container, expected);
+    // Filtered types are skipped before the segment reader is consulted.
+    for (String id : STANDARD_IDS) {
+      if (!expected.contains(id)) {
+        verify(segmentReader, never()).hasIndexFor(COLUMN, _stubTypes.get(id));
+      }
+    }
+  }
+
+  @Test
+  public void testFactoryReturningNullIsAbsent()
+      throws IOException {
+    installStandardStubs();
+    _stubTypes.get(StandardIndexes.DICTIONARY_ID).setReaderFactory((reader, configs, metadata) -> null);
+    Set<String> present =
+        Set.of(StandardIndexes.DICTIONARY_ID, StandardIndexes.FORWARD_ID, StandardIndexes.RANGE_ID);
+    assertPresentExactly(newContainer(present, false),
+        Set.of(StandardIndexes.FORWARD_ID, StandardIndexes.RANGE_ID));
+  }
+
+  @Test
+  public void testConstraintViolationSkipsIndex()
+      throws IOException {
+    installStandardStubs();
+    StubIndexType rangeType = _stubTypes.get(StandardIndexes.RANGE_ID);
+    rangeType.setReaderFactory((reader, configs, metadata) -> {
+      throw new IndexReaderConstraintException(COLUMN, rangeType, "no dictionary");
+    });
+    Set<String> present =
+        Set.of(StandardIndexes.DICTIONARY_ID, StandardIndexes.FORWARD_ID, StandardIndexes.RANGE_ID,
+            StandardIndexes.TEXT_ID);
+    assertPresentExactly(newContainer(present, false),
+        Set.of(StandardIndexes.DICTIONARY_ID, StandardIndexes.FORWARD_ID, StandardIndexes.TEXT_ID));
+  }
+
+  @Test
+  public void testCloseClosesEveryReaderOnce()
+      throws IOException {
+    installStandardStubs();
+    Set<String> present =
+        Set.of(StandardIndexes.BLOOM_FILTER_ID, StandardIndexes.DICTIONARY_ID, StandardIndexes.FORWARD_ID,
+            StandardIndexes.NULL_VALUE_VECTOR_ID, StandardIndexes.VECTOR_ID);
+    PhysicalColumnIndexContainer container = newContainer(present, false);
+    MultiColumnLuceneTextIndexReader multiColTextReader = mock(MultiColumnLuceneTextIndexReader.class);
+    container.setMultiColumnTextIndex(multiColTextReader);
+    assertSame(container.getMultiColumnTextIndex(), multiColTextReader);
+
+    container.close();
+
+    for (String id : STANDARD_IDS) {
+      if (present.contains(id)) {
+        verify(_stubReaders.get(id)).close();
+      } else {
+        verify(_stubReaders.get(id), never()).close();
+      }
+    }
+    // The multi-column text reader is shared across columns and closed by the segment, not the container.
+    verify(multiColTextReader, never()).close();
+    assertNull(container.getMultiColumnTextIndex());
+  }
+
+  @Test
+  public void testInitFailureClosesCreatedReaders()
+      throws IOException {
+    installStandardStubs();
+    IOException failure = new IOException("cannot open json index");
+    _stubTypes.get(StandardIndexes.JSON_ID).setReaderFactory((reader, configs, metadata) -> {
+      throw failure;
+    });
+    Set<String> present =
+        Set.of(StandardIndexes.BLOOM_FILTER_ID, StandardIndexes.DICTIONARY_ID, StandardIndexes.FORWARD_ID,
+            StandardIndexes.JSON_ID, StandardIndexes.RANGE_ID);
+    SegmentDirectory.Reader segmentReader = mockSegmentReader(present);
+
+    IOException thrown = expectThrows(IOException.class, () -> newContainer(segmentReader, false));
+    assertSame(thrown, failure);
+
+    // Readers created before the failure (lower numeric ids) are closed; the rest were never created.
+    verify(_stubReaders.get(StandardIndexes.BLOOM_FILTER_ID)).close();
+    verify(_stubReaders.get(StandardIndexes.DICTIONARY_ID)).close();
+    verify(_stubReaders.get(StandardIndexes.FORWARD_ID)).close();
+    verify(segmentReader, never()).hasIndexFor(COLUMN, _stubTypes.get(StandardIndexes.RANGE_ID));
+    verify(_stubReaders.get(StandardIndexes.RANGE_ID), never()).close();
+  }
+
+  @Test
+  public void testTooManyIndexTypesFailsConstruction() {
+    installIndexService(standardAndSyntheticTypes(Long.SIZE + 1));
+    assertEquals(IndexService.getInstance().getAllIndexes().size(), Long.SIZE + 1);
+
+    SegmentDirectory.Reader segmentReader = mock(SegmentDirectory.Reader.class);
+    IllegalStateException thrown =
+        expectThrows(IllegalStateException.class, () -> newContainer(segmentReader, false));
+    assertTrue(thrown.getMessage().contains("65 index types"), thrown.getMessage());
+    verify(segmentReader, never()).hasIndexFor(any(), any());
+  }
+
+  @Test
+  public void testMaximumIndexTypesFitInMask()
+      throws IOException {
+    List<StubIndexType> types = standardAndSyntheticTypes(Long.SIZE);
+    installIndexService(types);
+    IndexService indexService = IndexService.getInstance();
+    assertEquals(indexService.getAllIndexes().size(), Long.SIZE);
+
+    // The two extreme numeric ids (0 and 63) plus one in the middle.
+    Set<String> present = new HashSet<>();
+    for (int numericId : new int[]{0, 31, Long.SIZE - 1}) {
+      present.add(indexService.get(numericId).getId());
+    }
+    PhysicalColumnIndexContainer container = newContainer(mockSegmentReader(present), false);
+    for (StubIndexType type : types) {
+      if (present.contains(type.getId())) {
+        assertSame(container.getIndex(type), _stubReaders.get(type.getId()), type.getId());
+      } else {
+        assertNull(container.getIndex(type), type.getId());
+      }
+    }
+  }
+
+  /// Installs an IndexService whose types carry every standard index id, so numeric ids match production, backed by
+  /// one mock reader per type.
+  private void installStandardStubs() {
+    installIndexService(standardAndSyntheticTypes(STANDARD_IDS.size()));
+  }
+
+  /// The standard ids (so [StandardIndexes] accessors resolve) padded with synthetic ids up to the given count.
+  private static List<StubIndexType> standardAndSyntheticTypes(int numTypes) {
+    List<StubIndexType> types = new ArrayList<>();
+    for (String id : STANDARD_IDS) {
+      types.add(new StubIndexType(id));
+    }
+    for (int i = STANDARD_IDS.size(); i < numTypes; i++) {
+      types.add(new StubIndexType(String.format("synthetic_index_%02d", i)));
+    }
+    return types;
+  }
+
+  private void installIndexService(List<StubIndexType> types) {
+    Set<IndexPlugin<?>> plugins = new HashSet<>();
+    for (StubIndexType type : types) {
+      IndexReader reader = mock(IndexReader.class, type.getId());
+      _stubReaders.put(type.getId(), reader);
+      _stubTypes.put(type.getId(), type);
+      type.setReaderFactory((segmentReader, configs, metadata) -> reader);
+      plugins.add((IndexPlugin<StubIndexType>) () -> type);
+    }
+    IndexService.setInstance(new IndexService(plugins));
+  }
+
+  private SegmentDirectory.Reader mockSegmentReader(Set<String> presentIds) {
+    SegmentDirectory.Reader segmentReader = mock(SegmentDirectory.Reader.class);
+    when(segmentReader.hasIndexFor(eq(COLUMN), any())).thenAnswer(
+        invocation -> presentIds.contains(((IndexType<?, ?, ?>) invocation.getArgument(1)).getId()));
+    return segmentReader;
+  }
+
+  private PhysicalColumnIndexContainer newContainer(Set<String> presentIds, boolean forwardIndexOnly)
+      throws IOException {
+    return newContainer(mockSegmentReader(presentIds), forwardIndexOnly);
+  }
+
+  private static PhysicalColumnIndexContainer newContainer(SegmentDirectory.Reader segmentReader,
+      boolean forwardIndexOnly)
+      throws IOException {
+    ColumnMetadata metadata = mock(ColumnMetadata.class);
+    when(metadata.getColumnName()).thenReturn(COLUMN);
+    IndexLoadingConfig indexLoadingConfig = mock(IndexLoadingConfig.class);
+    when(indexLoadingConfig.isForwardIndexOnly()).thenReturn(forwardIndexOnly);
+    return new PhysicalColumnIndexContainer(segmentReader, metadata, indexLoadingConfig);
+  }
+
+  /// Asserts that getIndex returns the created reader for every present standard id and null for the others.
+  private void assertPresentExactly(PhysicalColumnIndexContainer container, Set<String> presentIds) {
+    for (String id : STANDARD_IDS) {
+      StubIndexType type = _stubTypes.get(id);
+      if (presentIds.contains(id)) {
+        assertSame(container.getIndex(type), _stubReaders.get(id), id);
+      } else {
+        assertNull(container.getIndex(type), id);
+      }
+    }
+  }
+
+  private static final class StubIndexType implements IndexType<IndexConfig, IndexReader, IndexCreator> {
+    private final String _id;
+    private IndexReaderFactory<IndexReader> _factory;
+
+    StubIndexType(String id) {
+      _id = id;
+    }
+
+    void setReaderFactory(IndexReaderFactory<IndexReader> factory) {
+      _factory = factory;
+    }
+
+    @Override
+    public String getId() {
+      return _id;
+    }
+
+    @Override
+    public Class<IndexConfig> getIndexConfigClass() {
+      return IndexConfig.class;
+    }
+
+    @Override
+    public IndexConfig getDefaultConfig() {
+      // The container reads the vector config through StandardIndexes.vector(), typed as VectorIndexConfig.
+      return _id.equals(StandardIndexes.VECTOR_ID) ? VectorIndexConfig.DISABLED : IndexConfig.DISABLED;
+    }
+
+    @Override
+    public Map<String, IndexConfig> getConfig(TableConfig tableConfig, Schema schema) {
+      return Map.of();
+    }
+
+    @Override
+    public IndexCreator createIndexCreator(IndexCreationContext context, IndexConfig indexConfig) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IndexReaderFactory<IndexReader> getReaderFactory() {
+      return _factory;
+    }
+
+    @Override
+    public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
+      return List.of();
+    }
+
+    @Override
+    public IndexHandler createIndexHandler(SegmentDirectory segmentDirectory,
+        Map<String, FieldIndexConfigs> configsByCol, Schema schema, TableConfig tableConfig) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean requiresDictionary(FieldSpec fieldSpec, IndexConfig indexConfig) {
+      return false;
+    }
+
+    @Override
+    public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, IndexConfig indexConfig) {
+      return false;
+    }
+
+    @Override
+    public void convertToNewFormat(TableConfig tableConfig, Schema schema) {
+    }
+
+    @Override
+    public String toString() {
+      return _id;
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/datasource/ImmutableDataSourceTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/datasource/ImmutableDataSourceTest.java
@@ -1,0 +1,177 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.datasource;
+
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import java.util.Set;
+import org.apache.pinot.segment.local.segment.index.map.SimpleColumnMetadata;
+import org.apache.pinot.segment.local.segment.virtualcolumn.DocIdVirtualColumnProvider;
+import org.apache.pinot.segment.local.segment.virtualcolumn.VirtualColumnContext;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
+import org.apache.pinot.segment.spi.index.metadata.ColumnMetadataImpl;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+
+/// Covers the [DataSourceMetadata] view an [ImmutableDataSource] exposes over the segment's [ColumnMetadata]. The
+/// view delegates to the column metadata instead of copying it, so every accessor must report the value (and, for
+/// reference types, the instance) the column metadata holds, while keeping the two contracts that differ between the
+/// interfaces: `getMaxNumValuesPerMVEntry()` is `-1` for single-value columns and `getMaxRowLengthInBytes()` stays
+/// at the [DataSourceMetadata] default of `-1`.
+public class ImmutableDataSourceTest {
+  private static final int NUM_DOCS = 1000;
+
+  @Test
+  public void testSingleValueColumn() {
+    FieldSpec fieldSpec = new DimensionFieldSpec("sv", DataType.INT, true);
+    PartitionFunction partitionFunction = PartitionFunctionFactory.getPartitionFunction("Modulo", 4, null);
+    Set<Integer> partitions = new IntOpenHashSet(new int[]{1, 3});
+    ColumnMetadata columnMetadata = new ColumnMetadataImpl.Builder().setFieldSpec(fieldSpec)
+        .setTotalDocs(NUM_DOCS)
+        .setCardinality(37)
+        .setHasDictionary(true)
+        .setSorted(true)
+        .setMinValue(-5)
+        .setMaxValue(123456)
+        .setPartitionFunction(partitionFunction)
+        .setPartitions(partitions)
+        .build();
+
+    DataSourceMetadata metadata = dataSourceMetadata(columnMetadata);
+    assertSame(metadata.getFieldSpec(), fieldSpec);
+    assertEquals(metadata.getDataType(), DataType.INT);
+    assertTrue(metadata.isSingleValue());
+    assertTrue(metadata.isSorted());
+    assertEquals(metadata.getNumDocs(), NUM_DOCS);
+    assertEquals(metadata.getNumValues(), NUM_DOCS);
+    assertEquals(metadata.getNumValues(), columnMetadata.getTotalNumberOfEntries());
+    assertEquals(metadata.getCardinality(), 37);
+    assertSame(metadata.getMinValue(), columnMetadata.getMinValue());
+    assertEquals(metadata.getMinValue(), -5);
+    assertSame(metadata.getMaxValue(), columnMetadata.getMaxValue());
+    assertEquals(metadata.getMaxValue(), 123456);
+    assertSame(metadata.getPartitionFunction(), partitionFunction);
+    assertSame(metadata.getPartitions(), partitions);
+
+    // Single-value columns report -1 through the data source view although the column metadata canonicalises to 0
+    assertEquals(columnMetadata.getMaxNumberOfMultiValues(), 0);
+    assertEquals(metadata.getMaxNumValuesPerMVEntry(), -1);
+
+    // The row length is not delegated: the column metadata computes it, the data source view keeps its default
+    assertEquals(columnMetadata.getMaxRowLengthInBytes(), Integer.BYTES);
+    assertEquals(metadata.getMaxRowLengthInBytes(), -1);
+  }
+
+  @Test
+  public void testMultiValueColumn() {
+    FieldSpec fieldSpec = new DimensionFieldSpec("mv", DataType.STRING, false);
+    ColumnMetadata columnMetadata = new ColumnMetadataImpl.Builder().setFieldSpec(fieldSpec)
+        .setTotalDocs(NUM_DOCS)
+        .setCardinality(11)
+        .setHasDictionary(true)
+        .setSorted(false)
+        .setMinValue("apple")
+        .setMaxValue("zebra")
+        .setTotalNumberOfEntries(4 * NUM_DOCS)
+        .setMaxNumberOfMultiValues(7)
+        .setMaxRowLengthInBytes(42)
+        .setLengthOfLongestElement(6)
+        .build();
+
+    DataSourceMetadata metadata = dataSourceMetadata(columnMetadata);
+    assertSame(metadata.getFieldSpec(), fieldSpec);
+    assertEquals(metadata.getDataType(), DataType.STRING);
+    assertFalse(metadata.isSingleValue());
+    assertFalse(metadata.isSorted());
+    assertEquals(metadata.getNumDocs(), NUM_DOCS);
+    assertEquals(metadata.getNumValues(), 4 * NUM_DOCS);
+    assertEquals(metadata.getMaxNumValuesPerMVEntry(), 7);
+    assertEquals(metadata.getMaxNumValuesPerMVEntry(), columnMetadata.getMaxNumberOfMultiValues());
+    assertEquals(metadata.getCardinality(), 11);
+    assertSame(metadata.getMinValue(), columnMetadata.getMinValue());
+    assertEquals(metadata.getMinValue(), "apple");
+    assertSame(metadata.getMaxValue(), columnMetadata.getMaxValue());
+    assertEquals(metadata.getMaxValue(), "zebra");
+    assertNull(metadata.getPartitionFunction());
+    assertNull(metadata.getPartitions());
+
+    assertEquals(columnMetadata.getMaxRowLengthInBytes(), 42);
+    assertEquals(metadata.getMaxRowLengthInBytes(), -1);
+  }
+
+  @Test
+  public void testVirtualColumn() {
+    FieldSpec fieldSpec = new DimensionFieldSpec("$docId", DataType.INT, true);
+    DataSource dataSource =
+        new DocIdVirtualColumnProvider().buildDataSource(new VirtualColumnContext(fieldSpec, NUM_DOCS));
+    assertTrue(dataSource instanceof ImmutableDataSource);
+
+    DataSourceMetadata metadata = dataSource.getDataSourceMetadata();
+    assertSame(metadata.getFieldSpec(), fieldSpec);
+    assertTrue(metadata.isSingleValue());
+    assertTrue(metadata.isSorted());
+    assertEquals(metadata.getNumDocs(), NUM_DOCS);
+    assertEquals(metadata.getNumValues(), NUM_DOCS);
+    assertEquals(metadata.getMaxNumValuesPerMVEntry(), -1);
+    assertEquals(metadata.getCardinality(), NUM_DOCS);
+    assertNull(metadata.getMinValue());
+    assertNull(metadata.getMaxValue());
+    assertNull(metadata.getPartitionFunction());
+    assertNull(metadata.getPartitions());
+    assertEquals(metadata.getMaxRowLengthInBytes(), -1);
+  }
+
+  /// A MAP key's data source is built over a [SimpleColumnMetadata] whose stats are all unavailable; the view must
+  /// pass them through unchanged rather than re-deriving them.
+  @Test
+  public void testUnavailableStatsPassThrough() {
+    FieldSpec fieldSpec = new DimensionFieldSpec("key", DataType.LONG, false);
+    ColumnMetadata columnMetadata = new SimpleColumnMetadata(fieldSpec, NUM_DOCS);
+
+    DataSourceMetadata metadata = dataSourceMetadata(columnMetadata);
+    assertSame(metadata.getFieldSpec(), fieldSpec);
+    assertFalse(metadata.isSorted());
+    assertEquals(metadata.getNumDocs(), NUM_DOCS);
+    assertEquals(metadata.getNumValues(), ColumnMetadata.UNAVAILABLE);
+    assertEquals(metadata.getMaxNumValuesPerMVEntry(), ColumnMetadata.UNAVAILABLE);
+    assertEquals(metadata.getCardinality(), ColumnMetadata.UNAVAILABLE);
+    assertNull(metadata.getMinValue());
+    assertNull(metadata.getMaxValue());
+    assertNull(metadata.getPartitionFunction());
+    assertNull(metadata.getPartitions());
+    assertEquals(metadata.getMaxRowLengthInBytes(), -1);
+  }
+
+  private static DataSourceMetadata dataSourceMetadata(ColumnMetadata columnMetadata) {
+    return new ImmutableDataSource(columnMetadata, ColumnIndexContainer.Empty.INSTANCE).getDataSourceMetadata();
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/map/ImmutableMapDataSourceTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/map/ImmutableMapDataSourceTest.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.map;
+
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.index.IndexReader;
+import org.apache.pinot.segment.spi.index.IndexType;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
+import org.apache.pinot.segment.spi.index.metadata.ColumnMetadataImpl;
+import org.apache.pinot.segment.spi.index.reader.MapIndexReader;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.spi.data.ComplexFieldSpec.KEY_FIELD;
+import static org.apache.pinot.spi.data.ComplexFieldSpec.VALUE_FIELD;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+/// Covers the [DataSourceMetadata] view an [ImmutableMapDataSource] exposes over the MAP column's [ColumnMetadata].
+/// The view delegates to the column metadata instead of copying it, except for the two MAP-specific contracts: the
+/// column is never reported as sorted, and `getMaxRowLengthInBytes()` is unsupported.
+public class ImmutableMapDataSourceTest {
+  private static final int NUM_DOCS = 1000;
+
+  @Test
+  public void testDelegatesToColumnMetadata() {
+    ComplexFieldSpec fieldSpec = new ComplexFieldSpec("m", DataType.MAP, true, Map.of(
+        KEY_FIELD, new DimensionFieldSpec(KEY_FIELD, DataType.STRING, true),
+        VALUE_FIELD, new DimensionFieldSpec(VALUE_FIELD, DataType.LONG, true)
+    ));
+    PartitionFunction partitionFunction = PartitionFunctionFactory.getPartitionFunction("Modulo", 2, null);
+    Set<Integer> partitions = new IntOpenHashSet(new int[]{0});
+    // Sorted is set on purpose: the MAP view must ignore it
+    ColumnMetadata columnMetadata = new ColumnMetadataImpl.Builder().setFieldSpec(fieldSpec)
+        .setTotalDocs(NUM_DOCS)
+        .setCardinality(5)
+        .setSorted(true)
+        .setMinValue("a")
+        .setMaxValue("z")
+        .setPartitionFunction(partitionFunction)
+        .setPartitions(partitions)
+        .build();
+    Map<IndexType, IndexReader> indexes = Map.of(StandardIndexes.forward(), mock(MapIndexReader.class));
+    ColumnIndexContainer indexContainer = new ColumnIndexContainer.FromMap(indexes);
+
+    DataSourceMetadata metadata = new ImmutableMapDataSource(columnMetadata, indexContainer).getDataSourceMetadata();
+    assertSame(metadata.getFieldSpec(), fieldSpec);
+    assertEquals(metadata.getDataType(), DataType.MAP);
+    assertTrue(metadata.isSingleValue());
+    assertTrue(columnMetadata.isSorted());
+    assertFalse(metadata.isSorted());
+    assertEquals(metadata.getNumDocs(), NUM_DOCS);
+    assertEquals(metadata.getNumValues(), NUM_DOCS);
+    assertEquals(metadata.getMaxNumValuesPerMVEntry(), -1);
+    assertEquals(metadata.getCardinality(), 5);
+    assertSame(metadata.getMinValue(), columnMetadata.getMinValue());
+    assertEquals(metadata.getMinValue(), "a");
+    assertSame(metadata.getMaxValue(), columnMetadata.getMaxValue());
+    assertEquals(metadata.getMaxValue(), "z");
+    assertSame(metadata.getPartitionFunction(), partitionFunction);
+    assertSame(metadata.getPartitions(), partitions);
+    assertThrows(UnsupportedOperationException.class, metadata::getMaxRowLengthInBytes);
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/ColumnMetadata.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/ColumnMetadata.java
@@ -25,12 +25,22 @@ import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.config.table.FieldConfig.EncodingType;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 /// The `ColumnMetadata` class holds the column level management information and data statistics.
 @InterfaceAudience.Private
 public interface ColumnMetadata extends ColumnShape {
   int UNAVAILABLE = -1;
+
+  /// Returns the [FieldSpec] of the column.
+  ///
+  /// A spec derived from segment metadata (`metadata.properties`) is shared: every loaded segment whose column parses
+  /// to an equal spec, in this table or any other, holds the same instance, so it must be treated as immutable. Never
+  /// call a setter on it; copy it (e.g. through a JSON round-trip) before mutating. Compare specs with
+  /// [FieldSpec#equals], never by identity.
+  @Override
+  FieldSpec getFieldSpec();
 
   /// Returns `true` when the column has a dictionary, `false` otherwise.
   @JsonProperty("hasDictionary")

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
@@ -64,6 +64,12 @@ public interface SegmentMetadata {
 
   SegmentVersion getVersion();
 
+  /// Returns the schema of the segment, one [org.apache.pinot.spi.data.FieldSpec] per column.
+  ///
+  /// The `Schema` object itself belongs to this segment, but the specs it holds are shared with every other loaded
+  /// segment (of this table or any other) whose column parses to an equal spec, and must be treated as immutable: never
+  /// call a setter on one; copy it (e.g. through a JSON round-trip) before mutating. Removing a column from this schema
+  /// does not affect other segments.
   Schema getSchema();
 
   int getTotalDocs();

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
@@ -20,6 +20,8 @@ package org.apache.pinot.segment.spi.index.metadata;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
 import com.google.common.collect.Maps;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
@@ -66,11 +68,21 @@ import static com.google.common.base.Preconditions.checkElementIndex;
 /// the per-column footprint small: column names, parent-column names, date-time formats/granularities and custom
 /// default-null literals are interned (they recur in every segment of a table), and a `defaultNullValue` that equals
 /// the type default is not handed to the [FieldSpec] at all, so the spec carries the shared static
-/// `FieldSpec.DEFAULT_*` constant and never retains the literal. Segment-derived [FieldSpec]s must therefore be
-/// treated as read-only: nothing may mutate their default null value in place (nothing ever did).
+/// `FieldSpec.DEFAULT_*` constant and never retains the literal. The [FieldSpec] itself is then interned through
+/// [#FIELD_SPEC_INTERNER], so every segment of a table (and every table with an identical column definition) shares
+/// one instance per distinct spec instead of retaining its own. Segment-derived [FieldSpec]s must therefore be treated
+/// as immutable: a setter call on one would bleed into every other segment and table that shares it, and would
+/// corrupt the interner's hash bucket (nothing ever mutated one; copy via a JSON round-trip before mutating).
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ColumnMetadataImpl implements ColumnMetadata {
   private static final long SIZE_MASK = 0xffffffffffffL;
+
+  /// Canonical instances of the [FieldSpec]s parsed from `metadata.properties`, keyed by [FieldSpec#equals] /
+  /// [FieldSpec#hashCode] (name, data type, single-value, default null value, max length, date-time format and
+  /// granularity, ...), so schema evolution yields a distinct canonical instance per version of a column. The specs
+  /// are held weakly: the canonical instance is exactly the one the loaded segments retain, so it lives as long as
+  /// any of them and is released once the last one is unloaded. Thread-safe.
+  private static final Interner<FieldSpec> FIELD_SPEC_INTERNER = Interners.newWeakInterner();
 
   private final FieldSpec _fieldSpec;
   private final int _totalDocs;
@@ -500,6 +512,11 @@ public class ColumnMetadataImpl implements ColumnMetadata {
     }
   }
 
+  /// Parses the [FieldSpec] of the given column. DIMENSION, METRIC, TIME and DATE_TIME specs are returned from
+  /// [#FIELD_SPEC_INTERNER], so the instance is shared with every other segment whose column parses to an equal spec
+  /// and must not be mutated. A COMPLEX spec is not interned: [ComplexFieldSpec] does not override
+  /// [FieldSpec#equals], so two structs with different children would alias; its children are parsed through this
+  /// method and are interned.
   public static FieldSpec extractFieldSpec(String column, PropertiesConfiguration config) {
     // The name is retained by the FieldSpec, the segment Schema and every per-segment column map, and it recurs in
     // every segment of the table: intern it so all of them alias one JVM-wide instance. When COLUMN_NAME is absent
@@ -520,19 +537,20 @@ public class ColumnMetadataImpl implements ColumnMetadata {
         ? FieldSpec.MaxLengthExceedStrategy.valueOf(maxLengthExceedStrategyString) : null;
     switch (fieldType) {
       case DIMENSION:
-        return new DimensionFieldSpec(fieldName, dataType, isSingleValue, maxLength,
-            canonicalDefaultNullValue(fieldType, dataType, defaultNullValueString), maxLengthExceedStrategy);
+        return FIELD_SPEC_INTERNER.intern(new DimensionFieldSpec(fieldName, dataType, isSingleValue, maxLength,
+            canonicalDefaultNullValue(fieldType, dataType, defaultNullValueString), maxLengthExceedStrategy));
       case METRIC:
-        return new MetricFieldSpec(fieldName, dataType,
-            canonicalDefaultNullValue(fieldType, dataType, defaultNullValueString), maxLength, maxLengthExceedStrategy);
+        return FIELD_SPEC_INTERNER.intern(new MetricFieldSpec(fieldName, dataType,
+            canonicalDefaultNullValue(fieldType, dataType, defaultNullValueString), maxLength,
+            maxLengthExceedStrategy));
       case TIME:
         TimeUnit timeUnit = TimeUnit.valueOf(config.getString(Segment.TIME_UNIT, "DAYS").toUpperCase());
-        return new TimeFieldSpec(new TimeGranularitySpec(dataType, timeUnit, fieldName));
+        return FIELD_SPEC_INTERNER.intern(new TimeFieldSpec(new TimeGranularitySpec(dataType, timeUnit, fieldName)));
       case DATE_TIME:
         String format = intern(config.getString(Column.getKeyFor(column, Column.DATETIME_FORMAT)));
         String granularity = intern(config.getString(Column.getKeyFor(column, Column.DATETIME_GRANULARITY)));
-        return new DateTimeFieldSpec(fieldName, dataType, format, granularity,
-            canonicalDefaultNullValue(fieldType, dataType, defaultNullValueString), null);
+        return FIELD_SPEC_INTERNER.intern(new DateTimeFieldSpec(fieldName, dataType, format, granularity,
+            canonicalDefaultNullValue(fieldType, dataType, defaultNullValueString), null));
       case COMPLEX:
         List<String> childFieldNames =
             config.getList(String.class, Column.getKeyFor(column, Column.COMPLEX_CHILD_FIELD_NAMES));
@@ -543,6 +561,7 @@ public class ColumnMetadataImpl implements ColumnMetadata {
                 extractFieldSpec(ComplexFieldSpec.getFullChildName(column, childField), config));
           }
         }
+        // Deliberately not interned (see the method doc): only the children above are shared.
         return new ComplexFieldSpec(fieldName, dataType, true, childFieldSpecs);
       default:
         throw new IllegalStateException("Unsupported field type: " + fieldType);

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImplTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImplTest.java
@@ -19,20 +19,29 @@
 package org.apache.pinot.segment.spi.index.metadata;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.lang.ref.WeakReference;
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column;
+import org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Segment;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 import org.apache.pinot.spi.config.table.FieldConfig.EncodingType;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.MetricFieldSpec;
+import org.apache.pinot.spi.data.TimeFieldSpec;
+import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -460,6 +469,132 @@ public class ColumnMetadataImplTest {
     String column = new String("plain");
     FieldSpec spec = ColumnMetadataImpl.extractFieldSpec(column, baseConfigWithoutName(column));
     assertSame(spec.getName(), "plain");
+  }
+
+  /// A server retains one FieldSpec per (segment, column) and every segment of a table parses the same column
+  /// definition, so the parse path interns the spec: two loads of the same metadata, or of two segments whose column
+  /// parses to an equal spec, alias one instance that is still equal to the spec the table schema builds.
+  @Test
+  public void equalSpecsAreInterned() {
+    PropertiesConfiguration config = baseConfig("col");
+    FieldSpec spec = ColumnMetadataImpl.fromPropertiesConfiguration(config, 1, "col").getFieldSpec();
+    assertSame(ColumnMetadataImpl.fromPropertiesConfiguration(config, 2, "col").getFieldSpec(), spec);
+    assertSame(ColumnMetadataImpl.fromPropertiesConfiguration(baseConfig("col"), 3, "col").getFieldSpec(), spec);
+    assertEquals(spec, new DimensionFieldSpec("col", DataType.STRING, true));
+
+    // A custom default and a max length are part of the key and are shared as well.
+    FieldSpec custom = parse(FieldType.DIMENSION, DataType.INT, "-1");
+    assertSame(parse(FieldType.DIMENSION, DataType.INT, "-1"), custom);
+    assertEquals(custom, new DimensionFieldSpec("col", DataType.INT, true, -1));
+    PropertiesConfiguration bounded = configFor(FieldType.DIMENSION, DataType.STRING, null);
+    bounded.setProperty(Column.getKeyFor("col", Column.SCHEMA_MAX_LENGTH), 10);
+    FieldSpec boundedSpec = ColumnMetadataImpl.extractFieldSpec("col", bounded);
+    assertSame(ColumnMetadataImpl.extractFieldSpec("col", bounded), boundedSpec);
+    assertEquals(boundedSpec, new DimensionFieldSpec("col", DataType.STRING, true, 10, null));
+  }
+
+  @Test
+  public void metricTimeAndDateTimeSpecsAreInterned() {
+    FieldSpec metric = parse(FieldType.METRIC, DataType.LONG, null);
+    assertSame(parse(FieldType.METRIC, DataType.LONG, null), metric);
+    assertEquals(metric, new MetricFieldSpec("col", DataType.LONG));
+
+    PropertiesConfiguration hours = configFor(FieldType.TIME, DataType.INT, null);
+    hours.setProperty(Segment.TIME_UNIT, "HOURS");
+    FieldSpec time = ColumnMetadataImpl.extractFieldSpec("col", hours);
+    assertSame(ColumnMetadataImpl.extractFieldSpec("col", hours), time);
+    assertEquals(time, new TimeFieldSpec(new TimeGranularitySpec(DataType.INT, TimeUnit.HOURS, "col")));
+    // The time unit is part of the TimeFieldSpec key.
+    PropertiesConfiguration days = configFor(FieldType.TIME, DataType.INT, null);
+    days.setProperty(Segment.TIME_UNIT, "DAYS");
+    assertNotSame(ColumnMetadataImpl.extractFieldSpec("col", days), time);
+
+    FieldSpec dateTime = parse(FieldType.DATE_TIME, DataType.LONG, null);
+    assertSame(parse(FieldType.DATE_TIME, DataType.LONG, null), dateTime);
+    assertEquals(dateTime, new DateTimeFieldSpec("col", DataType.LONG, DATETIME_FORMAT, DATETIME_GRANULARITY));
+  }
+
+  /// Interning is keyed by [FieldSpec#equals], so a column whose definition changed (schema evolution) parses to a
+  /// distinct canonical instance instead of aliasing the previous one.
+  @Test
+  public void differingSpecsAreNotInterned() {
+    FieldSpec base = parse(FieldType.DIMENSION, DataType.INT, null);
+    assertNotSame(parse(FieldType.DIMENSION, DataType.INT, "-1"), base, "default null value");
+    assertNotSame(parse(FieldType.DIMENSION, DataType.LONG, null), base, "data type");
+    assertNotSame(parse(FieldType.METRIC, DataType.INT, null), base, "field type");
+    assertNotSame(ColumnMetadataImpl.extractFieldSpec("other", baseConfig("other")),
+        ColumnMetadataImpl.extractFieldSpec("col", baseConfig("col")), "name");
+    PropertiesConfiguration multiValue = configFor(FieldType.DIMENSION, DataType.INT, null);
+    multiValue.setProperty(Column.getKeyFor("col", Column.IS_SINGLE_VALUED), false);
+    assertNotSame(ColumnMetadataImpl.extractFieldSpec("col", multiValue), base, "single value");
+    PropertiesConfiguration maxLength = configFor(FieldType.DIMENSION, DataType.INT, null);
+    maxLength.setProperty(Column.getKeyFor("col", Column.SCHEMA_MAX_LENGTH), 10);
+    assertNotSame(ColumnMetadataImpl.extractFieldSpec("col", maxLength), base, "max length");
+
+    FieldSpec dateTime = parse(FieldType.DATE_TIME, DataType.LONG, null);
+    PropertiesConfiguration otherFormat = configFor(FieldType.DATE_TIME, DataType.LONG, null);
+    otherFormat.setProperty(Column.getKeyFor("col", Column.DATETIME_FORMAT), "1:SECONDS:EPOCH");
+    assertNotSame(ColumnMetadataImpl.extractFieldSpec("col", otherFormat), dateTime, "format");
+    PropertiesConfiguration otherGranularity = configFor(FieldType.DATE_TIME, DataType.LONG, null);
+    otherGranularity.setProperty(Column.getKeyFor("col", Column.DATETIME_GRANULARITY), "1:SECONDS");
+    assertNotSame(ColumnMetadataImpl.extractFieldSpec("col", otherGranularity), dateTime, "granularity");
+  }
+
+  /// [ComplexFieldSpec] does not override equals/hashCode, so two structs with the same name but different children
+  /// are equal under [FieldSpec#equals]; interning the parent would alias them. Only the children are interned.
+  @Test
+  public void complexParentIsNotInternedWhileChildrenAre() {
+    PropertiesConfiguration twoChildren = complexConfig("metrics", "cpu", "host");
+    ComplexFieldSpec first = (ComplexFieldSpec) ColumnMetadataImpl.extractFieldSpec("metrics", twoChildren);
+    ComplexFieldSpec second = (ComplexFieldSpec) ColumnMetadataImpl.extractFieldSpec("metrics", twoChildren);
+    ComplexFieldSpec narrower =
+        (ComplexFieldSpec) ColumnMetadataImpl.extractFieldSpec("metrics", complexConfig("metrics", "cpu"));
+    assertNotSame(second, first);
+    assertNotSame(narrower, first);
+    // The guard is real: the parents are equal despite their different children.
+    assertEquals(narrower, first);
+    assertEquals(first.getChildFieldSpecs().keySet(), Set.of("cpu", "host"));
+    assertEquals(narrower.getChildFieldSpecs().keySet(), Set.of("cpu"));
+    assertSame(second.getChildFieldSpec("cpu"), first.getChildFieldSpec("cpu"));
+    assertSame(second.getChildFieldSpec("host"), first.getChildFieldSpec("host"));
+    assertSame(narrower.getChildFieldSpec("cpu"), first.getChildFieldSpec("cpu"));
+    assertEquals(first.getChildFieldSpec("cpu"),
+        new DimensionFieldSpec(ComplexFieldSpec.getFullChildName("metrics", "cpu"), DataType.DOUBLE, true));
+  }
+
+  /// The interner holds its specs weakly, so a spec is released once the last segment referencing it is unloaded; an
+  /// interner that pinned them would leak one spec per column definition ever loaded.
+  @Test
+  public void unreferencedSpecIsReleased()
+      throws InterruptedException {
+    WeakReference<FieldSpec> spec = internUnreferencedSpec();
+    for (int i = 0; i < 100 && spec.get() != null; i++) {
+      System.gc();
+      Thread.sleep(10);
+    }
+    assertNull(spec.get(), "the interner must not keep an unloaded segment's spec alive");
+  }
+
+  /// Parses a spec no other test builds (a random custom default) and hands back only a weak reference to it.
+  private static WeakReference<FieldSpec> internUnreferencedSpec() {
+    return new WeakReference<>(parse(FieldType.DIMENSION, DataType.STRING, "unreferenced-" + UUID.randomUUID()));
+  }
+
+  /// A COMPLEX parent with DOUBLE children, written the way the segment creator writes it.
+  private static PropertiesConfiguration complexConfig(String parent, String... children) {
+    PropertiesConfiguration config = new PropertiesConfiguration();
+    config.setProperty(Column.getKeyFor(parent, Column.COLUMN_NAME), parent);
+    config.setProperty(Column.getKeyFor(parent, Column.COLUMN_TYPE), FieldType.COMPLEX.name());
+    config.setProperty(Column.getKeyFor(parent, Column.DATA_TYPE), DataType.OPEN_STRUCT.name());
+    config.setProperty(Column.getKeyFor(parent, Column.IS_SINGLE_VALUED), true);
+    config.setProperty(Column.getKeyFor(parent, Column.COMPLEX_CHILD_FIELD_NAMES), List.of(children));
+    for (String child : children) {
+      String column = ComplexFieldSpec.getFullChildName(parent, child);
+      config.setProperty(Column.getKeyFor(column, Column.COLUMN_TYPE), FieldType.DIMENSION.name());
+      config.setProperty(Column.getKeyFor(column, Column.DATA_TYPE), DataType.DOUBLE.name());
+      config.setProperty(Column.getKeyFor(column, Column.IS_SINGLE_VALUED), true);
+    }
+    return config;
   }
 
   private static FieldSpec parse(FieldType fieldType, DataType dataType, @Nullable String defaultNullValue) {


### PR DESCRIPTION
> Superseded by #19473, which now includes the weak FieldSpec interner together with canonical defaults and interned metadata strings. The retained stack continues from #19475 directly to #19477. The original description below is preserved for reference.

## What

Every segment of a table parses its own `FieldSpec` per column, and after part 2 those specs are value-identical across segments. `ColumnMetadataImpl` now interns them through a weak interner keyed by `FieldSpec.equals`/`hashCode`, so all segments of a table share one instance per distinct column definition and schema evolution still yields a distinct instance per version. They are held weakly, so unloading the last segment releases them.

`ComplexFieldSpec` parents are not interned (no value equality); their children are.

Segment-derived specs must therefore be treated as immutable, which is documented on `ColumnMetadata#getFieldSpec()` and `SegmentMetadata#getSchema()`. An audit of all main sources found no caller that mutates one: the virtual-column provider mutates only specs it builds itself.

## Tests

`ColumnMetadataImplTest`: equal configurations parsed twice share one instance; differing default value, max length, data type, single-value or format do not alias; COMPLEX parents are not interned while children are; an unreferenced spec is released after GC.
## Why

A server keeps one metadata object graph per (segment, column) for as long as the segment is loaded, so on wide tables the per-column footprint decides how many segments a server can hold. Measured end to end on a 1000-column segment, this series takes the heap retained at load from **4.08 MB to 0.175 MB per segment** (4,080 to 174 bytes per column), with a fully compacting collector on both sides. No on-disk format change, the `/tables/{table}/segments/{segment}/metadata` JSON stays byte-identical, and every public and SPI signature keeps working.

## Stack

Part 5 of 9, based on #19475. Review only this part's own commits; the earlier parts account for the rest of the diff.

1. #19480 lazy index-size storage
2. #19473 canonical default-null values and interned per-column strings
3. #19474 delegating immutable DataSourceMetadata
4. #19475 presence-mask index container
5. #19476 weak FieldSpec interner
6. #19477 opt-in lazy column materialization
7. #19478 slim ColumnMetadataImpl and lazy per-segment Schema
8. #19479 primitive numeric min/max
9. #19481 sorted-array column metadata store
