### PR TITLE
Add `AbstractMetrics#removeTableMetrics` to drop every metric series for a table

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -19,8 +19,11 @@
 package org.apache.pinot.common.metrics;
 
 import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -48,6 +51,10 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
     G extends AbstractMetrics.Gauge, T extends AbstractMetrics.Timer> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractMetrics.class);
+
+  /// Name every table's series collapses into when table-level metrics are off. Shared by every table, so a
+  /// table-scoped sweep must never target it.
+  private static final String ALL_TABLES = "allTables";
 
   protected final String _metricPrefix;
 
@@ -711,6 +718,106 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
     return gauge.getGaugeName() + "." + pluginName;
   }
 
+  /// Removes every series this instance registered for the given table.
+  ///
+  /// Unlike the targeted `removeTable*` methods, this does not rebuild names from the rules used to emit them -- it
+  /// scans what is actually registered. That is the whole point. A series emitted with an extra key, or with a
+  /// composite table name, embeds a segment no caller can rediscover from the table name alone, so a sweep built on
+  /// reconstruction strands exactly those series and keeps stranding each new one that gets added.
+  ///
+  /// Matching is deliberately narrow:
+  ///
+  ///   - Only names under this instance's metric prefix are considered, so a table named after a component
+  ///     (`broker`) cannot match the prefix itself.
+  ///   - The table name must occupy whole `.`-delimited segments, never part of one -- `foo` does not match
+  ///     `foobar`, and a database-qualified `db.tbl_OFFLINE` matches only as a unit.
+  ///   - A sibling [AbstractMetrics] sharing this registry and prefix keeps its **gauges**. The ownership check
+  ///     below -- re-deriving the key under this instance's class -- is exact only where the registry key carries
+  ///     the owning class; yammer's does, dropwizard's discards it. What protects the case that actually matters,
+  ///     on every implementation, is the vocabulary check above: a sibling's gauge name is absent from this
+  ///     instance's [#getGauges()], so `<siblingGauge>.<table>` reads as meter-shaped and the table is not at
+  ///     offset 0, so it cannot match. Gauges are the only kind with a re-registration gate ([#_gaugeValues]), so
+  ///     dropping one from under its owner would silence it for the life of the process. A sibling's meter or
+  ///     timer may be dropped early where the key cannot distinguish owners; that is harmless -- they carry no
+  ///     gate and re-register on the next emission. Every instance should still run its own sweep, since that is
+  ///     what clears its own [#_gaugeValues].
+  ///
+  /// A table folded into the shared `allTables` aggregate is safe without a special case: no registered name
+  /// contains its name, so nothing matches. Passing `allTables` itself is rejected for the same reason it would be
+  /// a disaster -- it would delete the aggregate for every table at once.
+  ///
+  /// Two residual false positives are accepted: a workload or remote-cluster name exactly equal to a table name
+  /// sits in the same slot and would be swept. Both re-register on next use, so the cost is one counter reset.
+  ///
+  /// Two things this deliberately does **not** reach, both of which need their owner to clean up:
+  ///
+  ///   - Series a component registers outside any [AbstractMetrics] -- [ValidationMetrics] composes its own
+  ///     `pinot.controller.<table>.<gauge>` names against its own class and keeps its own value map, so the
+  ///     ownership check above skips it. Dropping its registry entries from here would strand that map and retire
+  ///     those gauges for the life of the process.
+  ///   - Names where the table is not followed by a path separator, such as the consumer client id form
+  ///     `<gauge>.<table>-<topic>-<partition>`. Matching those would mean accepting any prefix match, which is
+  ///     what makes `tbl` match `tbl_OFFLINE` and `db.tbl`.
+  ///
+  /// @param tableName the table to sweep, in whichever name form its emitters used (raw or with type)
+  /// @return the number of series removed
+  public int removeTableMetrics(String tableName) {
+    return removeTableMetrics(List.of(tableName));
+  }
+
+  /// Like [#removeTableMetrics(String)], for several tables at once. Prefer this when sweeping a batch: the
+  /// registry is scanned once per call, and yammer and dropwizard both materialise a fresh map on every
+  /// `allMetrics()`.
+  public int removeTableMetrics(Collection<String> tableNames) {
+    Set<String> targets = tableNames.stream().filter(t -> !ALL_TABLES.equals(t)).collect(Collectors.toSet());
+    if (targets.isEmpty()) {
+      return 0;
+    }
+    Set<String> gaugeNames =
+        Arrays.stream(getGauges()).map(Gauge::getGaugeName).collect(Collectors.toCollection(HashSet::new));
+    int removed = 0;
+    // Snapshot the keys before mutating: the compound registry hands back its live map.
+    for (PinotMetricName registeredName : new ArrayList<>(_metricsRegistry.allMetrics().keySet())) {
+      String name = registeredName.getName();
+      if (!name.startsWith(_metricPrefix)
+          || !matchesAnyTable(name.substring(_metricPrefix.length()), targets, gaugeNames)) {
+        continue;
+      }
+      // Re-deriving the key under this class is the ownership test: an identically named series registered by a
+      // sibling AbstractMetrics is a different key, so it compares unequal and is left for that instance to sweep.
+      if (registeredName.equals(PinotMetricUtils.makePinotMetricName(_clazz, name))) {
+        PinotMetricUtils.removeMetric(_metricsRegistry, registeredName);
+        removed++;
+      }
+    }
+    // The deprecated gauge paths gate re-registration on _gaugeValues, so an entry left here would stop a removed
+    // gauge from ever coming back. Swept from this instance's own map rather than from what matched above, so it
+    // stays correct even where the registry cannot tell two instances' series apart.
+    synchronized (_gaugeValues) {
+      _gaugeValues.keySet().removeIf(gaugeName -> matchesAnyTable(gaugeName, targets, gaugeNames));
+    }
+    return removed;
+  }
+
+  /// Whether the prefix-stripped metric name names one of the given tables.
+  ///
+  /// The table sits at exactly one offset, decided by the shape: gauges compose `<gauge>.<table>[.<key>]`, while
+  /// meters, timers and query phases compose `<table>.<rest>`. Which one applies is settled by asking whether the
+  /// leading segment is a known gauge name -- and that question is what keeps a bare `tbl_OFFLINE` from matching
+  /// `db.tbl_OFFLINE`, a genuinely different table whose series must survive. A free search for the name anywhere
+  /// in the string cannot tell those two apart.
+  private static boolean matchesAnyTable(String name, Set<String> tableNames, Set<String> gaugeNames) {
+    int firstDot = name.indexOf('.');
+    int start = firstDot > 0 && gaugeNames.contains(name.substring(0, firstDot)) ? firstDot + 1 : 0;
+    for (String tableName : tableNames) {
+      int end = start + tableName.length();
+      if (name.startsWith(tableName, start) && (end == name.length() || name.charAt(end) == '.')) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /// Remove gauge from Pinot metrics.
   /// @param gaugeName gauge name
   public void removeGauge(final String gaugeName) {
@@ -739,6 +846,6 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
   protected abstract G[] getGauges();
 
   protected String getTableName(String tableName) {
-    return _isTableLevelMetricsEnabled || _allowedTables.contains(tableName) ? tableName : "allTables";
+    return _isTableLevelMetricsEnabled || _allowedTables.contains(tableName) ? tableName : ALL_TABLES;
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/AbstractMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/AbstractMetricsTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.IntConsumer;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
+import org.apache.pinot.common.restlet.resources.RebalanceResult;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.metrics.PinotMeter;
 import org.apache.pinot.spi.metrics.PinotMetricName;
@@ -77,6 +78,107 @@ public abstract class AbstractMetricsTest {
   @AfterClass
   public void cleanUpMetricsFactory() {
     PinotMetricUtils.cleanUp();
+  }
+
+  @Test
+  public void testRemoveTableMetricsReachesNamesNoCallerCanReconstruct() {
+    ControllerMetrics metrics = buildTestMetrics();
+    String table = "myTable_OFFLINE";
+
+    // The four shapes a table series can take. The keyed timer is the one that matters: it is how
+    // tableRebalanceExecutionTimeMs is emitted, and no sweep that rebuilds names from the enums can reach it.
+    metrics.addMeteredTableValue(table, ControllerMeter.LLC_STREAM_DATA_LOSS, 1);
+    metrics.setValueOfTableGauge(table, ControllerGauge.NUMBER_OF_REPLICAS, 3);
+    metrics.setOrUpdateTableGauge(table, "someTenant", ControllerGauge.TABLE_TENANT_INFO, 1);
+    metrics.addTimedTableValue(table, RebalanceResult.Status.DONE.toString(),
+        ControllerTimer.TABLE_REBALANCE_EXECUTION_TIME_MS, 100, TimeUnit.MILLISECONDS);
+    Assert.assertEquals(metrics.getMetricsRegistry().allMetrics().size(), 4);
+
+    Assert.assertEquals(metrics.removeTableMetrics(table), 4);
+    Assert.assertTrue(metrics.getMetricsRegistry().allMetrics().isEmpty());
+
+    // A gauge removed here must be able to come back: _gaugeValues gates re-registration, so a stale entry there
+    // would silently retire the series for the life of the process.
+    metrics.setValueOfTableGauge(table, ControllerGauge.NUMBER_OF_REPLICAS, 5);
+    Assert.assertEquals(getGaugeValue(metrics, ControllerGauge.NUMBER_OF_REPLICAS.getGaugeName() + "." + table), 5);
+  }
+
+  /// Two AbstractMetrics routinely share a registry and a prefix -- OSS and a vendor extension do exactly that.
+  /// A sweep by one must not take the other's gauges with it: gauges are the only kind carrying a
+  /// re-registration gate, so dropping one from under its owner silences it for the life of the process. The
+  /// guarantee comes from the gauge-vocabulary check rather than from key identity, so it holds even on a
+  /// registry whose key does not record the owning class.
+  @Test
+  public void testSweepLeavesASiblingInstancesGaugesAlone() {
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty(CONFIG_OF_METRICS_FACTORY_CLASS_NAME, metricsFactoryClassName());
+    PinotMetricUtils.init(config);
+    PinotMetricsRegistry registry = buildRegistry();
+    String table = "shared_OFFLINE";
+
+    ControllerMetrics mine = new ControllerMetrics(registry);
+    ServerMetrics sibling = new ServerMetrics(mine.getMetricPrefix(), registry, true, java.util.Set.of());
+    mine.setValueOfTableGauge(table, ControllerGauge.NUMBER_OF_REPLICAS, 3);
+    sibling.setValueOfTableGauge(table, ServerGauge.LLC_PARTITION_CONSUMING, 1);
+    Assert.assertEquals(registry.allMetrics().size(), 2);
+
+    mine.removeTableMetrics(table);
+
+    // Asserted against the registry rather than through getGaugeValue: that helper derives the prefix from the
+    // instance type, so it would look the sibling up under "pinot.server." and miss the point of the test.
+    Assert.assertEquals(registry.allMetrics().size(), 1, "only the sweeping instance's gauge should be gone");
+    String survivor = mine.getMetricPrefix() + ServerGauge.LLC_PARTITION_CONSUMING.getGaugeName() + "." + table;
+    Assert.assertTrue(registry.allMetrics().keySet().stream().anyMatch(name -> survivor.equals(name.getName())),
+        "a sibling instance's gauge must survive a sweep by an instance sharing its prefix");
+  }
+
+  @Test
+  public void testRemoveTableMetricsMatchesWholeSegmentsOnly() {
+    ControllerMetrics metrics = buildTestMetrics();
+    metrics.addMeteredTableValue("foo_OFFLINE", ControllerMeter.LLC_STREAM_DATA_LOSS, 1);
+    metrics.addMeteredTableValue("foobar_OFFLINE", ControllerMeter.LLC_STREAM_DATA_LOSS, 1);
+    // Database-qualified names span two segments and must still match, but only as a unit.
+    metrics.addMeteredTableValue("db.foo_OFFLINE", ControllerMeter.LLC_STREAM_DATA_LOSS, 1);
+    // Gauges put the table in a different slot, so both shapes need covering.
+    metrics.setValueOfTableGauge("foo_OFFLINE", ControllerGauge.NUMBER_OF_REPLICAS, 1);
+    metrics.setValueOfTableGauge("db.foo_OFFLINE", ControllerGauge.NUMBER_OF_REPLICAS, 1);
+
+    // `db.foo_OFFLINE` is a different table, not a suffix of this one -- in either slot.
+    Assert.assertEquals(metrics.removeTableMetrics("foo_OFFLINE"), 2);
+    Assert.assertEquals(metrics.getMetricsRegistry().allMetrics().size(), 3);
+
+    Assert.assertEquals(metrics.removeTableMetrics("db.foo_OFFLINE"), 2);
+    // foobar survived every sweep: a prefix match is not a segment match.
+    Assert.assertEquals(metrics.getMetricsRegistry().allMetrics().size(), 1);
+  }
+
+  @Test
+  public void testRemoveTableMetricsLeavesGlobalAndOtherTablesAlone() {
+    ControllerMetrics metrics = buildTestMetrics();
+    metrics.addMeteredTableValue("doomed_OFFLINE", ControllerMeter.LLC_STREAM_DATA_LOSS, 1);
+    metrics.addMeteredTableValue("keep_OFFLINE", ControllerMeter.LLC_STREAM_DATA_LOSS, 1);
+    metrics.addMeteredGlobalValue(ControllerMeter.LLC_STREAM_DATA_LOSS, 1);
+    metrics.setValueOfGlobalGauge(ControllerGauge.VERSION, "1.0", 1);
+
+    Assert.assertEquals(metrics.removeTableMetrics("doomed_OFFLINE"), 1);
+    Assert.assertEquals(metrics.getMetricsRegistry().allMetrics().size(), 3);
+  }
+
+  /// With table-level metrics off every table folds into the shared `allTables` series. A sweep must not touch it:
+  /// deleting one table would otherwise zero the aggregate for all of them.
+  @Test
+  public void testRemoveTableMetricsCannotDeleteTheAllTablesAggregate() {
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty(CONFIG_OF_METRICS_FACTORY_CLASS_NAME, metricsFactoryClassName());
+    PinotMetricUtils.init(config);
+    ServerMetrics metrics = new ServerMetrics(buildRegistry(), false, java.util.Set.of());
+
+    metrics.addMeteredTableValue("folded_OFFLINE", ServerMeter.QUERIES_ON_TABLE, 1);
+    Assert.assertEquals(metrics.getMetricsRegistry().allMetrics().size(), 1);
+
+    Assert.assertEquals(metrics.removeTableMetrics("folded_OFFLINE"), 0);
+    Assert.assertEquals(metrics.removeTableMetrics("allTables"), 0);
+    Assert.assertEquals(metrics.getMetricsRegistry().allMetrics().size(), 1);
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/plugin/metrics/fake/FakePinotMetricName.java
+++ b/pinot-common/src/test/java/org/apache/pinot/plugin/metrics/fake/FakePinotMetricName.java
@@ -23,14 +23,25 @@ import org.apache.pinot.spi.metrics.PinotMetricName;
 
 
 public class FakePinotMetricName implements PinotMetricName {
+  /// Class-qualified, so that two `AbstractMetrics` sharing a metric prefix stay distinct keys -- mirroring the
+  /// yammer registry, where the owning class is part of the metric identity.
+  private final String _qualifiedName;
   private final String _name;
 
   public FakePinotMetricName(Class<?> clazz, String name) {
-    _name = clazz.getName() + "." + name;
+    _qualifiedName = clazz.getName() + "." + name;
+    _name = name;
   }
 
   @Override
   public Object getMetricName() {
+    return _qualifiedName;
+  }
+
+  /// The bare composed name. Must not include the class qualifier: callers use this to match a registered series
+  /// against a metric prefix, which the qualifier would push out of the way.
+  @Override
+  public String getName() {
     return _name;
   }
 
@@ -42,16 +53,16 @@ public class FakePinotMetricName implements PinotMetricName {
     if (!(o instanceof FakePinotMetricName)) {
       return false;
     }
-    return Objects.equals(_name, ((FakePinotMetricName) o)._name);
+    return Objects.equals(_qualifiedName, ((FakePinotMetricName) o)._qualifiedName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(_name);
+    return Objects.hashCode(_qualifiedName);
   }
 
   @Override
   public String toString() {
-    return _name;
+    return _qualifiedName;
   }
 }

--- a/pinot-plugins/pinot-metrics/pinot-compound-metrics/src/main/java/org/apache/pinot/plugin/metrics/compound/CompoundPinotMetricName.java
+++ b/pinot-plugins/pinot-metrics/pinot-compound-metrics/src/main/java/org/apache/pinot/plugin/metrics/compound/CompoundPinotMetricName.java
@@ -43,6 +43,11 @@ public class CompoundPinotMetricName implements PinotMetricName {
   }
 
   @Override
+  public String getName() {
+    return _toString;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/pinot-plugins/pinot-metrics/pinot-dropwizard/src/main/java/org/apache/pinot/plugin/metrics/dropwizard/DropwizardMetricName.java
+++ b/pinot-plugins/pinot-metrics/pinot-dropwizard/src/main/java/org/apache/pinot/plugin/metrics/dropwizard/DropwizardMetricName.java
@@ -38,6 +38,11 @@ public final class DropwizardMetricName implements PinotMetricName {
     return _metricName;
   }
 
+  @Override
+  public String getName() {
+    return _metricName;
+  }
+
   /// Overrides equals method by calling the equals from the actual metric name.
   @Override
   public boolean equals(Object obj) {

--- a/pinot-plugins/pinot-metrics/pinot-yammer/src/main/java/org/apache/pinot/plugin/metrics/yammer/YammerMetricName.java
+++ b/pinot-plugins/pinot-metrics/pinot-yammer/src/main/java/org/apache/pinot/plugin/metrics/yammer/YammerMetricName.java
@@ -38,6 +38,12 @@ public class YammerMetricName implements PinotMetricName {
     return _metricName;
   }
 
+  /// Overridden because [#toString()] here renders the JMX object name, not the bare metric name.
+  @Override
+  public String getName() {
+    return _metricName.getName();
+  }
+
   /// Overrides equals method by calling the equals from the actual metric name.
   @Override
   public boolean equals(Object obj) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMetricName.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMetricName.java
@@ -24,6 +24,19 @@ public interface PinotMetricName {
   /// Returns the actual metric name.
   Object getMetricName();
 
+  /// Returns the composed metric name, free of the registry-specific decoration that some implementations render
+  /// from [#toString()] (yammer renders a JMX object name there, for instance).
+  ///
+  /// This is what lets a caller reason about a series that is *already registered* without reconstructing its name
+  /// from the rules that produced it. Reconstruction cannot reach a name that carries a caller-supplied key, so a
+  /// bulk removal built on it silently strands exactly those series.
+  ///
+  /// The default returns [#toString()], which is correct for implementations whose string form is already the bare
+  /// name; implementations that decorate it must override.
+  default String getName() {
+    return toString();
+  }
+
   /// Overrides the equals method. This is needed as [PinotMetricName] is used as the key of the key-value pair
   /// inside the hashmap in MetricsRegistry. Without overriding equals() and hashCode() methods, all the existing k-v
   /// pairs


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Flow of AbstractMetrics\.removeTableMetrics: filter tables, snapshot metrics, match by prefix and table name, verify ownership, remove series, clean gauge values, return count\.

```mermaid
flowchart TD
  N0["Input table names #40;F1#41;"]:::stRemoved
  N1["Filter out allTables #40;F1#41;"]:::stAdded
  N2["Collect gauge names #40;F1#41;"]:::stAdded
  N3["Snapshot metric registry #40;F1#41;"]:::stAdded
  N4["Iterate over registered metric names #40;F1#41;"]:::stAdded
  N5["Get metric name string via getName#40;#41; #40;F1#44; F5#41;"]:::stAdded
  N6["Check prefix and table match #40;F1#41;"]:::stAdded
  N7["Evaluate matchesAnyTable #40;F1#41;"]:::stAdded
  N8["Check ownership via PinotMetricUtils#46;makePinotMetricName #40;F1#41;"]:::stAdded
  N9["Remove metric and increment counter #40;F1#41;"]:::stAdded
  N10["Clean up #95;gaugeValues for removed gauges #40;F1#41;"]:::stAdded
  N11["Return removed count #40;F1#41;"]:::stAdded
  N0 -->|"parameter to filter"| N1
  N1 -->|"filter to gauge names"| N2
  N2 -->|"gauge names to snapshot"| N3
  N3 -->|"snapshot to iteration"| N4
  N4 -->|"each iteration get name"| N5
  N5 -->|"name to prefix check"| N6
  N6 -->|"prefix pass to matchesAnyTable"| N7
  N6 -->|"prefix fail or no match #45;#62; continue"| N4
  N7 -->|"match true #45;#62; ownership check"| N8
  N8 -->|"ownership true #45;#62; removal"| N9
  N8 -->|"ownership false #45;#62; continue"| N4
  N9 -->|"after removal #45;#62; next iteration"| N4
  N4 -->|"loop ends #45;#62; gaugeValues cleanup"| N10
  N10 -->|"cleanup #45;#62; return"| N11
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics\.java — [before](https://github.com/apache/pinot/blob/bb448114ab2b93ddc2e27d53ec0ef1b4dee73d9d/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java) · [after](https://github.com/apache/pinot/blob/7be16970ae93e67281f29b88fdd73ac297f34c61/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java)
- F5: pinot\-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMetricName\.java — [before](https://github.com/apache/pinot/blob/bb448114ab2b93ddc2e27d53ec0ef1b4dee73d9d/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMetricName.java) · [after](https://github.com/apache/pinot/blob/7be16970ae93e67281f29b88fdd73ac297f34c61/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMetricName.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImJiNDQ4MTE0YWIyYjkzZGRjMmUyN2Q1M2VjMGVmMWI0ZGVlNzNkOWQiLCJjb250ZXh0X2hhc2giOiJlNjRmYmJkZmMzNWE5MGM3NDBkYmM0OTI2NDI2MzkxNTk4MGE0MjIzY2UwYjhiZTFiMTc1NWNiMWU3NmVmY2U0IiwiZ2VuZXJhdGVkX2F0IjoxNzkwMDQ4MjI1LCJoZWFkX3NoYSI6IjdiZTE2OTcwYWU5M2U2NzI4MWYyOWI4OGZkZDczYWMyOTdmMzRjNjEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI2YWFhMDQwNTU2NmM1NzZhNTFiNjRjYjRhMDMxMDMzYmIyNDA5ZWJhIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature ff4a2c31b16efb1f17fdd9ca0548e921b9e7647de4131317c8d7d387cad55b8d -->
<!-- pinot-pr-flow:end -->

## Intent

Delete a table and its metric series keep being exported by the brokers, servers and controllers that
were serving it — frozen at whatever value they last held — until each of those processes is restarted.

That is not merely untidy:

* **Dashboards lie.** A panel filtered by table shows a row for a table that no longer exists, holding
  its final measurement forever.
* **Alerts fire on ghosts.** Gauges such as `percentOfReplicas`, `segmentsInErrorState` or
  `percentSegmentsAvailable` keep their last value. If a table was degraded at the moment it was
  dropped — which is common, since deletion drives replicas offline — an alert can fire *after* the
  table is gone and never clear.
* **Cardinality only grows.** In a cluster where tables are created and dropped routinely, the metric
  registry, the JMX MBean set and everything downstream of it accumulate monotonically for the life of
  the process.

The goal is that deleting a table stops its metrics, everywhere, without waiting for a restart.

This PR does not do that on its own. It adds the one capability all three components need, and the one
SPI accessor that capability requires. It is deliberately **behaviour-neutral** — nothing calls it yet —
so that the API can be discussed separately from the three behaviour changes that will build on it.

## Why the cleanup we have today doesn't achieve it

Removal is retrofitted per component, and every implementation reconstructs metric names by replaying
the composition rules in `AbstractMetrics`. Reconstruction can only reach a name that is *fully
derivable from the table name*. Several names are not, so we have three hand-rolled sweeps, each
incomplete in a different way: the controller and server iterate their metric enums and so miss
anything carrying an extra segment between the table and the metric name, and the broker removes three
gauges and nothing else — no query counters, no phase timings, no time boundary, no quota gauges.

Two current examples of the blind spot:

**`tableRebalanceExecutionTimeMs`** is registered as `<table>.<jobStatus>.<timer>`, because
`TableRebalancer` passes a synthetic table name. The sweep composes `<table>.<timer>`. It never matches,
for any of the seven `RebalanceResult.Status` values. `cronSchedulerJobExecutionTimeMs` has the same
shape with a task type in place of the status.

**`OPEN_STRUCT_LAST_SEGMENT_KEY_DOC_COUNT`** is registered as `<gauge>.<table>.<column>$<key>`. The
server's deletion handler already documents this exact failure, works around it by recovering keys from
the table config, and concedes in its own javadoc that the workaround is partial: *"Gauges for
discovered keys survive until the server restarts."*

Both are the same defect. **Emission is modelled; removal is not.** Every new keyed metric silently
re-opens the hole, and nothing tells the author who added it.

## What this PR adds

A way to remove a table's series based on **what is actually registered**, rather than on names we can
reconstruct — so keyed, composite and future name shapes are all reachable without anyone having to
remember them.

Doing that needs one thing from the SPI: the ability to read a registered metric's name back as a
string. `PinotMetricName` exposes only `Object getMetricName()`, and `toString()` is not portable —
yammer renders a JMX object name there, dropwizard renders the bare name. So the PR adds a single
`default String getName()` and overrides it in the in-tree implementations. As a `default` method it is
source- and binary-compatible: a third-party metrics plugin keeps working, and at worst the sweep
matches nothing for it, which is exactly today's behaviour.

Arguably this accessor is one the interface should have had regardless; the sweep is just its first
consumer.

## The flow this unlocks

The follow-up PRs attach the sweep to each component's **existing** table-deletion signal — no new
messages, no new protocol, no new ZooKeeper writes.

```
                              DELETE /tables/{table}
                                        │
                        PinotHelixResourceManager.deleteTable
                                        │
   ┌────────────────────────────────────┼────────────────────────────────────┐
   │ ① removed from brokerResource      │ ② TableDeletionMessage             │ ③ table-config znode
   │    (happens FIRST)                 │    → every server                  │    removed (LAST)
   ▼                                    ▼                                    ▼
BROKER                               SERVER                              CONTROLLER (every one)
Helix ONLINE→OFFLINE/DROPPED         Helix USER_DEFINE_MSG                ZK child watch /CONFIGS/TABLE
   │                                    │                                    │
   ▼                                    ▼                                    ▼
BaseBrokerRoutingManager             SegmentMessageHandlerFactory         (new) TableMetricsCleaner
  .removeRoutingInternal              .TableDeletionMessageHandler
   │                                    │                                    │
   └────────────────┬───────────────────┴────────────────────────────────────┘
                    ▼
        AbstractMetrics.removeTableMetrics(...)      ← this PR
```


Two ordering facts the follow-ups have to respect, recorded here because they are not obvious and each
cost a debugging cycle to find:

* **The table config is removed last.** A "does the table still exist in ZooKeeper?" guard is therefore
  useless at broker and server time — the config is still present when the deletion becomes observable
  there. Only the controller's watch can use the ZK snapshot that reported the deletion, which *is*
  authoritative at that instant.
* **Some series key off the raw table name**, not the name with type — the deep store timers and byte
  counters, and the broker's whole query path. Those are shared by the OFFLINE and REALTIME halves of a
  hybrid table, so they may only be swept once neither half remains.

Scope note: this is deletion-driven. A table that still exists but has stopped being reported on —
disabled, ideal state unreadable, or leadership moved — remains `SegmentStatusChecker`'s business, since
only it knows it stopped reporting.

## Approaches considered and rejected

**Fix the two known offenders.** Add a keyed timer remover and loop over `RebalanceResult.Status`, then
do the same for the cron timer. Rejected as symptom-level: it leaves the defect class intact, so the
next keyed metric leaks again and the person adding it gets no signal.

**Extend the enum-driven sweep properly** — add an abstract `getTimers()` to `AbstractMetrics`, add
keyed `removeTableTimer` / `removeTableMeter` overloads, and have each component iterate every key it
knows about. This was the first design. Rejected because it inherits the very defect it is fixing: it
can still only remove names it can reconstruct, so it is complete only for as long as someone keeps it
in sync with every emission site. It also makes `getTimers()` a compile break for every subclass.

**Clean up inside `PinotHelixResourceManager#deleteTable`.** Superficially the obvious place. Rejected
because deletion happens in *one* process while the series live in nearly all of them: that controller
holds one metric registry out of N and cannot reach any broker's, any server's, or any other
controller's. It is also edge-triggered in the worst way — a missed call leaks forever, and it races a
delete-then-recreate.

**Parse `toString()` instead of adding an SPI method.** Rejected: the format is implementation-specific
(a JMX object name on yammer, the bare name on dropwizard), so this would mean implementation-specific
parsing inside a generic base class, silently wrong for any plugin we do not know about.

**Reach the name reflectively through the existing `Object getMetricName()`.** Technically workable for
the in-tree implementations. Rejected as an undocumented contract that would break silently rather than
at compile time.

**Have `AbstractMetrics` index the names it registers** and sweep that index, avoiding the SPI change
entirely. Genuinely attractive — ownership becomes exact by construction and sweeps get cheaper, since
`allMetrics()` materialises a fresh map on some implementations. Rejected on hot-path cost: it puts a
map write on every metric emission, and `addMeteredTableValue` runs several times per query, to save one
`default` method. It also introduces a second source of truth that can drift from the registry. The
registry scan pays its cost only on deletion, which is rare and operator-driven.

## Backward compatibility

* **No wire surface.** `PinotMetricName` is confined to the metrics packages, is not `Serializable`, and
  appears in no message class, ZooKeeper znode or request/response type. Metric names leave a process
  only as JMX MBeans.
* **No emitted name changes**, so every exporter rule, dashboard and alert keeps matching exactly what
  it matched before.
* **`default` method**, so third-party metrics plugins remain source- and binary-compatible.
* **Mixed versions are independent.** Each component has its own JVM, registry and copy of
  `pinot-common`; there is no shared metric state and nothing to negotiate. In a partially upgraded
  cluster each component simply behaves per its own version.
* **No behaviour change at all in this PR** — nothing calls the new method yet.

## Testing

`AbstractMetricsTest` is abstract with three concrete subclasses, so the new cases run against the
**fake**, **yammer** and **dropwizard** registries. They cover the names reconstruction cannot reach
(including a keyed timer registered exactly as `TableRebalancer` emits it), that a swept gauge can be
re-registered afterwards, whole-segment matching so neighbouring and database-qualified tables are not
caught, that global series and other tables survive, that the shared `allTables` aggregate cannot be
deleted, and that a second `AbstractMetrics` sharing the same registry and prefix keeps its gauges.

```
Pinot SPI ................ SUCCESS
Pinot Common ............. SUCCESS    46 tests
Pinot Yammer Metrics ..... SUCCESS    20 tests
Pinot Dropwizard Metrics . SUCCESS    20 tests
Pinot Compound Metrics ... SUCCESS
checkstyle:check + license:check ... clean
```
