### PR TITLE
Meter upsert compaction segments skipped because replicas disagree

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -82,6 +82,8 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   AUDIT_REQUEST_PAYLOAD_TRUNCATED("count", true),
   // Upsert compact merge task metrics
   UPSERT_COMPACT_MERGE_SEGMENT_SKIPPED_CONSENSUS_FAILURE("UpsertCompactMergeSegmentsSkipped", false),
+  // Segments UpsertCompactionTask refused to schedule because the replicas reported different valid doc counts
+  UPSERT_COMPACTION_SEGMENT_SKIPPED_CONSENSUS_FAILURE("UpsertCompactionSegmentsSkipped", false),
   // Query workload propagation metrics
   QUERY_WORKLOAD_PROPAGATION_COUNT("count", true),
   QUERY_WORKLOAD_PROPAGATION_ERROR("count", true),

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -40,6 +40,8 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.auth.NullAuthProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ControllerMeter;
+import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsBitmapResponse;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsMetadataInfo;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
@@ -470,6 +472,18 @@ public class MinionTaskUtils {
   public static ValidDocIdsMetadataInfo selectValidDocIdsMetadataForConsensus(String taskType,
       SegmentZKMetadata segmentZKMetadata, @Nullable List<ValidDocIdsMetadataInfo> replicas, int expectedReplicaCount,
       MinionConstants.ValidDocIdsConsensusMode consensusMode) {
+    return selectValidDocIdsMetadataForConsensus(taskType, segmentZKMetadata, replicas, expectedReplicaCount,
+        consensusMode, null, null);
+  }
+
+  /// Same, and additionally reports an EQUAL-mode disagreement on `controllerMetrics` as
+  /// [ControllerMeter#UPSERT_COMPACTION_SEGMENT_SKIPPED_CONSENSUS_FAILURE]. Only that skip reason is metered: the
+  /// others mean "ask again later", not that the replicas hold different data.
+  @Nullable
+  public static ValidDocIdsMetadataInfo selectValidDocIdsMetadataForConsensus(String taskType,
+      SegmentZKMetadata segmentZKMetadata, @Nullable List<ValidDocIdsMetadataInfo> replicas, int expectedReplicaCount,
+      MinionConstants.ValidDocIdsConsensusMode consensusMode, @Nullable ControllerMetrics controllerMetrics,
+      @Nullable String tableNameWithType) {
     String segmentName = segmentZKMetadata.getSegmentName();
     if (CollectionUtils.isEmpty(replicas)) {
       return null;
@@ -534,9 +548,15 @@ public class MinionTaskUtils {
       // keeps the generator cheap - it avoids serializing a bitmap per replica back to the controller.
       ValidDocIdsMetadataInfo first = usableReplicas.get(0);
       for (int i = 1; i < usableReplicas.size(); i++) {
-        if (usableReplicas.get(i).getTotalValidDocs() != first.getTotalValidDocs()) {
-          LOGGER.warn("Replicas disagree on valid doc count for segment: {}, skipping segment for {}", segmentName,
-              taskType);
+        ValidDocIdsMetadataInfo other = usableReplicas.get(i);
+        if (other.getTotalValidDocs() != first.getTotalValidDocs()) {
+          LOGGER.warn("Replicas disagree on valid doc count for segment: {}, server {} reports {} valid docs and "
+                  + "server {} reports {}, skipping segment for {}", segmentName, first.getInstanceId(),
+              first.getTotalValidDocs(), other.getInstanceId(), other.getTotalValidDocs(), taskType);
+          if (controllerMetrics != null && tableNameWithType != null) {
+            controllerMetrics.addMeteredTableValue(tableNameWithType,
+                ControllerMeter.UPSERT_COMPACTION_SEGMENT_SKIPPED_CONSENSUS_FAILURE, 1L);
+          }
           return null;
         }
       }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -27,11 +27,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.task.TaskState;
 import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsMetadataInfo;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -171,8 +173,9 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
           completedSegments.stream().collect(Collectors.toMap(SegmentZKMetadata::getSegmentName, Function.identity()));
 
       SegmentSelectionResult segmentSelectionResult =
-          processValidDocIdsMetadata(taskConfigs, completedSegmentsMap, validDocIdsMetadataList,
-              validDocIdsMetadataResult.getSegmentToExpectedReplicaCount(), consensusMode);
+          processValidDocIdsMetadata(tableNameWithType, taskConfigs, completedSegmentsMap, validDocIdsMetadataList,
+              validDocIdsMetadataResult.getSegmentToExpectedReplicaCount(), consensusMode,
+              _clusterInfoAccessor.getControllerMetrics());
       int skippedSegmentsCount = validDocIdsMetadataList.size()
               - segmentSelectionResult.getSegmentsForCompaction().size()
               - segmentSelectionResult.getSegmentsForDeletion().size();
@@ -217,10 +220,11 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
   }
 
   @VisibleForTesting
-  public static SegmentSelectionResult processValidDocIdsMetadata(Map<String, String> taskConfigs,
-      Map<String, SegmentZKMetadata> completedSegmentsMap,
+  public static SegmentSelectionResult processValidDocIdsMetadata(String tableNameWithType,
+      Map<String, String> taskConfigs, Map<String, SegmentZKMetadata> completedSegmentsMap,
       Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadataInfoMap,
-      Map<String, Integer> segmentToReplicaCount, MinionConstants.ValidDocIdsConsensusMode consensusMode) {
+      Map<String, Integer> segmentToReplicaCount, MinionConstants.ValidDocIdsConsensusMode consensusMode,
+      @Nullable ControllerMetrics controllerMetrics) {
     double invalidRecordsThresholdPercent = Double.parseDouble(
         taskConfigs.getOrDefault(UpsertCompactionTask.INVALID_RECORDS_THRESHOLD_PERCENT,
             String.valueOf(DEFAULT_INVALID_RECORDS_THRESHOLD_PERCENT)));
@@ -242,7 +246,8 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
       List<ValidDocIdsMetadataInfo> replicas = validDocIdsMetadataInfoMap.get(segmentName);
       ValidDocIdsMetadataInfo validDocIdsMetadata = MinionTaskUtils.selectValidDocIdsMetadataForConsensus(
           MinionConstants.UpsertCompactionTask.TASK_TYPE, segment, replicas,
-          segmentToReplicaCount.getOrDefault(segmentName, replicas.size()), consensusMode);
+          segmentToReplicaCount.getOrDefault(segmentName, replicas.size()), consensusMode, controllerMetrics,
+          tableNameWithType);
       if (validDocIdsMetadata == null) {
         continue;
       }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ControllerMeter;
+import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsMetadataInfo;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
 import org.apache.pinot.common.utils.ServiceStatus;
@@ -39,6 +41,7 @@ import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -233,14 +236,15 @@ public class UpsertCompactionTaskGeneratorTest {
 
     // no completed segments scenario, there shouldn't be any segment selected for compaction
     UpsertCompactionTaskGenerator.SegmentSelectionResult segmentSelectionResult =
-        UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, new HashMap<>(),
-            validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
+        UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+            new HashMap<>(), validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE, null);
     assertEquals(segmentSelectionResult.getSegmentsForCompaction().size(), 0);
 
     // test with valid crc and thresholds
     segmentSelectionResult =
-        UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-            validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
+        UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+            _completedSegmentsMap, validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE,
+            null);
     assertEquals(segmentSelectionResult.getSegmentsForCompaction().size(), 1);
     assertEquals(segmentSelectionResult.getSegmentsForDeletion().size(), 1);
     assertEquals(segmentSelectionResult.getSegmentsForCompaction().get(0).getSegmentName(),
@@ -250,8 +254,9 @@ public class UpsertCompactionTaskGeneratorTest {
     // test with a higher invalidRecordsThresholdPercent
     compactionConfigs = getCompactionConfigs("60", "10");
     segmentSelectionResult =
-        UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-            validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
+        UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+            _completedSegmentsMap, validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE,
+            null);
     assertTrue(segmentSelectionResult.getSegmentsForCompaction().isEmpty());
     assertEquals(segmentSelectionResult.getSegmentsForDeletion().size(), 1);
     assertEquals(segmentSelectionResult.getSegmentsForDeletion().get(0), _completedSegment2.getSegmentName());
@@ -259,8 +264,9 @@ public class UpsertCompactionTaskGeneratorTest {
     // test without an invalidRecordsThresholdPercent
     compactionConfigs = getCompactionConfigs("0", "10");
     segmentSelectionResult =
-        UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-            validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
+        UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+            _completedSegmentsMap, validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE,
+            null);
     assertEquals(segmentSelectionResult.getSegmentsForDeletion().size(), 1);
     assertEquals(segmentSelectionResult.getSegmentsForCompaction().size(), 1);
     assertEquals(segmentSelectionResult.getSegmentsForCompaction().get(0).getSegmentName(),
@@ -270,8 +276,9 @@ public class UpsertCompactionTaskGeneratorTest {
     // test without a invalidRecordsThresholdCount
     compactionConfigs = getCompactionConfigs("30", "0");
     segmentSelectionResult =
-        UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-            validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
+        UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+            _completedSegmentsMap, validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE,
+            null);
     assertEquals(segmentSelectionResult.getSegmentsForDeletion().size(), 1);
     assertEquals(segmentSelectionResult.getSegmentsForCompaction().size(), 1);
     assertEquals(segmentSelectionResult.getSegmentsForCompaction().get(0).getSegmentName(),
@@ -289,8 +296,9 @@ public class UpsertCompactionTaskGeneratorTest {
     validDocIdsMetadataInfo = JsonUtils.stringToObject(json, new TypeReference<>() {
     });
     segmentSelectionResult =
-        UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-            validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
+        UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+            _completedSegmentsMap, validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE,
+            null);
 
     // completedSegment is supposed to be filtered out
     Assert.assertEquals(segmentSelectionResult.getSegmentsForCompaction().size(), 0);
@@ -314,8 +322,9 @@ public class UpsertCompactionTaskGeneratorTest {
     });
     compactionConfigs = getCompactionConfigs("30", "0");
     segmentSelectionResult =
-        UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-            validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
+        UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+            _completedSegmentsMap, validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE,
+            null);
     Assert.assertEquals(segmentSelectionResult.getSegmentsForCompaction().size(), 2);
     Assert.assertEquals(segmentSelectionResult.getSegmentsForDeletion().size(), 0);
     assertEquals(segmentSelectionResult.getSegmentsForCompaction().get(0).getSegmentName(),
@@ -339,51 +348,53 @@ public class UpsertCompactionTaskGeneratorTest {
         meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1"),
         meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server2")));
     UpsertCompactionTaskGenerator.SegmentSelectionResult result =
-        UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-            equalReplicas, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
+        UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+            _completedSegmentsMap, equalReplicas, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL, null);
     assertEquals(result.getSegmentsForCompaction().size(), 1);
 
     Map<String, List<ValidDocIdsMetadataInfo>> unequalReplicas = Map.of(segmentName, List.of(
         meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1"),
         meta(segmentName, 60, 40, 100, crc, ServiceStatus.Status.GOOD, "server2")));
-    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-        unequalReplicas, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+        _completedSegmentsMap, unequalReplicas, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL, null);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
     assertTrue(result.getSegmentsForDeletion().isEmpty());
 
     Map<String, List<ValidDocIdsMetadataInfo>> oneResponded = Map.of(segmentName, List.of(
         meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1")));
-    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-        oneResponded, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+        _completedSegmentsMap, oneResponded, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL, null);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
 
     Map<String, List<ValidDocIdsMetadataInfo>> crcMismatch = Map.of(segmentName, List.of(
         meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1"),
         meta(segmentName, 50, 50, 100, crc + 1, ServiceStatus.Status.GOOD, "server2")));
-    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-        crcMismatch, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+        _completedSegmentsMap, crcMismatch, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL, null);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
 
     Map<String, List<ValidDocIdsMetadataInfo>> unhealthy = Map.of(segmentName, List.of(
         meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1"),
         meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.STARTING, "server2")));
-    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-        unhealthy, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+        _completedSegmentsMap, unhealthy, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL, null);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
 
-    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-        crcMismatch, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+        _completedSegmentsMap, crcMismatch, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.UNSAFE, null);
     assertEquals(result.getSegmentsForCompaction().size(), 1);
 
-    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-        crcMismatch, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.MOST_VALID_DOCS);
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+        _completedSegmentsMap, crcMismatch, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.MOST_VALID_DOCS,
+        null);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
 
     Map<String, List<ValidDocIdsMetadataInfo>> mostValidDocs = Map.of(segmentName, List.of(
         meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
         meta(segmentName, 100, 0, 100, crc, ServiceStatus.Status.GOOD, "server2")));
-    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-        mostValidDocs, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.MOST_VALID_DOCS);
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+        _completedSegmentsMap, mostValidDocs, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.MOST_VALID_DOCS,
+        null);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
     assertTrue(result.getSegmentsForDeletion().isEmpty());
 
@@ -397,16 +408,86 @@ public class UpsertCompactionTaskGeneratorTest {
     Map<String, List<ValidDocIdsMetadataInfo>> dataCrcMatch = Map.of(segmentName, List.of(
         metaWithDataCrc(segmentName, 50, 50, 100, 2000, "5000", ServiceStatus.Status.GOOD, "server1"),
         metaWithDataCrc(segmentName, 50, 50, 100, 2000, "5000", ServiceStatus.Status.GOOD, "server2")));
-    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, dataCrcMap, dataCrcMatch,
-        twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+        dataCrcMap, dataCrcMatch, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL, null);
     assertEquals(result.getSegmentsForCompaction().size(), 1);
 
     Map<String, List<ValidDocIdsMetadataInfo>> dataCrcMismatch = Map.of(segmentName, List.of(
         metaWithDataCrc(segmentName, 50, 50, 100, 2000, "9999", ServiceStatus.Status.GOOD, "server1"),
         metaWithDataCrc(segmentName, 50, 50, 100, 2000, "9999", ServiceStatus.Status.GOOD, "server2")));
-    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, dataCrcMap, dataCrcMismatch,
-        twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+        dataCrcMap, dataCrcMismatch, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL, null);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
+  }
+
+  /// Tests that only a genuine replica disagreement raises the divergence meter. A CRC mismatch, an unhealthy
+  /// server or a short responder list all mean "ask again later", so those skips must leave the meter alone.
+  @Test
+  public void testProcessValidDocIdsMetadataConsensusFailureMeter() {
+    Map<String, String> compactionConfigs = getCompactionConfigs("1", "10");
+    String segmentName = _completedSegment.getSegmentName();
+    long crc = _completedSegment.getCrc();
+    Map<String, Integer> twoReplicas = Map.of(segmentName, 2);
+    ControllerMetrics controllerMetrics = new ControllerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    // The registry is shared across tests, so compare deltas rather than absolute counts.
+    long baseline = meterCount(controllerMetrics);
+
+    Map<String, List<ValidDocIdsMetadataInfo>> agree = Map.of(segmentName, List.of(
+        meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server2")));
+    UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+        _completedSegmentsMap, agree, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL, controllerMetrics);
+    assertEquals(meterCount(controllerMetrics) - baseline, 0, "Agreeing replicas must not raise the meter");
+
+    Map<String, List<ValidDocIdsMetadataInfo>> crcMismatch = Map.of(segmentName, List.of(
+        meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        meta(segmentName, 50, 50, 100, crc + 1, ServiceStatus.Status.GOOD, "server2")));
+    UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+        _completedSegmentsMap, crcMismatch, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL,
+        controllerMetrics);
+    assertEquals(meterCount(controllerMetrics) - baseline, 0,
+        "A CRC mismatch is a segment reload in flight, not divergence");
+
+    Map<String, List<ValidDocIdsMetadataInfo>> unhealthy = Map.of(segmentName, List.of(
+        meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.STARTING, "server2")));
+    UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+        _completedSegmentsMap, unhealthy, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL,
+        controllerMetrics);
+    assertEquals(meterCount(controllerMetrics) - baseline, 0, "A server that is still starting is not divergence");
+
+    Map<String, List<ValidDocIdsMetadataInfo>> oneResponded = Map.of(segmentName, List.of(
+        meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1")));
+    UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+        _completedSegmentsMap, oneResponded, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL,
+        controllerMetrics);
+    assertEquals(meterCount(controllerMetrics) - baseline, 0, "A short responder list is not divergence");
+
+    Map<String, List<ValidDocIdsMetadataInfo>> disagree = Map.of(segmentName, List.of(
+        meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        meta(segmentName, 60, 40, 100, crc, ServiceStatus.Status.GOOD, "server2")));
+    UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+        _completedSegmentsMap, disagree, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL,
+        controllerMetrics);
+    assertEquals(meterCount(controllerMetrics) - baseline, 1,
+        "Replicas reporting different valid doc counts must raise the meter");
+
+    // MOST_VALID_DOCS picks a winner instead of skipping, so it never reports divergence.
+    UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+        _completedSegmentsMap, disagree, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.MOST_VALID_DOCS,
+        controllerMetrics);
+    assertEquals(meterCount(controllerMetrics) - baseline, 1,
+        "MOST_VALID_DOCS resolves the disagreement, so the meter must not move");
+
+    // A null ControllerMetrics is the no-metrics path and must not blow up.
+    UpsertCompactionTaskGenerator.processValidDocIdsMetadata(REALTIME_TABLE_NAME, compactionConfigs,
+        _completedSegmentsMap, disagree, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL, null);
+    assertEquals(meterCount(controllerMetrics) - baseline, 1, "The null-metrics path must not move the meter");
+  }
+
+  private static long meterCount(ControllerMetrics controllerMetrics) {
+    return controllerMetrics.getMeteredTableValue(REALTIME_TABLE_NAME,
+        ControllerMeter.UPSERT_COMPACTION_SEGMENT_SKIPPED_CONSENSUS_FAILURE).count();
   }
 
   private static ValidDocIdsMetadataInfo meta(String segmentName, long validDocs, long invalidDocs, long totalDocs,


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Generator processes segments, checks replica consensus, and increments meter on disagreement\.

```mermaid
flowchart TD
  N0["UpsertCompactionTaskGenerator#46;generateTasks #40;F3#41;"]:::stModified
  N1["UpsertCompactionTaskGenerator#46;processValidDocIdsMetadata #40;F3#41;"]:::stModified
  N2["MinionTaskUtils#46;selectValidDocIdsMetadataForConsensus #40;F2#41;"]:::stModified
  N3["Increment UpsertCompactionSegmentsSkipped meter #40;F2#41;"]:::stModified
  N0 -->|"calls"| N1
  N1 -->|"calls"| N2
  N2 -->|"increments meter on disagreement"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-plugins/pinot\-minion\-tasks/pinot\-minion\-builtin\-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils\.java — [before](https://github.com/apache/pinot/blob/5e05b9cf062e1ae04aac65bc8f7a594f37709810/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java) · [after](https://github.com/apache/pinot/blob/c6948a2e0b76c665086a46cbca4e1e625329aa14/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java)
- F3: pinot\-plugins/pinot\-minion\-tasks/pinot\-minion\-builtin\-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator\.java — [before](https://github.com/apache/pinot/blob/5e05b9cf062e1ae04aac65bc8f7a594f37709810/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java) · [after](https://github.com/apache/pinot/blob/c6948a2e0b76c665086a46cbca4e1e625329aa14/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjVlMDViOWNmMDYyZTFhZTA0YWFjNjViYzhmN2E1OTRmMzc3MDk4MTAiLCJjb250ZXh0X2hhc2giOiI4OTRiYzY5M2Q1MDgwOWMzMTgwMGQyODBiYzM3NzQwNDY1M2M1NWE0ZGVjYjYxNTg1M2NmYmUzMDE1MmMzZGQ3IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NzIwNjU3LCJoZWFkX3NoYSI6ImM2OTQ4YTJlMGI3NmM2NjUwODZhNDZjYmNhNGUxZTYyNTMyOWFhMTQiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJjYWIxMzgyMmIyNjdmYzMwMWM0Yjc4OTI2MzMxZjk3NzNmMGQwYmZjIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 58f1456a4d90191e7f91789dd54f88fa4fec06d2ae244946d64620fd139fe8ff -->
<!-- pinot-pr-flow:end -->

## TL;DR

`UpsertCompactionTask`'s generator already compares valid doc counts across replicas and refuses
to schedule a segment whose replicas disagree. Today that refusal is a log line and nothing else,
so the controller notices that two replicas of an upsert table hold different data, quietly stops
compacting the segment, and tells no one. This PR emits a meter for it, scoped to the one skip
reason that actually means divergence.

## The problem

`MinionTaskUtils.selectValidDocIdsMetadataForConsensus` is the generator's pre-scheduling gate. It
returns `null` to skip a segment, and it does that for six different reasons. Five of them are
"the answer is not trustworthy right now". One of them means the replicas have genuinely drifted
apart: in `EQUAL` mode, two replicas report a different number of valid docs for the same segment
with the same CRC, both servers healthy, all replicas accounted for.

That last case is the interesting one and it is invisible. There is no metric on it, so a table can
sit with diverged replicas for weeks, serving different answers depending on which replica the
broker picks, while compaction silently stalls on the affected segments.

```mermaid
flowchart LR
  subgraph Before["❌ Today"]
    A[replicas report<br/>different valid doc counts] --> B[generator skips segment]
    B --> C[LOGGER.warn]
    C --> D[nobody knows<br/>compaction stalls]
  end
  subgraph After["✅ With this PR"]
    E[replicas report<br/>different valid doc counts] --> F[generator skips segment]
    F --> G[LOGGER.warn names<br/>both servers and both counts]
    F --> H[UpsertCompactionSegmentsSkipped<br/>meter per table]
    H --> I[alertable]
  end
```

## The approach

1. Add `ControllerMeter.UPSERT_COMPACTION_SEGMENT_SKIPPED_CONSENSUS_FAILURE`, a per-table meter
   exported as `UpsertCompactionSegmentsSkipped`.
2. Give `selectValidDocIdsMetadataForConsensus` an optional `ControllerMetrics` and the table name,
   and bump that meter from the `EQUAL`-mode disagreement branch only.
3. Thread `ControllerMetrics` and `tableNameWithType` from `UpsertCompactionTaskGenerator`'s
   `generateTasks` into `processValidDocIdsMetadata`, which is where the per-segment loop lives.
4. Keep the existing five-argument `selectValidDocIdsMetadataForConsensus` as an overload that
   meters nothing, so the other caller is untouched.
5. Extend the disagreement log line to name both servers and both counts.

## Which skip reasons are metered

Only the last row. The other five are transient states that resolve on their own, and metering them
would make the signal fire during every segment reload and every rolling restart.

| Why the generator skips the segment | Metered | Why not |
|---|---|---|
| No replica reported metadata | no | Nothing to compare yet |
| Replica's CRC will not parse | no | Bad response, not bad data |
| Replica CRC does not match ZK | no | Usually a reload in flight |
| A server is not in `GOOD` state | no | It may still be mutating the segment |
| Fewer replicas responded than expected | no | Cannot confirm consensus either way |
| `EQUAL` mode, replicas report different valid doc counts | **yes** | The replicas hold different data |

This is also why the meter sits inside the helper rather than at the generator's
`if (validDocIdsMetadata == null) { continue; }`. By the time the caller sees the `null`, the reason
is gone.

## Flow

```mermaid
sequenceDiagram
  participant G as UpsertCompactionTaskGenerator
  participant R as ServerSegmentMetadataReader
  participant S as Servers
  participant U as MinionTaskUtils
  participant M as ControllerMetrics

  G->>R: getSegmentToValidDocIdsMetadataFromServer
  R->>S: validDocIdsMetadata per segment batch
  S-->>R: per-replica valid doc counts, CRCs, server status
  R-->>G: segment -> List<ValidDocIdsMetadataInfo>

  loop per candidate segment
    G->>U: selectValidDocIdsMetadataForConsensus(..., metrics, tableNameWithType)
    alt CRC mismatch, unhealthy server, or short responder list
      U-->>G: null (skipped, not metered)
    else EQUAL mode and counts differ
      U->>M: addMeteredTableValue(UpsertCompactionSegmentsSkipped, 1)
      U-->>G: null (skipped, metered)
    else replicas agree
      U-->>G: chosen replica
    end
  end
```

## New metrics

| Metric | Type | Meaning |
|---|---|---|
| `UPSERT_COMPACTION_SEGMENT_SKIPPED_CONSENSUS_FAILURE` (`UpsertCompactionSegmentsSkipped`) | Meter, per table | A segment was not scheduled for `UpsertCompactionTask` because its replicas reported different valid doc counts |

No configuration changes. No JMX-to-Prometheus exporter changes either: `controller.yml` and
`pinot.yml` both end in a catch-all pattern for table-scoped meters, so this exports as
`pinot_controller_UpsertCompactionSegmentsSkipped_Count` with `table` and `tableType` labels.

**When this meter fires, do not switch `validDocIdsConsensusMode` to `UNSAFE` or `MOST_VALID_DOCS`
to unblock compaction.** That lets the task pick a diverged replica and delete rows from it. Take
the segment from the `Replicas disagree on valid doc count for segment` log line, which also names
both servers and both counts, and compare those two servers with the RocksDB key lookup API.

`YammerControllerPrometheusMetricsTest` enumerates every `ControllerMeter` and asserts each one
exports correctly, and it passes with the new entry, so that name and label set is verified rather
than assumed.

## Compatibility notes

- `UpsertCompactMergeTask` is deliberately untouched. It keeps calling the five-argument
  `selectValidDocIdsMetadataForConsensus` overload, which meters nothing, and no file under
  `upsertcompactmerge/` is in this diff.
- The existing, declared-but-unused
  `ControllerMeter.UPSERT_COMPACT_MERGE_SEGMENT_SKIPPED_CONSENSUS_FAILURE` is left exactly as it is.
  This PR does not wire it. Its name is specific to the compact-merge task, so reusing it for the
  compaction task would have exported a misleading metric name.
- `UpsertCompactionTaskGenerator.processValidDocIdsMetadata` is `@VisibleForTesting public static`
  and gains two parameters: `tableNameWithType` first and a nullable `ControllerMetrics` last. Any
  out-of-tree caller of that method needs updating. Passing `null` for the metrics keeps the old
  behavior exactly.

## Performance considerations

- Nothing new runs on the happy path. When the replicas agree, the added code is not reached.
- On a disagreement the cost is one `addMeteredTableValue` call, which is a map lookup plus a meter
  mark, on a path that already just decided to skip work.
- The extended log line reads two more fields off objects the code already holds, and only inside a
  branch that was already logging.

## Testing

`UpsertCompactionTaskGeneratorTest.testProcessValidDocIdsMetadataConsensusFailureMeter` drives
`processValidDocIdsMetadata` through each case and asserts the meter's delta:

| Case | Expected meter delta |
|---|---|
| Replicas agree | 0 |
| CRC mismatch between a replica and ZK | 0 |
| One server in `STARTING` | 0 |
| Only one of two replicas responded | 0 |
| Replicas report different valid doc counts, `EQUAL` mode | 1 |
| Same disagreement under `MOST_VALID_DOCS` | 0, the mode picks a winner instead of skipping |
| Same disagreement with a `null` `ControllerMetrics` | 0, and no exception |

The existing `testProcessValidDocIdsMetadataConsensus` still covers the selection behavior itself and
is unchanged apart from the two new arguments. The suite passes, as does
`YammerControllerPrometheusMetricsTest` for the new metric's export.

