### PR TITLE
Use immutable outputs for same-name minion metadata pushes

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
@@ -45,6 +45,7 @@ import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.api.resources.ResourceUtils;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.segment.local.utils.SegmentReplacementUtils;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
@@ -81,6 +82,9 @@ public class ZKOperator {
     String segmentName = segmentMetadata.getName();
     boolean refreshOnly =
         Boolean.parseBoolean(headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.REFRESH_ONLY));
+    checkReplacementRegistration(tableNameWithType, segmentName, uploadType, sourceDownloadURIStr,
+        segmentDownloadURIStr, finalSegmentLocationURI, enableParallelPushProtection, headers);
+
 
     ZNRecord existingSegmentMetadataZNRecord =
         _pinotHelixResourceManager.getSegmentMetadataZnRecord(tableNameWithType, segmentName);
@@ -134,6 +138,9 @@ public class ZKOperator {
     for (SegmentUploadMetadata segmentUploadMetadata: segmentUploadMetadataList) {
       SegmentMetadata segmentMetadata = segmentUploadMetadata.getSegmentMetadata();
       String segmentName = segmentMetadata.getName();
+      checkReplacementRegistration(tableNameWithType, segmentName, uploadType,
+          segmentUploadMetadata.getSourceDownloadURIStr(), segmentUploadMetadata.getSegmentDownloadURIStr(),
+          segmentUploadMetadata.getFinalSegmentLocationURI(), enableParallelPushProtection, headers);
 
       ZNRecord existingSegmentMetadataZNRecord =
           _pinotHelixResourceManager.getSegmentMetadataZnRecord(tableNameWithType, segmentName);
@@ -293,6 +300,10 @@ public class ZKOperator {
     segmentZKMetadata.setSegmentUploadStartTime(-1);
 
     try {
+      // Recheck after acquiring the existing upload lock. Collection retains candidates while this lock is held,
+      // covering a controller pause between this deadline check and the versioned metadata update.
+      checkReplacementRegistration(tableNameWithType, segmentName, uploadType, sourceDownloadURIStr,
+          segmentDownloadURIStr, finalSegmentLocationURI, enableParallelPushProtection, headers);
       // Construct the segment ZK metadata custom map modifier
       String customMapModifierStr =
           headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER);
@@ -399,6 +410,33 @@ public class ZKOperator {
       processExistingSegment(tableConfig, segmentMetadata, uploadType, existingSegmentMetadataZNRecord,
           finalSegmentLocationURI, segmentFile, sourceDownloadURIStr, segmentDownloadURIStr, crypterName,
           segmentSizeInBytes, enableParallelPushProtection, headers);
+    }
+  }
+
+  /// Managed replacements have a finite registration window. Enforce it in both single and batch paths, and require
+  /// the existing refresh guards/upload lock so expired objects cannot be registered after collection has begun.
+  private void checkReplacementRegistration(String tableNameWithType, String segmentName, FileUploadType uploadType,
+      String sourceUri, String downloadUri, URI finalLocation, boolean parallelPushProtection, HttpHeaders headers) {
+    Long deadline;
+    try {
+      deadline = SegmentReplacementUtils.registrationDeadline(sourceUri, tableNameWithType, segmentName);
+    } catch (RuntimeException e) {
+      throw new ControllerApplicationException(LOGGER, "Invalid replacement URI: " + sourceUri,
+          Response.Status.BAD_REQUEST, e);
+    }
+    if (deadline == null) {
+      return;
+    }
+    if (uploadType != FileUploadType.METADATA || finalLocation != null || !sourceUri.equals(downloadUri)
+        || !parallelPushProtection || headers.getHeaderString(HttpHeaders.IF_MATCH) == null
+        || !Boolean.parseBoolean(headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.REFRESH_ONLY))) {
+      throw new ControllerApplicationException(LOGGER,
+          "Managed replacement requires direct METADATA push, If-Match, REFRESH_ONLY and parallel push protection",
+          Response.Status.BAD_REQUEST);
+    }
+    if (System.currentTimeMillis() >= deadline) {
+      throw new ControllerApplicationException(LOGGER, "Replacement upload expired; retry with a fresh output URI",
+          Response.Status.GONE);
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentValidationManager.java
@@ -34,6 +34,7 @@ import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTask;
 import org.apache.pinot.controller.util.SegmentIntervalUtils;
+import org.apache.pinot.segment.local.utils.SegmentReplacementUtils;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -56,6 +57,7 @@ public class OfflineSegmentValidationManager extends ControllerPeriodicTask<Offl
   private final boolean _segmentAutoResetOnErrorAtValidation;
   private final ResourceUtilizationManager _resourceUtilizationManager;
   private final int _segmentLevelValidationIntervalInSeconds;
+  private final String _dataDir;
   // Legacy frequency setting maintained for backward compatibility
   private final int _offlineSegmentIntervalCheckerFrequencyInSeconds;
   private long _lastSegmentLevelValidationRunTimeMs = 0L;
@@ -70,6 +72,7 @@ public class OfflineSegmentValidationManager extends ControllerPeriodicTask<Offl
     _segmentAutoResetOnErrorAtValidation = config.isAutoResetErrorSegmentsOnValidationEnabled();
     _resourceUtilizationManager = resourceUtilizationManager;
     _segmentLevelValidationIntervalInSeconds = config.getSegmentLevelValidationIntervalInSeconds();
+    _dataDir = config.getDataDir();
     _offlineSegmentIntervalCheckerFrequencyInSeconds = config.getOfflineSegmentIntervalCheckerFrequencyInSeconds();
   }
 
@@ -132,6 +135,8 @@ public class OfflineSegmentValidationManager extends ControllerPeriodicTask<Offl
   private void validateOfflineSegmentPush(TableConfig tableConfig) {
     String offlineTableName = tableConfig.getTableName();
     List<SegmentZKMetadata> segmentsZKMetadata = _pinotHelixResourceManager.getSegmentsZKMetadata(offlineTableName);
+    // Reuse this already-required snapshot; cleanup must not trigger another metadata read.
+    SegmentReplacementUtils.cleanup(_dataDir, offlineTableName, segmentsZKMetadata);
 
     // Compute the missing segments if there are at least two segments and the table has time column
     int numMissingSegments = 0;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -39,6 +39,7 @@ import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTask;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
+import org.apache.pinot.segment.local.utils.SegmentReplacementUtils;
 import org.apache.pinot.spi.config.table.DisasterRecoveryMode;
 import org.apache.pinot.spi.config.table.PauseState;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -65,6 +66,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
   private final StorageQuotaChecker _storageQuotaChecker;
   private final ResourceUtilizationManager _resourceUtilizationManager;
   private final int _segmentLevelValidationIntervalInSeconds;
+  private final String _dataDir;
   private final boolean _segmentAutoResetOnErrorAtValidation;
 
   private long _lastSegmentLevelValidationRunTimeMs = 0L;
@@ -85,6 +87,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     _resourceUtilizationManager = resourceUtilizationManager;
 
     _segmentLevelValidationIntervalInSeconds = config.getSegmentLevelValidationIntervalInSeconds();
+    _dataDir = config.getDataDir();
     _segmentAutoResetOnErrorAtValidation = config.isAutoResetErrorSegmentsOnValidationEnabled();
     _disasterRecoveryMode = config.getDisasterRecoveryMode();
     Preconditions.checkState(_segmentLevelValidationIntervalInSeconds > 0);
@@ -217,6 +220,8 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     String realtimeTableName = tableConfig.getTableName();
 
     List<SegmentZKMetadata> segmentsZKMetadata = _pinotHelixResourceManager.getSegmentsZKMetadata(realtimeTableName);
+    // Reuse this already-required snapshot; cleanup must not trigger another metadata read.
+    SegmentReplacementUtils.cleanup(_dataDir, realtimeTableName, segmentsZKMetadata);
 
     // Delete tmp segments
     if (_llcRealtimeSegmentManager.isTmpSegmentAsyncDeletionEnabled()) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/ZKOperatorReplacementTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/ZKOperatorReplacementTest.java
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.upload;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.common.utils.FileUploadDownloadClient.FileUploadType;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.exception.ControllerApplicationException;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.segment.local.utils.SegmentReplacementUtils;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.mockito.MockedStatic;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+
+/// Managed replacement registration must expire without introducing metadata reads or upload locks of its own.
+public class ZKOperatorReplacementTest {
+  private static final String TABLE = "test_OFFLINE";
+  private static final String SEGMENT = "segment";
+  private static final TableConfig CONFIG = new TableConfigBuilder(TableType.OFFLINE).setTableName("test").build();
+
+  @DataProvider
+  public Object[][] batchModes() {
+    return new Object[][]{{false}, {true}};
+  }
+
+  @Test(dataProvider = "batchModes")
+  public void testExpiredUploadRejectedBeforeMetadataRead(boolean batch) throws Exception {
+    PinotHelixResourceManager manager = mock(PinotHelixResourceManager.class);
+    String uri = uri(1);
+    ControllerApplicationException failure = expectThrows(ControllerApplicationException.class,
+        () -> push(manager, uri, headers(), true, batch));
+    assertEquals(failure.getResponse().getStatus(), Response.Status.GONE.getStatusCode());
+    verifyNoInteractions(manager);
+  }
+
+  @Test
+  public void testManagedUploadRequiresExistingLockAndRefreshGuards() throws Exception {
+    PinotHelixResourceManager manager = mock(PinotHelixResourceManager.class);
+    String uri = uri(System.currentTimeMillis() + 100_000);
+    ControllerApplicationException failure = expectThrows(ControllerApplicationException.class,
+        () -> push(manager, uri, headers(), false, false));
+    assertEquals(failure.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+    HttpHeaders missingGuard = headers();
+    when(missingGuard.getHeaderString(HttpHeaders.IF_MATCH)).thenReturn(null);
+    expectThrows(ControllerApplicationException.class, () -> push(manager, uri, missingGuard, true, false));
+    verifyNoInteractions(manager);
+  }
+
+  @Test(dataProvider = "batchModes")
+  public void testSameCrcReplacementUpdatesUrlUsingExistingMetadataOperations(boolean batch) throws Exception {
+    PinotHelixResourceManager manager = existingSegment();
+    List<SegmentZKMetadata> updates = captureUpdates(manager);
+    String uri = uri(System.currentTimeMillis() + 100_000);
+    push(manager, uri, headers(), true, batch);
+    assertEquals(updates.size(), 2, "Reuse the existing lock and metadata-update writes");
+    assertEquals(updates.get(0).getDownloadUrl(), "s3://original/segment");
+    assertTrue(updates.get(0).getSegmentUploadStartTime() > 0);
+    assertEquals(updates.get(1).getDownloadUrl(), uri);
+    assertEquals(updates.get(1).getCrc(), 100);
+    assertEquals(updates.get(1).getSegmentUploadStartTime(), -1);
+    verify(manager).getSegmentMetadataZnRecord(TABLE, SEGMENT);
+    verify(manager, never()).getSegmentsZKMetadata(anyString());
+  }
+
+  @Test
+  public void testExpiryAfterLockReleasesLockWithoutChangingUrl() throws Exception {
+    PinotHelixResourceManager manager = existingSegment();
+    List<SegmentZKMetadata> updates = captureUpdates(manager);
+    String uri = uri(System.currentTimeMillis() + 100_000);
+    try (MockedStatic<SegmentReplacementUtils> utils = mockStatic(SegmentReplacementUtils.class)) {
+      utils.when(() -> SegmentReplacementUtils.registrationDeadline(uri, TABLE, SEGMENT))
+          .thenReturn(System.currentTimeMillis() + 100_000, 1L);
+      ControllerApplicationException failure = expectThrows(ControllerApplicationException.class,
+          () -> push(manager, uri, headers(), true, false));
+      assertEquals(failure.getResponse().getStatus(), Response.Status.GONE.getStatusCode());
+    }
+    assertEquals(updates.size(), 2);
+    assertEquals(updates.get(1).getDownloadUrl(), "s3://original/segment");
+    assertEquals(updates.get(1).getSegmentUploadStartTime(), -1);
+  }
+
+  private static String uri(long deadline) {
+    return SegmentReplacementUtils.outputRoot(URI.create("s3://bucket/table"), TABLE)
+        + Long.toString(deadline) + "/" + UUID.randomUUID() + "/" + SEGMENT + ".tar.gz";
+  }
+
+  private static HttpHeaders headers() {
+    HttpHeaders headers = mock(HttpHeaders.class);
+    when(headers.getHeaderString(HttpHeaders.IF_MATCH)).thenReturn("100");
+    when(headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.REFRESH_ONLY)).thenReturn("true");
+    return headers;
+  }
+
+  private static PinotHelixResourceManager existingSegment() {
+    PinotHelixResourceManager manager = mock(PinotHelixResourceManager.class);
+    SegmentZKMetadata current = new SegmentZKMetadata(SEGMENT);
+    current.setCrc(100);
+    current.setDownloadUrl("s3://original/segment");
+    when(manager.getSegmentMetadataZnRecord(TABLE, SEGMENT)).thenReturn(current.toZNRecord());
+    IdealState idealState = mock(IdealState.class);
+    when(idealState.getInstanceStateMap(SEGMENT)).thenReturn(Map.of("server", "ONLINE"));
+    when(manager.getTableIdealState(TABLE)).thenReturn(idealState);
+    return manager;
+  }
+
+  private static List<SegmentZKMetadata> captureUpdates(PinotHelixResourceManager manager) {
+    List<SegmentZKMetadata> updates = new ArrayList<>();
+    when(manager.updateZkMetadata(eq(TABLE), any(), anyInt())).thenAnswer(i -> {
+      SegmentZKMetadata metadata = i.getArgument(1);
+      updates.add(new SegmentZKMetadata(new ZNRecord(metadata.toZNRecord())));
+      return true;
+    });
+    return updates;
+  }
+
+  private static void push(PinotHelixResourceManager manager, String uri, HttpHeaders headers, boolean parallel,
+      boolean batch) throws Exception {
+    SegmentMetadata metadata = mock(SegmentMetadata.class);
+    when(metadata.getName()).thenReturn(SEGMENT);
+    when(metadata.getCrc()).thenReturn("100");
+    ZKOperator operator = new ZKOperator(manager, new ControllerConf(), mock(ControllerMetrics.class));
+    if (batch) {
+      SegmentUploadMetadata upload = new SegmentUploadMetadata(uri, uri, null, 10L, metadata, Pair.of(null, null));
+      operator.completeSegmentsOperations(CONFIG, FileUploadType.METADATA, parallel, true, headers, List.of(upload));
+    } else {
+      operator.completeSegmentOperations(CONFIG, metadata, FileUploadType.METADATA, null, null, uri, uri, null, 10,
+          parallel, true, headers);
+    }
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/SegmentReplacementValidationTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/SegmentReplacementValidationTest.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.validation;
+
+import java.util.List;
+import java.util.Properties;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.metrics.ValidationMetrics;
+import org.apache.pinot.common.restlet.resources.PauseStatusDetails;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
+import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
+import org.apache.pinot.segment.local.utils.SegmentReplacementUtils;
+import org.apache.pinot.spi.config.table.PauseState;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.mockito.MockedStatic;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.expectThrows;
+
+
+/// Replacement collection must reuse the metadata already fetched for validation, including failures and empty tables.
+public class SegmentReplacementValidationTest {
+  @DataProvider
+  public Object[][] tableTypes() {
+    return new Object[][]{{TableType.OFFLINE}, {TableType.REALTIME}};
+  }
+
+  @Test(dataProvider = "tableTypes")
+  public void testCleanupReusesValidationSnapshot(TableType type) {
+    checkValidation(type, false);
+  }
+
+  @Test(dataProvider = "tableTypes")
+  public void testFailedMetadataReadDoesNotRunCleanup(TableType type) {
+    checkValidation(type, true);
+  }
+
+  private void checkValidation(TableType type, boolean failRead) {
+    String tableName = "test_" + type;
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    ControllerConf config = new ControllerConf();
+    config.setDataDir("s3://controller/deep-store");
+    TableConfigBuilder builder = new TableConfigBuilder(type).setTableName("test");
+    if (type == TableType.REALTIME) {
+      builder.setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap());
+    }
+    TableConfig table = builder.build();
+    when(resourceManager.getTableConfig(tableName)).thenReturn(table);
+    List<SegmentZKMetadata> snapshot = List.of();
+    if (failRead) {
+      when(resourceManager.getSegmentsZKMetadata(tableName))
+          .thenThrow(new IllegalStateException("metadata unavailable"));
+    } else {
+      when(resourceManager.getSegmentsZKMetadata(tableName)).thenReturn(snapshot);
+    }
+    Runnable validate;
+    if (type == TableType.OFFLINE) {
+      OfflineSegmentValidationManager manager = new OfflineSegmentValidationManager(config, resourceManager, null,
+          mock(ValidationMetrics.class), mock(ControllerMetrics.class), mock(ResourceUtilizationManager.class));
+      validate = () -> manager.processTable(tableName, manager.preprocess(new Properties()));
+    } else {
+      PinotLLCRealtimeSegmentManager llcManager = mock(PinotLLCRealtimeSegmentManager.class);
+      when(llcManager.getPauseStatusDetails(tableName))
+          .thenReturn(new PauseStatusDetails(true, null, PauseState.ReasonCode.ADMINISTRATIVE, null, null));
+      RealtimeSegmentValidationManager manager = new RealtimeSegmentValidationManager(config, resourceManager, null,
+          llcManager, mock(ValidationMetrics.class), mock(ControllerMetrics.class), mock(StorageQuotaChecker.class),
+          mock(ResourceUtilizationManager.class));
+      validate = () -> manager.processTable(tableName, manager.preprocess(new Properties()));
+    }
+    try (MockedStatic<SegmentReplacementUtils> cleanup = mockStatic(SegmentReplacementUtils.class)) {
+      if (failRead) {
+        expectThrows(IllegalStateException.class, validate::run);
+        cleanup.verifyNoInteractions();
+      } else {
+        validate.run();
+        cleanup.verify(() -> SegmentReplacementUtils.cleanup(config.getDataDir(), tableName, snapshot));
+      }
+      verify(resourceManager).getSegmentsZKMetadata(tableName);
+      verify(resourceManager, never()).getSegmentZKMetadata(anyString(), anyString());
+    }
+  }
+}

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.NameValuePair;
@@ -36,6 +37,7 @@ import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifi
 import org.apache.pinot.common.metrics.MinionMeter;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.TarCompressionUtils;
+import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.minion.event.MinionEventObserver;
@@ -43,6 +45,7 @@ import org.apache.pinot.minion.event.MinionEventObservers;
 import org.apache.pinot.minion.exception.TaskCancelledException;
 import org.apache.pinot.plugin.minion.tasks.purge.PurgeTaskExecutor;
 import org.apache.pinot.segment.local.utils.SegmentPushUtils;
+import org.apache.pinot.segment.local.utils.SegmentReplacementUtils;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.filesystem.PinotFS;
@@ -200,7 +203,7 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
                 uploadURL, convertedTarredSegmentFile);
             break;
           case METADATA:
-            uploadSegmentWithMetadata(configs, pinotTaskConfig, segmentConversionResult, authProvider, parameters,
+            uploadSegmentWithMetadata(configs, httpHeaders, parameters,
                 tableNameWithType, convertedTarredSegmentFile);
             break;
           default:
@@ -227,8 +230,8 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
   /// Pushes the segment in METADATA (or URI) mode: copies the tarred segment to the output PinotFS and sends segment
   /// URI and metadata to the controller. Requires [BatchConfigProperties#OUTPUT_SEGMENT_DIR_URI] and
   /// [BatchConfigProperties#PUSH_CONTROLLER_URI] in configs.
-  private void uploadSegmentWithMetadata(Map<String, String> configs, PinotTaskConfig pinotTaskConfig,
-      SegmentConversionResult segmentConversionResult, AuthProvider authProvider, List<NameValuePair> parameters,
+  private void uploadSegmentWithMetadata(Map<String, String> configs, List<Header> httpHeaders,
+      List<NameValuePair> parameters,
       String tableNameWithType, File convertedTarredSegmentFile)
       throws Exception {
     if (!configs.containsKey(BatchConfigProperties.OUTPUT_SEGMENT_DIR_URI)) {
@@ -243,36 +246,45 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
     SegmentGenerationJobSpec spec = generateSegmentGenerationJobSpec(
         TableNameBuilder.extractRawTableName(tableNameWithType), configs, pushJobSpec);
 
-    List<Header> metadataHeaders = getSegmentPushMetadataHeaders(pinotTaskConfig, authProvider,
-        segmentConversionResult);
-
+    // The TAR and metadata paths must use the same If-Match, REFRESH_ONLY, custom-map and authentication headers.
     try (PinotFS outputFileFS = MinionTaskUtils.getOutputPinotFS(configs, outputSegmentDirURI)) {
       Map<String, String> segmentUriToTarPathMap = SegmentPushUtils.getSegmentUriToTarPathMap(outputSegmentDirURI,
           pushJobSpec, new String[]{outputSegmentTarURI.toString()});
+      // An exception can follow successful registration (e.g. a lost response). Preserve the immutable output;
+      // controller validation collects it after it becomes obsolete. A retry always uses a fresh output URI.
+      SegmentPushUtils.sendSegmentUriAndMetadata(spec, outputFileFS, segmentUriToTarPathMap, httpHeaders, parameters);
+    }
+  }
+
+  @Override
+  protected URI moveSegmentToOutputPinotFS(Map<String, String> configs, File localSegmentTarFile) throws Exception {
+    Preconditions.checkState(StringUtils.isEmpty(configs.get(BatchConfigProperties.PUSH_SEGMENT_URI_PREFIX))
+            && StringUtils.isEmpty(configs.get(BatchConfigProperties.PUSH_SEGMENT_URI_SUFFIX)),
+        "Same-name metadata replacement requires physical output URIs without push URI prefix/suffix remapping");
+    String references = configs.get(SegmentReplacementUtils.ROOT_REFERENCES_CONFIG_KEY);
+    Preconditions.checkState(references != null,
+        "Missing replacement output root registry; regenerate this metadata-push task with the updated controller");
+    URI root = SegmentReplacementUtils.outputRoot(
+        URI.create(configs.get(BatchConfigProperties.OUTPUT_SEGMENT_DIR_URI)),
+        configs.get(MinionConstants.TABLE_NAME_KEY));
+    SegmentReplacementUtils.rememberRoot(URI.create(references), root);
+    long registrationDeadline = System.currentTimeMillis() + SegmentReplacementUtils.REGISTRATION_WINDOW_MS;
+    URI output = URI.create(root + Long.toString(registrationDeadline) + "/" + UUID.randomUUID()
+        + "/" + URIUtils.encode(localSegmentTarFile.getName()));
+    try (PinotFS fs = MinionTaskUtils.getOutputPinotFS(configs, root)) {
       try {
-        SegmentPushUtils.sendSegmentUriAndMetadata(spec, outputFileFS, segmentUriToTarPathMap, metadataHeaders,
-            parameters);
+        fs.copyFromLocalFile(localSegmentTarFile, output);
       } catch (Exception e) {
-        // The tar was already staged to the output PinotFS before this failure. If the task is retried, the next
-        // moveSegmentToOutputPinotFS() would fail with "Output file already exists" (overwriteOutput defaults to
-        // false), making transient metadata-push failures permanently stuck. Delete the staged tar so the retry can
-        // re-stage it and self-heal.
+        // The fresh URI has not been submitted to the controller, so this partial copy can be removed immediately.
         try {
-          cleanupMetadataPushFailure(outputFileFS, outputSegmentTarURI);
-        } catch (Exception deleteException) {
-          LOGGER.warn("Failed to delete staged segment tar: {} after metadata push failure, the next retry may fail "
-              + "with 'Output file already exists'", outputSegmentTarURI, deleteException);
+          fs.delete(output, false);
+        } catch (Exception cleanupFailure) {
+          e.addSuppressed(cleanupFailure);
         }
         throw e;
       }
     }
-  }
-
-  /// Cleans up an output after metadata push throws. Executors that publish immutable output URIs can defer cleanup
-  /// until they have reconciled controller metadata: a lost response does not prove the controller rejected the push.
-  protected void cleanupMetadataPushFailure(PinotFS outputFileFS, URI outputSegmentTarURI)
-      throws Exception {
-    outputFileFS.delete(outputSegmentTarURI, true);
+    return output;
   }
 
   // For tests only.

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
@@ -258,7 +258,7 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
         // false), making transient metadata-push failures permanently stuck. Delete the staged tar so the retry can
         // re-stage it and self-heal.
         try {
-          outputFileFS.delete(outputSegmentTarURI, true);
+          cleanupMetadataPushFailure(outputFileFS, outputSegmentTarURI);
         } catch (Exception deleteException) {
           LOGGER.warn("Failed to delete staged segment tar: {} after metadata push failure, the next retry may fail "
               + "with 'Output file already exists'", outputSegmentTarURI, deleteException);
@@ -266,6 +266,13 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
         throw e;
       }
     }
+  }
+
+  /// Cleans up an output after metadata push throws. Executors that publish immutable output URIs can defer cleanup
+  /// until they have reconciled controller metadata: a lost response does not prove the controller rejected the push.
+  protected void cleanupMetadataPushFailure(PinotFS outputFileFS, URI outputSegmentTarURI)
+      throws Exception {
+    outputFileFS.delete(outputSegmentTarURI, true);
   }
 
   // For tests only.

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -52,6 +52,7 @@ import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
 import org.apache.pinot.controller.util.ServerSegmentMetadataReader;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.minion.MinionContext;
+import org.apache.pinot.segment.local.utils.SegmentReplacementUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -264,6 +265,13 @@ public class MinionTaskUtils {
 
       singleFileGenerationTaskConfig.put(BatchConfigProperties.PUSH_CONTROLLER_URI,
           clusterInfoAccessor.getVipUrlForLeadController(tableName));
+      // A single-segment replacement records its output root here before uploading, so controller validation can
+      // discover custom roots without new ZK records or reading task history. Other executors ignore this key.
+      if (BatchConfigProperties.SegmentPushType.METADATA.name().equalsIgnoreCase(
+          singleFileGenerationTaskConfig.get(BatchConfigProperties.PUSH_MODE))) {
+        singleFileGenerationTaskConfig.put(SegmentReplacementUtils.ROOT_REFERENCES_CONFIG_KEY,
+            SegmentReplacementUtils.referencesDir(clusterInfoAccessor.getDataDir(), tableName).toString());
+      }
       return singleFileGenerationTaskConfig;
     } catch (Exception e) {
       singleFileGenerationTaskConfig.put(BatchConfigProperties.PUSH_MODE,

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutorTest.java
@@ -20,13 +20,18 @@ package org.apache.pinot.plugin.minion.tasks;
 
 import java.io.File;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.common.metrics.MinionMetrics;
+import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.minion.MinionContext;
@@ -34,6 +39,7 @@ import org.apache.pinot.minion.event.MinionEventObservers;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.local.utils.SegmentPushUtils;
+import org.apache.pinot.segment.local.utils.SegmentReplacementUtils;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -41,16 +47,20 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.filesystem.LocalPinotFS;
 import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
 
 
 /// Tests the [BaseSingleSegmentConversionExecutor#executeTask] upload-failure handling: a segment-upload failure
@@ -76,7 +86,7 @@ public class BaseSingleSegmentConversionExecutorTest {
   public void setUp()
       throws Exception {
     FileUtils.deleteDirectory(TEMP_DIR);
-    MinionMetrics.register(Mockito.mock(MinionMetrics.class));
+    MinionMetrics.register(mock(MinionMetrics.class));
 
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(D1, FieldSpec.DataType.INT).build();
@@ -96,7 +106,7 @@ public class BaseSingleSegmentConversionExecutorTest {
     driver.build();
     _segmentIndexDir = new File(SEGMENT_DIR, SEGMENT_NAME);
 
-    Assert.assertTrue(DATA_DIR.mkdirs());
+    assertTrue(DATA_DIR.mkdirs());
     MinionContext.getInstance().setDataDir(DATA_DIR);
     // executeTask resolves the event observer from the registry by task id; register one so it is non-null.
     MinionEventObservers.getInstance().addMinionEventObserver(TASK_ID, MinionTaskTestUtils.getMinionProgressObserver());
@@ -105,17 +115,17 @@ public class BaseSingleSegmentConversionExecutorTest {
   @Test
   public void testExecuteTaskRethrowsWhenUploadFails()
       throws Exception {
-    try (MockedStatic<SegmentConversionUtils> mocked = Mockito.mockStatic(SegmentConversionUtils.class)) {
-      mocked.when(() -> SegmentConversionUtils.uploadSegment(Mockito.any(), Mockito.any(), Mockito.any(),
-              Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any(File.class)))
+    try (MockedStatic<SegmentConversionUtils> mocked = mockStatic(SegmentConversionUtils.class)) {
+      mocked.when(() -> SegmentConversionUtils.uploadSegment(any(), any(), any(),
+              anyString(), anyString(), anyString(), any(File.class)))
           .thenThrow(new RuntimeException("simulated upload failure"));
 
       TestSingleSegmentConversionExecutor executor = new TestSingleSegmentConversionExecutor();
       try {
         executor.executeTask(createTaskConfig());
-        Assert.fail("executeTask must rethrow when segment upload fails, not report success");
+        fail("executeTask must rethrow when segment upload fails, not report success");
       } catch (RuntimeException e) {
-        Assert.assertEquals(e.getMessage(), "simulated upload failure");
+        assertEquals(e.getMessage(), "simulated upload failure");
       }
     }
   }
@@ -123,14 +133,14 @@ public class BaseSingleSegmentConversionExecutorTest {
   @Test
   public void testExecuteTaskSucceedsWhenUploadSucceeds()
       throws Exception {
-    try (MockedStatic<SegmentConversionUtils> mocked = Mockito.mockStatic(SegmentConversionUtils.class)) {
+    try (MockedStatic<SegmentConversionUtils> mocked = mockStatic(SegmentConversionUtils.class)) {
       // uploadSegment is a no-op by default for the mocked static, simulating a successful upload.
       TestSingleSegmentConversionExecutor executor = new TestSingleSegmentConversionExecutor();
       SegmentConversionResult result = executor.executeTask(createTaskConfig());
-      Assert.assertEquals(result.getSegmentName(), SEGMENT_NAME);
-      Assert.assertEquals(result.getTableNameWithType(), TABLE_NAME_WITH_TYPE);
-      mocked.verify(() -> SegmentConversionUtils.uploadSegment(Mockito.any(), Mockito.any(), Mockito.any(),
-          Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any(File.class)));
+      assertEquals(result.getSegmentName(), SEGMENT_NAME);
+      assertEquals(result.getTableNameWithType(), TABLE_NAME_WITH_TYPE);
+      mocked.verify(() -> SegmentConversionUtils.uploadSegment(any(), any(), any(),
+          anyString(), anyString(), anyString(), any(File.class)));
     }
   }
 
@@ -145,63 +155,122 @@ public class BaseSingleSegmentConversionExecutorTest {
     return new PinotTaskConfig(TASK_TYPE, configs);
   }
 
-  /// Verifies that when a METADATA-mode push fails after the converted tar was already staged to the output PinotFS,
-  /// the staged tar is deleted before the exception propagates. Without this cleanup the rethrow would make the retry
-  /// fail in moveSegmentToOutputPinotFS with "Output file already exists" (overwriteOutput defaults to false), so
-  /// transient push failures would never self-heal.
+  /// A lost response can follow successful registration. Retain the output and propagate the failure.
   @Test
-  public void testExecuteTaskCleansUpStagedTarWhenMetadataPushFails()
+  public void testExecuteTaskKeepsStagedTarWhenMetadataPushFails()
       throws Exception {
     File outputDir = new File(TEMP_DIR, "output");
     FileUtils.forceMkdir(outputDir);
-    PinotFS mockOutputFS = Mockito.mock(PinotFS.class);
-    Mockito.when(mockOutputFS.exists(Mockito.any())).thenReturn(false);
+    PinotFS mockOutputFS = mock(PinotFS.class);
+    when(mockOutputFS.exists(any())).thenReturn(false);
 
     try (MockedStatic<MinionTaskUtils> minionTaskUtils =
-            Mockito.mockStatic(MinionTaskUtils.class, Mockito.CALLS_REAL_METHODS);
+            mockStatic(MinionTaskUtils.class, CALLS_REAL_METHODS);
         MockedStatic<SegmentPushUtils> segmentPushUtils =
-            Mockito.mockStatic(SegmentPushUtils.class, Mockito.CALLS_REAL_METHODS)) {
-      minionTaskUtils.when(() -> MinionTaskUtils.getOutputPinotFS(Mockito.any(), Mockito.any()))
+            mockStatic(SegmentPushUtils.class, CALLS_REAL_METHODS);
+        MockedStatic<PinotFSFactory> factory = mockStatic(PinotFSFactory.class)) {
+      factory.when(() -> PinotFSFactory.create("file")).thenAnswer(i -> new LocalPinotFS());
+      minionTaskUtils.when(() -> MinionTaskUtils.getOutputPinotFS(any(), any()))
           .thenReturn(mockOutputFS);
-      segmentPushUtils.when(() -> SegmentPushUtils.sendSegmentUriAndMetadata(Mockito.any(), Mockito.any(),
-              Mockito.any(), Mockito.anyList(), Mockito.anyList()))
+      segmentPushUtils.when(() -> SegmentPushUtils.sendSegmentUriAndMetadata(any(), any(),
+              any(), anyList(), anyList()))
           .thenThrow(new RuntimeException("simulated metadata push failure"));
 
       TestSingleSegmentConversionExecutor executor = new TestSingleSegmentConversionExecutor();
       try {
         executor.executeTask(createMetadataPushTaskConfig(outputDir));
-        Assert.fail("executeTask must rethrow when metadata push fails");
+        fail("executeTask must rethrow when metadata push fails");
       } catch (RuntimeException e) {
-        Assert.assertEquals(e.getMessage(), "simulated metadata push failure");
+        assertEquals(e.getMessage(), "simulated metadata push failure");
       }
-      // The staged tar must be deleted so a retry can re-stage it and self-heal.
-      Mockito.verify(mockOutputFS).delete(Mockito.any(URI.class), Mockito.eq(true));
+      verify(mockOutputFS, never()).delete(any(URI.class), anyBoolean());
+      assertEquals(new File(DATA_DIR, TASK_TYPE).list().length, 0, "Local task files are still cleaned in finally");
     }
   }
 
   @Test
-  public void testMetadataPushFailureCleanupCanBeDeferred()
-      throws Exception {
-    PinotFS outputFS = Mockito.mock(PinotFS.class);
-    try (MockedStatic<MinionTaskUtils> minionTaskUtils =
-            Mockito.mockStatic(MinionTaskUtils.class, Mockito.CALLS_REAL_METHODS);
-        MockedStatic<SegmentPushUtils> segmentPushUtils =
-            Mockito.mockStatic(SegmentPushUtils.class, Mockito.CALLS_REAL_METHODS)) {
-      minionTaskUtils.when(() -> MinionTaskUtils.getOutputPinotFS(Mockito.any(), Mockito.any()))
-          .thenReturn(outputFS);
-      segmentPushUtils.when(() -> SegmentPushUtils.sendSegmentUriAndMetadata(Mockito.any(), Mockito.any(),
-              Mockito.any(), Mockito.anyList(), Mockito.anyList()))
-          .thenThrow(new RuntimeException("response lost after registration"));
-      TestSingleSegmentConversionExecutor executor = new TestSingleSegmentConversionExecutor() {
-        @Override
-        protected void cleanupMetadataPushFailure(PinotFS outputFileFS, URI outputSegmentTarURI) {
-          // Immutable outputs are reconciled by this executor's task generator.
-        }
-      };
-      RuntimeException failure = Assert.expectThrows(RuntimeException.class,
-          () -> executor.executeTask(createMetadataPushTaskConfig(new File(TEMP_DIR, "immutable-output"))));
-      Assert.assertEquals(failure.getMessage(), "response lost after registration");
-      Mockito.verify(outputFS, Mockito.never()).delete(Mockito.any(), Mockito.anyBoolean());
+  public void testMetadataPushKeepsReplacementHeaders() throws Exception {
+    PinotFS outputFS = mock(PinotFS.class);
+    try (MockedStatic<MinionTaskUtils> utils = mockStatic(MinionTaskUtils.class, CALLS_REAL_METHODS);
+        MockedStatic<SegmentPushUtils> push = mockStatic(SegmentPushUtils.class, CALLS_REAL_METHODS);
+        MockedStatic<PinotFSFactory> factory = mockStatic(PinotFSFactory.class)) {
+      factory.when(() -> PinotFSFactory.create("file")).thenAnswer(i -> new LocalPinotFS());
+      utils.when(() -> MinionTaskUtils.getOutputPinotFS(anyMap(), any())).thenReturn(outputFS);
+      push.when(() -> SegmentPushUtils.sendSegmentUriAndMetadata(any(), any(), any(), anyList(), anyList()))
+          .thenAnswer(i -> null);
+      TestSingleSegmentConversionExecutor executor = new TestSingleSegmentConversionExecutor();
+      executor.executeTask(createMetadataPushTaskConfig(new File(TEMP_DIR, "headers")));
+      ArgumentCaptor<List<Header>> headers = ArgumentCaptor.forClass(List.class);
+      push.verify(() -> SegmentPushUtils.sendSegmentUriAndMetadata(any(), any(), any(),
+          headers.capture(), anyList()));
+      assertTrue(headers.getValue().stream().anyMatch(h -> HttpHeaders.IF_MATCH.equals(h.getName())
+          && Long.toString(SEGMENT_CRC).equals(h.getValue())));
+      assertTrue(headers.getValue().stream().anyMatch(h ->
+          FileUploadDownloadClient.CustomHeaders.REFRESH_ONLY.equals(h.getName()) && "true".equals(h.getValue())));
+      assertTrue(headers.getValue().stream().anyMatch(h ->
+          FileUploadDownloadClient.CustomHeaders.SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER.equals(h.getName())));
+    }
+  }
+
+  @Test
+  public void testRetriesNeverOverwriteExistingSegment() throws Exception {
+    File original = new File(TEMP_DIR, "immutable/" + SEGMENT_NAME + ".tar.gz");
+    File tar = new File(TEMP_DIR, "local/" + SEGMENT_NAME + ".tar.gz");
+    FileUtils.writeStringToFile(original, "original", StandardCharsets.UTF_8);
+    FileUtils.writeStringToFile(tar, "replacement", StandardCharsets.UTF_8);
+    Map<String, String> configs = createMetadataPushTaskConfig(original.getParentFile()).getConfigs();
+    configs.put(BatchConfigProperties.OVERWRITE_OUTPUT, "true");
+    try (MockedStatic<PinotFSFactory> factory = mockStatic(PinotFSFactory.class)) {
+      factory.when(() -> PinotFSFactory.create("file")).thenAnswer(i -> new LocalPinotFS());
+      TestSingleSegmentConversionExecutor executor = new TestSingleSegmentConversionExecutor();
+      URI first = executor.moveSegmentToOutputPinotFS(configs, tar);
+      URI retry = executor.moveSegmentToOutputPinotFS(configs, tar);
+      assertNotEquals(first, retry);
+      assertEquals(Files.readString(original.toPath()), "original");
+      assertEquals(Files.readString(new File(first).toPath()), "replacement");
+      assertEquals(Files.readString(new File(retry).toPath()), "replacement");
+    }
+  }
+
+  @Test
+  public void testPartialCopyIsRemovedBeforeSubmission() throws Exception {
+    PinotFS outputFS = mock(PinotFS.class);
+    doThrow(new RuntimeException("partial copy")).when(outputFS).copyFromLocalFile(any(), any());
+    try (MockedStatic<PinotFSFactory> factory = mockStatic(PinotFSFactory.class);
+        MockedStatic<MinionTaskUtils> utils = mockStatic(MinionTaskUtils.class, CALLS_REAL_METHODS)) {
+      factory.when(() -> PinotFSFactory.create("file")).thenAnswer(i -> new LocalPinotFS());
+      utils.when(() -> MinionTaskUtils.getOutputPinotFS(anyMap(), any())).thenReturn(outputFS);
+      TestSingleSegmentConversionExecutor executor = new TestSingleSegmentConversionExecutor();
+      expectThrows(RuntimeException.class, () -> executor.moveSegmentToOutputPinotFS(
+          createMetadataPushTaskConfig(new File(TEMP_DIR, "partial")).getConfigs(), new File("segment.tar.gz")));
+      ArgumentCaptor<URI> output = ArgumentCaptor.forClass(URI.class);
+      verify(outputFS).copyFromLocalFile(any(), output.capture());
+      verify(outputFS).delete(output.getValue(), false);
+    }
+  }
+
+  @Test
+  public void testOldMetadataTaskWithoutRegistryFailsBeforeWriting() throws Exception {
+    Map<String, String> configs = createMetadataPushTaskConfig(new File(TEMP_DIR, "old-task")).getConfigs();
+    configs.remove(SegmentReplacementUtils.ROOT_REFERENCES_CONFIG_KEY);
+    TestSingleSegmentConversionExecutor executor = new TestSingleSegmentConversionExecutor();
+    try (MockedStatic<PinotFSFactory> factory = mockStatic(PinotFSFactory.class)) {
+      IllegalStateException failure = expectThrows(IllegalStateException.class,
+          () -> executor.moveSegmentToOutputPinotFS(configs, new File("segment.tar.gz")));
+      assertTrue(failure.getMessage().contains("regenerate"));
+      factory.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  public void testUriAliasesCannotHideCleanupOwnership() throws Exception {
+    Map<String, String> configs = createMetadataPushTaskConfig(new File(TEMP_DIR, "alias")).getConfigs();
+    configs.put(BatchConfigProperties.PUSH_SEGMENT_URI_PREFIX, "https://alias/");
+    TestSingleSegmentConversionExecutor executor = new TestSingleSegmentConversionExecutor();
+    try (MockedStatic<PinotFSFactory> factory = mockStatic(PinotFSFactory.class)) {
+      expectThrows(IllegalStateException.class,
+          () -> executor.moveSegmentToOutputPinotFS(configs, new File("segment.tar.gz")));
+      factory.verifyNoInteractions();
     }
   }
 
@@ -215,6 +284,8 @@ public class BaseSingleSegmentConversionExecutorTest {
     configs.put("TASK_ID", TASK_ID);
     configs.put(BatchConfigProperties.PUSH_MODE, BatchConfigProperties.SegmentPushType.METADATA.name());
     configs.put(BatchConfigProperties.OUTPUT_SEGMENT_DIR_URI, outputDir.toURI().toString());
+    configs.put(SegmentReplacementUtils.ROOT_REFERENCES_CONFIG_KEY,
+        new File(TEMP_DIR, "references").toURI().toString());
     return new PinotTaskConfig(TASK_TYPE, configs);
   }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutorTest.java
@@ -179,6 +179,32 @@ public class BaseSingleSegmentConversionExecutorTest {
     }
   }
 
+  @Test
+  public void testMetadataPushFailureCleanupCanBeDeferred()
+      throws Exception {
+    PinotFS outputFS = Mockito.mock(PinotFS.class);
+    try (MockedStatic<MinionTaskUtils> minionTaskUtils =
+            Mockito.mockStatic(MinionTaskUtils.class, Mockito.CALLS_REAL_METHODS);
+        MockedStatic<SegmentPushUtils> segmentPushUtils =
+            Mockito.mockStatic(SegmentPushUtils.class, Mockito.CALLS_REAL_METHODS)) {
+      minionTaskUtils.when(() -> MinionTaskUtils.getOutputPinotFS(Mockito.any(), Mockito.any()))
+          .thenReturn(outputFS);
+      segmentPushUtils.when(() -> SegmentPushUtils.sendSegmentUriAndMetadata(Mockito.any(), Mockito.any(),
+              Mockito.any(), Mockito.anyList(), Mockito.anyList()))
+          .thenThrow(new RuntimeException("response lost after registration"));
+      TestSingleSegmentConversionExecutor executor = new TestSingleSegmentConversionExecutor() {
+        @Override
+        protected void cleanupMetadataPushFailure(PinotFS outputFileFS, URI outputSegmentTarURI) {
+          // Immutable outputs are reconciled by this executor's task generator.
+        }
+      };
+      RuntimeException failure = Assert.expectThrows(RuntimeException.class,
+          () -> executor.executeTask(createMetadataPushTaskConfig(new File(TEMP_DIR, "immutable-output"))));
+      Assert.assertEquals(failure.getMessage(), "response lost after registration");
+      Mockito.verify(outputFS, Mockito.never()).delete(Mockito.any(), Mockito.anyBoolean());
+    }
+  }
+
   private PinotTaskConfig createMetadataPushTaskConfig(File outputDir) {
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME_WITH_TYPE);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
@@ -41,6 +41,7 @@ import org.apache.pinot.controller.util.ServerSegmentMetadataReader;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.common.MinionConstants.UpsertCompactionTask;
 import org.apache.pinot.minion.MinionContext;
+import org.apache.pinot.segment.local.utils.SegmentReplacementUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -691,10 +692,11 @@ public class MinionTaskUtilsTest {
     taskConfig.put(BatchConfigProperties.PUSH_MODE, BatchConfigProperties.SegmentPushType.URI.toString());
     Map<String, String> pushTaskConfigs = MinionTaskUtils.getPushTaskConfig(_tableConfig.getTableName(), taskConfig,
         getMockClusterInfo("hdfs://data/dir", "http://localhost:9000"));
-    assertEquals(pushTaskConfigs.size(), 3);
+    assertEquals(pushTaskConfigs.size(), 4);
     assertEquals(pushTaskConfigs.get(BatchConfigProperties.PUSH_MODE),
         BatchConfigProperties.SegmentPushType.METADATA.toString());
     assertEquals(pushTaskConfigs.get(BatchConfigProperties.OUTPUT_SEGMENT_DIR_URI), "hdfs://data/dir/myTable");
+    assertNotNull(pushTaskConfigs.get(SegmentReplacementUtils.ROOT_REFERENCES_CONFIG_KEY));
     assertEquals(pushTaskConfigs.get(BatchConfigProperties.PUSH_CONTROLLER_URI), "http://localhost:9000");
   }
 
@@ -706,9 +708,10 @@ public class MinionTaskUtilsTest {
     Map<String, String> pushTaskConfigs =
         MinionTaskUtils.getPushTaskConfig(_tableConfig.getTableName(), taskConfig, mockClusterInfo);
     assertEquals(pushTaskConfigs.get(BatchConfigProperties.OUTPUT_SEGMENT_DIR_URI), "hdfs://data/dir/myTable");
+    assertNotNull(pushTaskConfigs.get(SegmentReplacementUtils.ROOT_REFERENCES_CONFIG_KEY));
     assertEquals(pushTaskConfigs.get(BatchConfigProperties.PUSH_MODE),
         BatchConfigProperties.SegmentPushType.METADATA.toString());
-    assertEquals(pushTaskConfigs.size(), 3);
+    assertEquals(pushTaskConfigs.size(), 4);
   }
 
   @Test
@@ -720,10 +723,11 @@ public class MinionTaskUtilsTest {
         getMockClusterInfo("/data/dir", "http://localhost:9000"));
 
     assertEquals(pushTaskConfigs.get(BatchConfigProperties.OUTPUT_SEGMENT_DIR_URI), "hdfs://data/dir/myTable");
+    assertNotNull(pushTaskConfigs.get(SegmentReplacementUtils.ROOT_REFERENCES_CONFIG_KEY));
     assertEquals(pushTaskConfigs.get(BatchConfigProperties.PUSH_MODE),
         BatchConfigProperties.SegmentPushType.METADATA.toString());
     assertEquals(pushTaskConfigs.get(BatchConfigProperties.PUSH_CONTROLLER_URI), "http://localhost:9000");
-    assertEquals(pushTaskConfigs.size(), 3);
+    assertEquals(pushTaskConfigs.size(), 4);
   }
 
   @Test
@@ -751,7 +755,7 @@ public class MinionTaskUtilsTest {
     assertEquals(pushTaskConfigs.get(BatchConfigProperties.PUSH_MODE),
         BatchConfigProperties.SegmentPushType.METADATA.toString());
     assertEquals(pushTaskConfigs.get(BatchConfigProperties.PUSH_CONTROLLER_URI), "http://localhost:9000");
-    assertEquals(pushTaskConfigs.size(), 4);
+    assertEquals(pushTaskConfigs.size(), 5);
   }
 
   private static SegmentZKMetadata makeSegmentWithEndTimeMs(String name, long endTimeMs) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentReplacementUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentReplacementUtils.java
@@ -1,0 +1,266 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.utils;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.File;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.utils.URIUtils;
+import org.apache.pinot.spi.filesystem.FileMetadata;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkState;
+
+/// Filesystem ownership and collection of immutable same-name segment replacements. Callers supply metadata already
+/// loaded by normal controller validation; this class never reads or writes ZooKeeper. Concurrent uploads must use
+/// fresh UUIDs, a bounded registration window, and refresh-only/If-Match guards. Expired URIs cannot be repushed.
+public final class SegmentReplacementUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentReplacementUtils.class);
+  private static final String NAMESPACE = "segment-replacements-v1";
+  public static final String ROOT_REFERENCES_CONFIG_KEY = "segment.replacement.output.roots.uri";
+  private static final String ROOT_REFERENCES_DIR = ".segment-replacement-roots";
+  static final String OBSOLETE_SUFFIX = ".obsolete";
+  public static final long REGISTRATION_WINDOW_MS = TimeUnit.DAYS.toMillis(1);
+  static final long RETENTION_MS = TimeUnit.DAYS.toMillis(3);
+
+  private SegmentReplacementUtils() {
+  }
+
+  public static URI outputRoot(URI outputDir, String tableNameWithType) {
+    String directory = outputDir.toString();
+    return URI.create(directory + (directory.endsWith("/") ? "" : "/")
+        + NAMESPACE + "/" + URIUtils.encode(tableNameWithType) + "/");
+  }
+
+  public static URI referencesDir(String dataDir, String tableNameWithType) {
+    return URIUtils.getUri(dataDir, TableNameBuilder.extractRawTableName(tableNameWithType), ROOT_REFERENCES_DIR,
+        URIUtils.encode(tableNameWithType) + "/");
+  }
+
+  /// Returns the registration deadline for a managed replacement URI, or null for a normal external segment URI.
+  /// The controller enforces this deadline so an unreferenced output can be collected even when its CRC never changes.
+  @Nullable
+  public static Long registrationDeadline(String sourceUri, String tableNameWithType, String segmentName) {
+    if (sourceUri == null) {
+      return null;
+    }
+    String rawPath = URI.create(sourceUri).getRawPath();
+    if (rawPath == null) {
+      return null;
+    }
+    String[] parts = rawPath.split("/");
+    int length = parts.length;
+    if (length < 5 || !NAMESPACE.equals(parts[length - 5])) {
+      return null;
+    }
+    checkState(URIUtils.decode(parts[length - 4]).equals(tableNameWithType)
+            && URIUtils.decode(parts[length - 1]).equals(segmentName + ".tar.gz"),
+        "Replacement URI must belong to the requested table and segment");
+    checkState(UUID.fromString(parts[length - 2]).toString().equals(parts[length - 2]),
+        "Invalid replacement attempt UUID");
+    long deadline = Long.parseLong(parts[length - 3]);
+    checkState(deadline > 0, "Invalid replacement registration deadline");
+    return deadline;
+  }
+
+  /// Persist root discovery before copying an output, including roots from earlier task configurations.
+  public static void rememberRoot(URI referencesDir, URI root) throws Exception {
+    try (PinotFS fs = PinotFSFactory.create(referencesDir.getScheme())) {
+      rememberRoot(fs, referencesDir, root);
+    }
+  }
+
+  /// Called with the existing validation snapshot, including on tables with no time retention or minion schedule.
+  /// A filesystem error skips collection and is retried by the next normal validation pass.
+  public static void cleanup(String dataDir, String tableNameWithType, List<SegmentZKMetadata> segments) {
+    if (dataDir == null) {
+      return;
+    }
+    try {
+      URI referencesDir = referencesDir(dataDir, tableNameWithType);
+      try (PinotFS referenceFS = PinotFSFactory.create(referencesDir.getScheme())) {
+        if (!referenceFS.exists(referencesDir)) {
+          return;
+        }
+        Set<URI> roots = new HashSet<>();
+        for (String path : referenceFS.listFiles(referencesDir, false)) {
+          URI reference = SegmentPushUtils.generateSegmentTarURI(referencesDir, URI.create(path), null, null);
+          if (!reference.getPath().endsWith(".root")) {
+            continue;
+          }
+          try (InputStream input = referenceFS.open(reference)) {
+            String root = new String(input.readNBytes(8193), StandardCharsets.UTF_8);
+            checkState(root.length() <= 8192 && reference.getPath().endsWith(DigestUtils.sha256Hex(root) + ".root"),
+                "Invalid segment replacement root reference: %s", reference);
+            URI rootUri = URI.create(root);
+            checkState(rootUri.getRawPath().endsWith("/" + NAMESPACE + "/" + URIUtils.encode(tableNameWithType) + "/"),
+                "Replacement root must belong to the requested table: %s", root);
+            roots.add(rootUri);
+          }
+        }
+        Map<String, SegmentZKMetadata> segmentsByName = new HashMap<>();
+        for (SegmentZKMetadata segment : segments) {
+          segmentsByName.put(segment.getSegmentName(), segment);
+        }
+        for (URI root : roots) {
+          try (PinotFS fs = PinotFSFactory.create(root.getScheme())) {
+            cleanup(root, fs, segmentsByName, System.currentTimeMillis());
+          } catch (Exception e) {
+            LOGGER.warn("Unable to clean segment replacements under {}, will retry on the next validation", root, e);
+          }
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Unable to clean replacements for {}, retrying on the next validation", tableNameWithType, e);
+    }
+  }
+
+  @VisibleForTesting
+  static void rememberRoot(PinotFS fs, URI referencesDir, URI root) throws Exception {
+    String rootString = root.toString();
+    checkState(rootString.length() <= 8192, "Segment replacement output root URI is too long");
+    URI reference = referencesDir.resolve(DigestUtils.sha256Hex(rootString) + ".root");
+    if (fs.exists(reference)) {
+      try (InputStream input = fs.open(reference)) {
+        if (rootString.equals(new String(input.readNBytes(8193), StandardCharsets.UTF_8))) {
+          return;
+        }
+      }
+    }
+    File localReference = File.createTempFile("segment-output-root-", ".txt");
+    try {
+      Files.writeString(localReference.toPath(), rootString, StandardCharsets.UTF_8);
+      fs.mkdir(referencesDir);
+      fs.copyFromLocalFile(localReference, reference);
+      try (InputStream input = fs.open(reference)) {
+        checkState(rootString.equals(new String(input.readNBytes(8193), StandardCharsets.UTF_8)),
+            "Failed to record segment replacement output root: %s", root);
+      }
+    } finally {
+      FileUtils.deleteQuietly(localReference);
+    }
+  }
+
+  @VisibleForTesting
+  static void cleanup(URI root, PinotFS fs, Map<String, SegmentZKMetadata> segmentsByName, long nowMs)
+      throws Exception {
+    if (!fs.exists(root)) {
+      return;
+    }
+    Set<URI> referencedUrls = new HashSet<>();
+    for (SegmentZKMetadata segment : segmentsByName.values()) {
+      if (segment.getDownloadUrl() != null) {
+        referencedUrls.add(URI.create(segment.getDownloadUrl()));
+      }
+    }
+    List<FileMetadata> files = fs.listFilesWithMetadata(root, true);
+    Map<URI, FileMetadata> metadata = new HashMap<>();
+    for (FileMetadata file : files) {
+      metadata.put(SegmentPushUtils.generateSegmentTarURI(root, URI.create(file.getFilePath()), null, null), file);
+    }
+    for (FileMetadata file : files) {
+      if (file.isDirectory()) {
+        continue;
+      }
+      URI candidate = SegmentPushUtils.generateSegmentTarURI(root, URI.create(file.getFilePath()), null, null);
+      String relative = root.relativize(candidate).toString();
+      String[] parts = relative.split("/");
+      // Only remove files in our exact <deadline>/<attempt UUID>/<segment>.tar.gz layout. Never delete directories.
+      if (parts.length != 3) {
+        continue;
+      }
+      long registrationDeadline;
+      try {
+        registrationDeadline = Long.parseLong(parts[0]);
+        if (registrationDeadline <= 0) {
+          continue;
+        }
+        if (!UUID.fromString(parts[1]).toString().equals(parts[1])) {
+          continue;
+        }
+      } catch (IllegalArgumentException e) {
+        continue;
+      }
+      if (parts[2].endsWith(".tar.gz" + OBSOLETE_SUFFIX)) {
+        // Retry marker cleanup if the tar was removed but deleting its marker failed on a previous run.
+        URI tar = URI.create(candidate.toString().substring(0,
+            candidate.toString().length() - OBSOLETE_SUFFIX.length()));
+        if (!fs.exists(tar)) {
+          fs.delete(candidate, false);
+        }
+        continue;
+      }
+      if (!parts[2].endsWith(".tar.gz")) {
+        continue;
+      }
+      String segmentName = URIUtils.decode(parts[2].substring(0, parts[2].length() - ".tar.gz".length()));
+      // Registration is forbidden after the deadline. Keep outputs until then even if they are not currently live.
+      // Keep outputs while the upload lock is held: a request can pause after checking its deadline.
+      SegmentZKMetadata current = segmentsByName.get(segmentName);
+      URI marker = URI.create(candidate + OBSOLETE_SUFFIX);
+      FileMetadata obsolete = metadata.get(marker);
+      boolean stillReferenced = current != null && (current.getDownloadUrl() == null
+          || candidate.equals(URI.create(current.getDownloadUrl())));
+      if (referencedUrls.contains(candidate) || stillReferenced || nowMs <= registrationDeadline
+          || (current != null && current.getSegmentUploadStartTime() > 0)) {
+        // If a previously obsolete URI is observed live again, restart the grace period before ever collecting it.
+        if (obsolete != null) {
+          fs.delete(marker, false);
+        }
+        continue;
+      }
+      // Age since upload is insufficient: an old object might have become obsolete only seconds ago. Start the
+      // grace period at our first observation, giving existing server/minion downloads time to finish.
+      if (obsolete == null) {
+        if (!fs.touch(marker)) {
+          LOGGER.warn("Could not mark replacement {} obsolete, retrying on the next validation", candidate);
+        }
+        continue;
+      }
+      long lastReferenceChange = current == null ? 0 : Math.max(current.getPushTime(), current.getRefreshTime());
+      if (obsolete.getLastModifiedTime() <= 0
+          || nowMs - Math.max(obsolete.getLastModifiedTime(), lastReferenceChange) < RETENTION_MS) {
+        continue;
+      }
+      if (fs.delete(candidate, false)) {
+        fs.delete(marker, false);
+      } else {
+        LOGGER.warn("Could not delete obsolete replacement {}, retrying on the next validation", candidate);
+      }
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentReplacementUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentReplacementUtilsTest.java
@@ -1,0 +1,221 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.spi.filesystem.FileMetadata;
+import org.apache.pinot.spi.filesystem.LocalPinotFS;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.mockito.MockedStatic;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+/// Exercises root discovery and collection using actual local files and supplied metadata snapshots.
+public class SegmentReplacementUtilsTest {
+  private static final String TABLE = "test_OFFLINE";
+  private static final URI ROOT = URI.create("s3://bucket/table/segment-replacements-v1/test_OFFLINE/");
+  private static final long NOW = SegmentReplacementUtils.RETENTION_MS * 2;
+
+  @DataProvider
+  public Object[][] cleanupCases() {
+    return new Object[][]{
+        {200L, false, true}, // Expired, obsolete output from a changed segment.
+        {200L, true, false}, // Successful push: preserve the registered URL.
+        {100L, false, true}, // Expired attempts are collectible even when the segment CRC never changes.
+        {-1L, false, true} // Deleted segment cannot be re-added by a REFRESH_ONLY push.
+    };
+  }
+
+  @Test(dataProvider = "cleanupCases")
+  public void testCleanupUsesCurrentMetadata(long crc, boolean registered, boolean delete) throws Exception {
+    URI output = ROOT.resolve("100/" + UUID.randomUUID() + "/segment.tar.gz");
+    PinotFS fs = mock(PinotFS.class);
+    when(fs.exists(any())).thenReturn(true);
+    when(fs.listFilesWithMetadata(ROOT, true)).thenReturn(List.of(file(output, 1),
+        file(URI.create(output + SegmentReplacementUtils.OBSOLETE_SUFFIX), 1)));
+    SegmentZKMetadata current = crc == -1 ? null : segment(crc, registered ? output.toString() : "s3://other/segment");
+    SegmentReplacementUtils.cleanup(ROOT, fs, current == null ? Map.of() : Map.of("segment", current), NOW);
+    verify(fs, times(delete ? 1 : 0)).delete(output, false);
+  }
+
+  @Test
+  public void testCleanupKeepsUnexpiredAttemptsAndActiveUploads() throws Exception {
+    URI unexpired = ROOT.resolve((NOW + 1) + "/" + UUID.randomUUID() + "/segment.tar.gz");
+    URI expired = ROOT.resolve("100/" + UUID.randomUUID() + "/segment.tar.gz");
+    PinotFS fs = mock(PinotFS.class);
+    when(fs.exists(any())).thenReturn(true);
+    when(fs.listFilesWithMetadata(ROOT, true)).thenReturn(List.of(file(unexpired, 1), file(expired, 1),
+        file(URI.create(expired + SegmentReplacementUtils.OBSOLETE_SUFFIX), 1)));
+    SegmentZKMetadata current = segment(200, "s3://other/segment");
+    current.setSegmentUploadStartTime(1);
+    SegmentReplacementUtils.cleanup(ROOT, fs, Map.of("segment", current), NOW);
+    verify(fs, never()).delete(expired, false);
+    verify(fs, never()).delete(unexpired, false);
+    current.setSegmentUploadStartTime(-1);
+    SegmentReplacementUtils.cleanup(ROOT, fs, Map.of("segment", current), NOW);
+    verify(fs).delete(expired, false);
+    verify(fs, never()).delete(unexpired, false);
+  }
+
+  @Test
+  public void testCleanupWaitsFromFirstObsoleteObservation() throws Exception {
+    URI output = ROOT.resolve("100/" + UUID.randomUUID() + "/segment.tar.gz");
+    URI marker = URI.create(output + SegmentReplacementUtils.OBSOLETE_SUFFIX);
+    PinotFS fs = mock(PinotFS.class);
+    when(fs.exists(any())).thenReturn(true);
+    when(fs.listFilesWithMetadata(ROOT, true)).thenReturn(List.of(file(output, 1)));
+    Map<String, SegmentZKMetadata> segments = Map.of("segment", segment(200, "s3://other/segment"));
+    SegmentReplacementUtils.cleanup(ROOT, fs, segments, NOW);
+    verify(fs).touch(marker);
+    verify(fs, never()).delete(output, false);
+    when(fs.listFilesWithMetadata(ROOT, true)).thenReturn(List.of(file(output, 1), file(marker, NOW)));
+    SegmentReplacementUtils.cleanup(ROOT, fs, segments, NOW + 1);
+    verify(fs, never()).delete(output, false);
+    SegmentReplacementUtils.cleanup(ROOT, fs, segments, NOW + SegmentReplacementUtils.RETENTION_MS);
+    verify(fs).delete(output, false);
+  }
+
+  @Test
+  public void testCleanupKeepsYoungUnknownAndReferencedFiles() throws Exception {
+    URI young = ROOT.resolve("100/" + UUID.randomUUID() + "/young.tar.gz");
+    URI unknownTime = ROOT.resolve("100/" + UUID.randomUUID() + "/unknown.tar.gz");
+    URI malformed = ROOT.resolve("100/not-an-attempt/segment.tar.gz");
+    URI referenced = ROOT.resolve("100/" + UUID.randomUUID() + "/referenced.tar.gz");
+    PinotFS fs = mock(PinotFS.class);
+    when(fs.exists(any())).thenReturn(true);
+    when(fs.listFilesWithMetadata(ROOT, true)).thenReturn(List.of(file(young, NOW), file(unknownTime, 0),
+        file(malformed, 1), file(referenced, 1)));
+    SegmentReplacementUtils.cleanup(ROOT, fs, Map.of("segment", segment(200, referenced.toString())), NOW);
+    verify(fs, never()).delete(any(), anyBoolean());
+  }
+
+  @Test
+  public void testRootsSurviveConfigChangesAndUseSuppliedSnapshot() throws Exception {
+    File temp = Files.createTempDirectory("segment-replacement-roots").toFile();
+    URI first = SegmentReplacementUtils.outputRoot(new File(temp, "first").toURI(), TABLE);
+    URI second = SegmentReplacementUtils.outputRoot(new File(temp, "second").toURI(), TABLE);
+    URI references = SegmentReplacementUtils.referencesDir(new File(temp, "controller").toURI().toString(), TABLE);
+    URI output = first.resolve("100/" + UUID.randomUUID() + "/segment.tar.gz");
+    try (MockedStatic<PinotFSFactory> factory = mockStatic(PinotFSFactory.class)) {
+      factory.when(() -> PinotFSFactory.create("file")).thenAnswer(i -> new LocalPinotFS());
+      SegmentReplacementUtils.rememberRoot(references, first);
+      SegmentReplacementUtils.rememberRoot(references, second);
+      FileUtils.writeStringToFile(new File(output), "purged", StandardCharsets.UTF_8);
+      String dataDir = new File(temp, "controller").toURI().toString();
+      SegmentReplacementUtils.cleanup(dataDir, TABLE, List.of(segment(200, output.toString())));
+      File marker = new File(URI.create(output + SegmentReplacementUtils.OBSOLETE_SUFFIX));
+      assertFalse(marker.exists());
+      SegmentReplacementUtils.cleanup(dataDir, TABLE, List.of(segment(300, "s3://other/segment")));
+      assertTrue(marker.isFile());
+      assertTrue(marker.setLastModified(System.currentTimeMillis() - SegmentReplacementUtils.RETENTION_MS - 1000));
+      SegmentReplacementUtils.cleanup(dataDir, TABLE, List.of(segment(300, "s3://other/segment")));
+      assertFalse(new File(output).exists());
+      assertFalse(marker.exists());
+    } finally {
+      FileUtils.deleteDirectory(temp);
+    }
+  }
+
+  @Test
+  public void testRootPersistenceUsesOneFileAndRepairsIncompleteWrite() throws Exception {
+    File temp = Files.createTempDirectory("purge-root-reference").toFile();
+    try (PinotFS fs = new LocalPinotFS()) {
+      URI references = temp.toURI();
+      SegmentReplacementUtils.rememberRoot(fs, references, ROOT);
+      SegmentReplacementUtils.rememberRoot(fs, references, ROOT);
+      String[] files = fs.listFiles(references, false);
+      assertEquals(files.length, 1);
+      File reference = new File(files[0]);
+      assertEquals(Files.readString(reference.toPath()), ROOT.toString());
+      Files.writeString(reference.toPath(), "partial write");
+      SegmentReplacementUtils.rememberRoot(fs, references, ROOT);
+      assertEquals(Files.readString(reference.toPath()), ROOT.toString());
+      assertEquals(fs.listFiles(references, false).length, 1);
+    } finally {
+      FileUtils.deleteDirectory(temp);
+    }
+  }
+
+  @Test
+  public void testCorruptReferenceSkipsCleanup() throws Exception {
+    File temp = Files.createTempDirectory("segment-replacement-corrupt-reference").toFile();
+    String dataDir = temp.toURI().toString();
+    try (MockedStatic<PinotFSFactory> factory = mockStatic(PinotFSFactory.class)) {
+      factory.when(() -> PinotFSFactory.create("file")).thenAnswer(i -> new LocalPinotFS());
+      PinotFS outputFS = mock(PinotFS.class);
+      factory.when(() -> PinotFSFactory.create("s3")).thenReturn(outputFS);
+      SegmentReplacementUtils.rememberRoot(SegmentReplacementUtils.referencesDir(dataDir, TABLE), ROOT);
+      File reference = FileUtils.listFiles(temp, new String[]{"root"}, true).iterator().next();
+      Files.writeString(reference.toPath(), "s3://wrong-bucket/");
+      SegmentReplacementUtils.cleanup(dataDir, TABLE, List.of());
+      verifyNoInteractions(outputFS);
+    } finally {
+      FileUtils.deleteDirectory(temp);
+    }
+  }
+
+  @Test
+  public void testReferenceToAnotherTableCannotAuthorizeCleanup() throws Exception {
+    File temp = Files.createTempDirectory("segment-replacement-wrong-table").toFile();
+    String dataDir = temp.toURI().toString();
+    try (MockedStatic<PinotFSFactory> factory = mockStatic(PinotFSFactory.class)) {
+      factory.when(() -> PinotFSFactory.create("file")).thenAnswer(i -> new LocalPinotFS());
+      PinotFS outputFS = mock(PinotFS.class);
+      factory.when(() -> PinotFSFactory.create("s3")).thenReturn(outputFS);
+      URI other = SegmentReplacementUtils.outputRoot(URI.create("s3://bucket/table"), "other_OFFLINE");
+      SegmentReplacementUtils.rememberRoot(SegmentReplacementUtils.referencesDir(dataDir, TABLE), other);
+      SegmentReplacementUtils.cleanup(dataDir, TABLE, List.of());
+      verifyNoInteractions(outputFS);
+    } finally {
+      FileUtils.deleteDirectory(temp);
+    }
+  }
+
+  @Test
+  public void testRootPersistenceReadbackFailureStopsGeneration() throws Exception {
+    PinotFS fs = mock(PinotFS.class);
+    when(fs.open(any())).thenAnswer(i -> new ByteArrayInputStream("truncated".getBytes(StandardCharsets.UTF_8)));
+    expectThrows(IllegalStateException.class,
+        () -> SegmentReplacementUtils.rememberRoot(fs, URI.create("s3://bucket/references/"), ROOT));
+  }
+
+  private static SegmentZKMetadata segment(long crc, String downloadUrl) {
+    SegmentZKMetadata segment = new SegmentZKMetadata("segment");
+    segment.setCrc(crc);
+    segment.setDownloadUrl(downloadUrl);
+    return segment;
+  }
+
+  private static FileMetadata file(URI uri, long modified) {
+    return new FileMetadata.Builder().setFilePath(uri.toString()).setLastModifiedTime(modified).build();
+  }
+}


### PR DESCRIPTION
## Summary

Make `BaseSingleSegmentConversionExecutor` metadata pushes safe for repeated replacements of the same segment name. Each execution uploads to a new URI, and the controller registers that URI without changing the bytes behind the currently live URL. TAR behavior remains unchanged.

The old uploader reused `<outputDir>/<segment>.tar.gz`: retries could collide, and `overwriteOutput=true` could replace live bytes before metadata registration. It also deleted the output on any push exception, including a lost response after successful registration, and omitted TAR's `If-Match` and `REFRESH_ONLY` headers.

## Shared implementation

Use the existing TAR headers for metadata push, including authentication and the custom metadata modifier. Allocate an immutable physical output for each execution:

```text
<configured output directory>/segment-replacements-v1/<tableWithType>/<registrationDeadlineMillis>/<attemptUUID>/<segment>.tar.gz
```

The segment name stays the same. The UUID isolates retries. The deadline gives the attempt 24 hours to register its URI; it does not expire a successfully registered segment or prevent servers from downloading it.

The controller checks the deadline in both single and batch upload paths, then checks again after acquiring the existing upload lock. Managed replacement URIs require direct METADATA push, `If-Match`, `REFRESH_ONLY`, and parallel push protection. An expired request returns 410 and must retry with a fresh URI. These checks reuse the existing metadata read and lock/update writes.

A failed copy is removed immediately when possible because its URI has not been submitted. After submission, both successful and uncertain outputs remain in deep store. Local task files retain their existing `finally` cleanup.

## Cleanup without additional ZK operations

Root discovery lives in deep store: one small, content-verified `.root` file per output root, beneath `<controllerDataDir>/<rawTable>/.segment-replacement-roots/<tableWithType>/`. The shared task-config helper supplies that location, and the executor records the root before copying. Historical roots remain discoverable after output configuration changes or task-history expiry.

Offline and realtime segment validation pass their **already-loaded** segment metadata lists to the shared collector. Cleanup adds no bulk or per-output ZK reads, no task-history queries, and no cleanup-specific ZK records or writes. Tests verify the existing metadata-read count and the existing two upload writes.

The collector preserves registered download URLs, unexpired attempts, and candidates covered by an active upload lock. Once an output is expired and unreferenced, it creates an `.obsolete` marker. A later validation pass deletes it after three days, also respecting a newer segment push/refresh time. Starting the grace period when obsolescence is observed protects downloads of a recently replaced segment. Failed deletions are retried; unknown layouts and corrupt root references cannot authorize deletion.

The registration deadline is necessary even with CRC checks: a no-op conversion can keep the same CRC, allowing a delayed request to re-register an otherwise obsolete URI. Expiry makes those files collectible without waiting for the CRC to change. The existing upload lock protects a request paused between checking its deadline and updating metadata.

## Why the additional methods exist

| Method | Purpose |
| --- | --- |
| `BaseSingleSegmentConversionExecutor.moveSegmentToOutputPinotFS` | Allocate an immutable attempt URI, record ownership before copying, and remove a failed partial copy. |
| `SegmentReplacementUtils.outputRoot` / `referencesDir` | Define the table-specific output namespace and stable root-discovery location, including custom output directories. |
| `rememberRoot` overloads | Persist and verify a small filesystem reference; repeated attempts reuse the reference. The overload accepting `PinotFS` supports direct filesystem tests. |
| `registrationDeadline` | Parse the managed URI and validate its table, segment, UUID, and deadline without accessing metadata storage. |
| `ZKOperator.checkReplacementRegistration` | Enforce expiry and the existing replacement/locking contract before reading metadata and again under the acquired upload lock. |
| `cleanup` overloads | Discover roots and collect eligible files using the metadata snapshot supplied by existing controller validation. |

The configuration helper alone cannot provide upload isolation, safe handling of uncertain responses, or garbage collection. These now live in the shared OSS implementation instead of task-specific executor/generator overrides.

## Compatibility and boundaries

- Roll out controllers before enabling this behavior on minions. Keep explicit TAR configured during a mixed deployment. Previously queued METADATA tasks without the root-registry config fail before writing an output and must be regenerated.
- The controller and minions need access to the relevant filesystems; minions must be able to record roots in the controller deep store. Custom output directories remain supported when those access requirements are met.
- Managed same-name replacements reject URI prefix/suffix remapping and controller copy-back: cleanup must be able to identify the registered physical object. Other upload URIs retain their existing behavior.
- Collection continues while normal segment validation runs, including tables without a time-retention policy or an active minion schedule. After a table is dropped, remaining objects depend on the table/storage deletion policy; custom roots require external cleanup. Source objects outside the reserved namespace remain with their existing owner/lifecycle policy.
- An unresolved upload lock causes conservative retention until ordinary upload recovery clears it. The collector never removes the current registered segment merely because its registration deadline has passed.

## Validation

89 tests passed through Maven, with no failures or skips: 12 filesystem/collection cases, 6 replacement-registration cases, 3 existing `ZKOperatorTest` cases, 4 validation-snapshot cases, 8 executor cases, and 56 shared task-utility cases. Module-scoped Spotless, Checkstyle, license format/check, RAT, and `git diff --check` passed. The controller UI was built on the first run and reused for the final Java checks.

```shell
./mvnw -nsu -pl pinot-segment-local,pinot-controller,pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks -Dskip.npm -Dmaven.javadoc.skip=true spotless:apply license:format checkstyle:check license:check -Dtest=SegmentReplacementUtilsTest,SegmentReplacementValidationTest,ZKOperatorReplacementTest,ZKOperatorTest,BaseSingleSegmentConversionExecutorTest,MinionTaskUtilsTest -Dsurefire.failIfNoSpecifiedTests=false -Dnet.bytebuddy.experimental=true install -ntp
```
