### PR TITLE
Use plain component names for the MultiValueLimit record

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -828,13 +828,13 @@ public class MutableSegmentImpl implements MutableSegment {
   /// @throws IllegalStateException if a multi-value column exceeds its maximum number of values
   private void validateNumMultiValues(GenericRow row) {
     for (MultiValueLimit limit : _multiValueLimits) {
-      Object value = row.getValue(limit._column);
+      Object value = row.getValue(limit.column());
       if (value != null) {
         int numValues = ((Object[]) value).length;
-        if (numValues > limit._maxNumMultiValues) {
+        if (numValues > limit.maxNumMultiValues()) {
           throw new IllegalStateException(
               String.format("Number of values: %d in MV column: %s exceeds the maximum allowed: %d", numValues,
-                  limit._column, limit._maxNumMultiValues));
+                  limit.column(), limit.maxNumMultiValues()));
         }
       }
     }
@@ -1688,7 +1688,7 @@ public class MutableSegmentImpl implements MutableSegment {
   }
 
   /// Per-column cap on the number of values in a multi-value entry, as configured on the mutable index context.
-  private record MultiValueLimit(String _column, int _maxNumMultiValues) {
+  private record MultiValueLimit(String column, int maxNumMultiValues) {
   }
 
   private class IndexContainer implements Closeable {


### PR DESCRIPTION
## Summary

`MultiValueLimit` in `MutableSegmentImpl` declares its record components with the `_` field prefix, so its generated accessors are `_column()` and `_maxNumMultiValues()`, and its call sites read the backing fields directly (`limit._column`).

A record component names the generated accessor, which makes it API rather than private member state. The `_` prefix exists for the latter — checkstyle's `MemberName` mandates `^_[a-z][a-zA-Z0-9]*$` for member variables, but record components are `RECORD_COMPONENT_DEF` and fall outside that check, which is why the prefixed form passes silently. Semantically they are closer to the canonical constructor's parameters, and `ParameterName` requires plain camelCase there. Every other record in the codebase uses plain names.

This renames the components to `column` and `maxNumMultiValues` and reads them through the accessors instead of the fields.

No behavior change. The record is `private` to `MutableSegmentImpl`, its components were read in exactly one method (`validateNumMultiValues`), and no other file references them — the identically named `_maxNumMultiValues` fields in `MutableIndexContext` and `FixedByteMVMutableForwardIndex` are genuine private members and are untouched.
