### PR TITLE
Defer TTL watermark bump until after segment add/preload/replace (upsert & dedup)

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManager.java
@@ -168,18 +168,15 @@ public abstract class BasePartitionDedupMetadataManager implements PartitionDedu
     }
     try {
       // Bump watermark after doPreloadSegment; a concurrent removeExpiredPrimaryKeys sweep reading a pre-bumped
-      // watermark could expire keys this preload is about to insert. On the skip path no rows are added, so it is
-      // safe to bump before returning.
-      if (skipSegmentOutOfTTL(segment)) {
-        updateLargestSeenTime(segment);
-        return;
-      }
-      try (DedupUtils.DedupRecordInfoReader dedupRecordInfoReader = new DedupUtils.DedupRecordInfoReader(segment,
-          _primaryKeyColumns, _dedupTimeColumn)) {
-        Iterator<DedupRecordInfo> dedupRecordInfoIterator =
-            DedupUtils.getDedupRecordInfoIterator(dedupRecordInfoReader, segment.getSegmentMetadata().getTotalDocs());
-        doPreloadSegment(segment, dedupRecordInfoIterator);
-        updatePrimaryKeyGauge();
+      // watermark could expire keys this preload is about to insert.
+      if (!skipSegmentOutOfTTL(segment)) {
+        try (DedupUtils.DedupRecordInfoReader dedupRecordInfoReader = new DedupUtils.DedupRecordInfoReader(segment,
+            _primaryKeyColumns, _dedupTimeColumn)) {
+          Iterator<DedupRecordInfo> dedupRecordInfoIterator =
+              DedupUtils.getDedupRecordInfoIterator(dedupRecordInfoReader, segment.getSegmentMetadata().getTotalDocs());
+          doPreloadSegment(segment, dedupRecordInfoIterator);
+          updatePrimaryKeyGauge();
+        }
       }
       updateLargestSeenTime(segment);
     } catch (Exception e) {
@@ -209,12 +206,10 @@ public abstract class BasePartitionDedupMetadataManager implements PartitionDedu
     }
     try {
       // Bump watermark after add; see preloadSegment.
-      if (skipSegmentOutOfTTL(segment)) {
-        updateLargestSeenTime(segment);
-      } else {
+      if (!skipSegmentOutOfTTL(segment)) {
         addOrReplaceSegment(null, segment);
-        updateLargestSeenTime(segment);
       }
+      updateLargestSeenTime(segment);
     } catch (Exception e) {
       throw new RuntimeException(
           String.format("Caught exception while adding segment: %s of table: %s to %s", segmentName, _tableNameWithType,
@@ -233,12 +228,10 @@ public abstract class BasePartitionDedupMetadataManager implements PartitionDedu
     }
     try {
       // Bump watermark after replace; see preloadSegment.
-      if (skipSegmentOutOfTTL(newSegment)) {
-        updateLargestSeenTime(newSegment);
-      } else {
+      if (!skipSegmentOutOfTTL(newSegment)) {
         addOrReplaceSegment(oldSegment, newSegment);
-        updateLargestSeenTime(newSegment);
       }
+      updateLargestSeenTime(newSegment);
     } catch (Exception e) {
       throw new RuntimeException(
           String.format("Caught exception while replacing segment: %s with segment: %s of table: %s in %s",

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManager.java
@@ -167,7 +167,11 @@ public abstract class BasePartitionDedupMetadataManager implements PartitionDedu
       return;
     }
     try {
-      if (skipSegmentOutOfTTL(segment, true)) {
+      // Bump watermark after doPreloadSegment; a concurrent removeExpiredPrimaryKeys sweep reading a pre-bumped
+      // watermark could expire keys this preload is about to insert. On the skip path no rows are added, so it is
+      // safe to bump before returning.
+      if (skipSegmentOutOfTTL(segment)) {
+        updateLargestSeenTime(segment);
         return;
       }
       try (DedupUtils.DedupRecordInfoReader dedupRecordInfoReader = new DedupUtils.DedupRecordInfoReader(segment,
@@ -177,6 +181,7 @@ public abstract class BasePartitionDedupMetadataManager implements PartitionDedu
         doPreloadSegment(segment, dedupRecordInfoIterator);
         updatePrimaryKeyGauge();
       }
+      updateLargestSeenTime(segment);
     } catch (Exception e) {
       throw new RuntimeException(
           String.format("Caught exception while preloading segment: %s of table: %s in %s", segmentName,
@@ -203,8 +208,12 @@ public abstract class BasePartitionDedupMetadataManager implements PartitionDedu
       return;
     }
     try {
-      if (!skipSegmentOutOfTTL(segment, true)) {
+      // Bump watermark after add; see preloadSegment.
+      if (skipSegmentOutOfTTL(segment)) {
+        updateLargestSeenTime(segment);
+      } else {
         addOrReplaceSegment(null, segment);
+        updateLargestSeenTime(segment);
       }
     } catch (Exception e) {
       throw new RuntimeException(
@@ -223,8 +232,12 @@ public abstract class BasePartitionDedupMetadataManager implements PartitionDedu
       return;
     }
     try {
-      if (!skipSegmentOutOfTTL(newSegment, true)) {
+      // Bump watermark after replace; see preloadSegment.
+      if (skipSegmentOutOfTTL(newSegment)) {
+        updateLargestSeenTime(newSegment);
+      } else {
         addOrReplaceSegment(oldSegment, newSegment);
+        updateLargestSeenTime(newSegment);
       }
     } catch (Exception e) {
       throw new RuntimeException(
@@ -236,16 +249,13 @@ public abstract class BasePartitionDedupMetadataManager implements PartitionDedu
     }
   }
 
-  protected boolean skipSegmentOutOfTTL(IndexSegment segment, boolean updateWatermark) {
+  protected boolean skipSegmentOutOfTTL(IndexSegment segment) {
     if (_metadataTTL <= 0) {
       return false;
     }
     // If metadataTTL is enabled, we can skip adding dedup metadata for segment already out of the TTL. Different
     // from upsert table, there is no need to initialize things like validDocIds bitmap for those skipped segments.
     double maxDedupTime = getMaxDedupTime(segment);
-    if (updateWatermark) {
-      _largestSeenTime.getAndUpdate(time -> Math.max(time, maxDedupTime));
-    }
     if (!isOutOfMetadataTTL(maxDedupTime)) {
       return false;
     }
@@ -253,6 +263,18 @@ public abstract class BasePartitionDedupMetadataManager implements PartitionDedu
         _metadataTTL);
     // Return true if skipped. Boolean value allows subclasses to disable skipping.
     return true;
+  }
+
+  protected void updateLargestSeenTime(IndexSegment segment) {
+    if (_metadataTTL > 0) {
+      updateLargestSeenTime(getMaxDedupTime(segment));
+    }
+  }
+
+  protected void updateLargestSeenTime(double dedupTime) {
+    if (_metadataTTL > 0) {
+      _largestSeenTime.getAndUpdate(time -> Math.max(time, dedupTime));
+    }
   }
 
   private void addOrReplaceSegment(@Nullable IndexSegment oldSegment, IndexSegment newSegment)
@@ -281,7 +303,7 @@ public abstract class BasePartitionDedupMetadataManager implements PartitionDedu
       return;
     }
     try {
-      if (skipSegmentOutOfTTL(segment, false)) {
+      if (skipSegmentOutOfTTL(segment)) {
         return;
       }
       try (DedupUtils.DedupRecordInfoReader dedupRecordInfoReader = new DedupUtils.DedupRecordInfoReader(segment,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/ConcurrentMapPartitionDedupMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/ConcurrentMapPartitionDedupMetadataManager.java
@@ -116,9 +116,6 @@ class ConcurrentMapPartitionDedupMetadataManager extends BasePartitionDedupMetad
       return true;
     }
     try {
-      if (_metadataTTL > 0) {
-        _largestSeenTime.getAndUpdate(time -> Math.max(time, dedupRecordInfo.getDedupTime()));
-      }
       AtomicBoolean present = new AtomicBoolean(false);
       _primaryKeyToSegmentAndTimeMap.compute(HashUtils.hashPrimaryKey(dedupRecordInfo.getPrimaryKey(), _hashFunction),
           (primaryKey, segmentAndTime) -> {
@@ -131,6 +128,8 @@ class ConcurrentMapPartitionDedupMetadataManager extends BasePartitionDedupMetad
             present.set(true);
             return segmentAndTime;
           });
+      // Bump after the map is updated to avoid racing removeExpiredPrimaryKeys.
+      updateLargestSeenTime(dedupRecordInfo.getDedupTime());
       if (!present.get()) {
         updatePrimaryKeyGauge();
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -316,6 +316,12 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     return _metadataTTL > 0 || _deletedKeysTTL > 0;
   }
 
+  protected void updateLargestSeenComparisonValue(double comparisonValue) {
+    if (isTTLEnabled()) {
+      _largestSeenComparisonValue.getAndUpdate(v -> Math.max(v, comparisonValue));
+    }
+  }
+
   protected double getMaxComparisonValue(IndexSegment segment) {
     return ((Number) segment.getSegmentMetadata().getColumnMetadataMap().get(_comparisonColumns.get(0))
         .getMaxValue()).doubleValue();
@@ -364,12 +370,15 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   protected void doAddSegment(ImmutableSegmentImpl segment) {
     String segmentName = segment.getSegmentName();
     _logger.info("Adding segment: {}, current primary key count: {}", segmentName, getNumPrimaryKeys());
-    if (isTTLEnabled()) {
-      double maxComparisonValue = getMaxComparisonValue(segment);
-      _largestSeenComparisonValue.getAndUpdate(v -> Math.max(v, maxComparisonValue));
-      if (isOutOfMetadataTTL(maxComparisonValue) && skipAddSegmentOutOfTTL(segment)) {
-        return;
-      }
+    // Bump watermark after rows are added, otherwise a concurrent removeExpiredPrimaryKeys can expire keys we are
+    // about to insert. Per-partition state transitions are serialized by Helix, so concurrent doAddSegment on the
+    // same partition is not possible; the only concurrency here is with the sweep. If addSegment throws, the
+    // watermark stays unchanged - the segment's rows are not in the map, so recording their max would misrepresent
+    // what we have observed and let the sweep expire other keys against a phantom watermark.
+    double maxComparisonValue = isTTLEnabled() ? getMaxComparisonValue(segment) : TTL_WATERMARK_NOT_SET;
+    if (isTTLEnabled() && isOutOfMetadataTTL(maxComparisonValue) && skipAddSegmentOutOfTTL(segment)) {
+      updateLargestSeenComparisonValue(maxComparisonValue);
+      return;
     }
     long startTimeMs = System.currentTimeMillis();
     if (!_enableSnapshot) {
@@ -381,8 +390,13 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
           UpsertUtils.getRecordInfoIterator(recordInfoReader, segment.getSegmentMetadata().getTotalDocs());
       addSegment(segment, null, null, recordInfoIterator);
     } catch (Exception e) {
+      // On failure, do not bump the watermark: the segment's rows are not in the map, and bumping would let the
+      // sweep expire other keys against a phantom watermark. Helix retries the transition and re-bumps.
       throw new RuntimeException(
           String.format("Caught exception while adding segment: %s, table: %s", segmentName, _tableNameWithType), e);
+    }
+    if (isTTLEnabled()) {
+      updateLargestSeenComparisonValue(maxComparisonValue);
     }
 
     // Update metrics
@@ -442,12 +456,12 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       segment.enableUpsert(this, new ThreadSafeMutableRoaringBitmap(), queryableDocIds);
       return;
     }
-    if (isTTLEnabled()) {
-      double maxComparisonValue = getMaxComparisonValue(segment);
-      _largestSeenComparisonValue.getAndUpdate(v -> Math.max(v, maxComparisonValue));
-      if (isOutOfMetadataTTL(maxComparisonValue) && skipPreloadSegmentOutOfTTL(segment, validDocIds)) {
-        return;
-      }
+    // Bump watermark after rows are added; see doAddSegment.
+    double maxComparisonValue = isTTLEnabled() ? getMaxComparisonValue(segment) : TTL_WATERMARK_NOT_SET;
+    if (isTTLEnabled() && isOutOfMetadataTTL(maxComparisonValue)
+        && skipPreloadSegmentOutOfTTL(segment, validDocIds)) {
+      updateLargestSeenComparisonValue(maxComparisonValue);
+      return;
     }
     try (UpsertUtils.RecordInfoReader recordInfoReader = new UpsertUtils.RecordInfoReader(segment, _primaryKeyColumns,
         _comparisonColumns, _deleteRecordColumn)) {
@@ -456,6 +470,9 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       throw new RuntimeException(
           String.format("Caught exception while preloading segment: %s, table: %s", segmentName, _tableNameWithType),
           e);
+    }
+    if (isTTLEnabled()) {
+      updateLargestSeenComparisonValue(maxComparisonValue);
     }
 
     // Update metrics
@@ -596,12 +613,10 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       replaceSegment(segment, null, null, null, oldSegment);
       return;
     }
-    if (isTTLEnabled()) {
-      double maxComparisonValue = getMaxComparisonValue(segment);
-      _largestSeenComparisonValue.getAndUpdate(v -> Math.max(v, maxComparisonValue));
-      // Segment might be uploaded directly to the table to replace an old segment. So update the TTL watermark but
-      // we can't skip segment even if it's out of TTL as its validDocIds bitmap is not updated yet.
-    }
+    // Bump watermark after replaceSegment; see doAddSegment. A segment may be uploaded directly to the table to
+    // replace an old one; the incoming validDocIds bitmap is not populated yet, so we cannot skip even if the
+    // segment is out of TTL.
+    double maxComparisonValue = isTTLEnabled() ? getMaxComparisonValue(segment) : TTL_WATERMARK_NOT_SET;
     try (UpsertUtils.RecordInfoReader recordInfoReader = new UpsertUtils.RecordInfoReader(segment, _primaryKeyColumns,
         _comparisonColumns, _deleteRecordColumn)) {
       // Reload-only fast path for an upsert + TTL table. The incoming segment carries a validDocIds snapshot ONLY when
@@ -632,6 +647,9 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       throw new RuntimeException(
           String.format("Caught exception while replacing segment: %s, table: %s, message: %s", segmentName,
               _tableNameWithType, e.getMessage()), e);
+    }
+    if (isTTLEnabled()) {
+      updateLargestSeenComparisonValue(maxComparisonValue);
     }
 
     // Update metrics

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -369,11 +369,6 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
     int newDocId = recordInfo.getDocId();
     Comparable newComparisonValue = recordInfo.getComparisonValue();
 
-    // When TTL is enabled, update largestSeenComparisonValue when adding new record
-    if (isTTLEnabled()) {
-      double comparisonValue = ((Number) newComparisonValue).doubleValue();
-      _largestSeenComparisonValue.getAndUpdate(v -> Math.max(v, comparisonValue));
-    }
     _primaryKeyToRecordLocationMap.compute(HashUtils.hashPrimaryKey(recordInfo.getPrimaryKey(), _hashFunction),
         (primaryKey, currentRecordLocation) -> {
           if (currentRecordLocation != null) {
@@ -409,6 +404,10 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
             return new RecordLocation(segment, newDocId, newComparisonValue);
           }
         });
+    // Bump after the record is installed to avoid racing removeExpiredPrimaryKeys.
+    if (isTTLEnabled()) {
+      updateLargestSeenComparisonValue(((Number) newComparisonValue).doubleValue());
+    }
 
     updatePrimaryKeyGauge();
     return !isOutOfOrderRecord.get();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java
@@ -490,12 +490,6 @@ public class ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes
     int newDocId = recordInfo.getDocId();
     Comparable newComparisonValue = recordInfo.getComparisonValue();
 
-    // When TTL is enabled, update largestSeenComparisonValue when adding new record
-    if (_deletedKeysTTL > 0) {
-      double comparisonValue = ((Number) newComparisonValue).doubleValue();
-      _largestSeenComparisonValue.getAndUpdate(v -> Math.max(v, comparisonValue));
-    }
-
     _primaryKeyToRecordLocationMap.compute(HashUtils.hashPrimaryKey(recordInfo.getPrimaryKey(), _hashFunction),
         (primaryKey, currentRecordLocation) -> {
           if (currentRecordLocation != null) {
@@ -540,6 +534,10 @@ public class ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes
             return new RecordLocation(segment, newDocId, newComparisonValue, 1);
           }
         });
+    // Bump after the record is installed; see ConcurrentMapPartitionUpsertMetadataManager#doAddRecord.
+    if (_deletedKeysTTL > 0) {
+      updateLargestSeenComparisonValue(((Number) newComparisonValue).doubleValue());
+    }
 
     updatePrimaryKeyGauge();
     return !isOutOfOrderRecord.get();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/dedup/ConcurrentMapPartitionDedupMetadataManagerWithTTLTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/dedup/ConcurrentMapPartitionDedupMetadataManagerWithTTLTest.java
@@ -437,6 +437,37 @@ public class ConcurrentMapPartitionDedupMetadataManagerWithTTLTest {
     verifyAddSegmentAfterStop(HashFunction.MURMUR3);
   }
 
+  // skipSegmentOutOfTTL must not bump the watermark: caller does that after the rows are added, so a concurrent
+  // sweep cannot expire keys the in-flight add is about to insert.
+  @Test
+  public void testSkipSegmentOutOfTTLDoesNotBumpWatermark()
+      throws IOException {
+    _dedupContextBuilder.setHashFunction(HashFunction.NONE);
+    ConcurrentMapPartitionDedupMetadataManager metadataManager =
+        new ConcurrentMapPartitionDedupMetadataManager(DedupTestUtils.REALTIME_TABLE_NAME, 0,
+            _dedupContextBuilder.build());
+
+    metadataManager._largestSeenTime.set(5000);
+
+    IndexSegment segment = DedupTestUtils.mockSegment(1, 10);
+    SegmentMetadataImpl segmentMetadata = mock(SegmentMetadataImpl.class);
+    ColumnMetadata columnMetadata = mock(ColumnMetadata.class);
+    when(segmentMetadata.getColumnMetadataMap()).thenReturn(new TreeMap<>() {{
+        this.put(DEDUP_TIME_COLUMN_NAME, columnMetadata);
+      }});
+    doReturn(10000.0).when(columnMetadata).getMaxValue();
+    when(segment.getSegmentMetadata()).thenReturn(segmentMetadata);
+
+    assertFalse(metadataManager.skipSegmentOutOfTTL(segment));
+    assertEquals(metadataManager._largestSeenTime.get(), 5000.0);
+
+    metadataManager.updateLargestSeenTime(segment);
+    assertEquals(metadataManager._largestSeenTime.get(), 10000.0);
+
+    metadataManager.stop();
+    metadataManager.close();
+  }
+
   private void verifyAddSegmentAfterStop(HashFunction hashFunction) {
     _dedupContextBuilder.setHashFunction(hashFunction);
     ConcurrentMapPartitionDedupMetadataManager metadataManager =

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -265,6 +265,39 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     upsertMetadataManager.close();
   }
 
+  // Watermark must not advance before addSegment inserts rows, or a concurrent sweep can drop the incoming keys.
+  @Test
+  public void testDoAddSegmentBumpsWatermarkAfterRowInsert()
+      throws Exception {
+    _contextBuilder.setEnableSnapshot(true).setMetadataTTL(30);
+    double[] watermarkDuringAdd = {Double.NaN};
+    ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build()) {
+          @Override
+          public void addSegment(ImmutableSegmentImpl segment, @Nullable ThreadSafeMutableRoaringBitmap validDocIds,
+              @Nullable ThreadSafeMutableRoaringBitmap queryableDocIds, Iterator<RecordInfo> recordInfoIterator) {
+            watermarkDuringAdd[0] = getWatermark();
+            super.addSegment(segment, validDocIds, queryableDocIds, recordInfoIterator);
+          }
+        };
+
+    ThreadSafeMutableRoaringBitmap seedValidDocIds = new ThreadSafeMutableRoaringBitmap();
+    MutableSegment seedSegment = mockMutableSegment(1, seedValidDocIds, null);
+    upsertMetadataManager.addRecord(seedSegment, new RecordInfo(makePrimaryKey(999), 0, 100, false));
+    assertEquals(upsertMetadataManager.getWatermark(), 100.0);
+
+    ThreadSafeMutableRoaringBitmap validDocIds = new ThreadSafeMutableRoaringBitmap();
+    ImmutableSegmentImpl segment =
+        createRealSegment("deferred_bump_segment", new int[]{1, 2, 3}, new int[]{150, 180, 200}, validDocIds);
+    upsertMetadataManager.addSegment(segment);
+
+    assertEquals(watermarkDuringAdd[0], 100.0);
+    assertEquals(upsertMetadataManager.getWatermark(), 200.0);
+
+    upsertMetadataManager.stop();
+    upsertMetadataManager.close();
+  }
+
   @Test
   public void testManageWatermark()
       throws IOException {


### PR DESCRIPTION
## Problem

Both upsert (`BasePartitionUpsertMetadataManager.doAddSegment` / `doPreloadSegment` / `doReplaceSegment`) and dedup (`BasePartitionDedupMetadataManager.addSegment` / `preloadSegment` / `replaceSegment`) advance the TTL watermark (`_largestSeenComparisonValue` / `_largestSeenTime`) **before** the segment's rows are inserted into the primary-key map. A concurrent `removeExpiredPrimaryKeys` sweep on another thread reads the newly-advanced watermark and can expire pointers for primary keys the in-flight add is about to insert, producing duplicate first-row inserts on those keys.

Race timeline (upsert `doAddSegment` for segment with `max=1000`, `metadataTTL=300`, previous watermark `500`):
1. T1 bumps `_largestSeenComparisonValue` from 500 → 1000.
2. T2 (`removeExpiredPrimaryKeys`) reads watermark = 1000, expires all PKs with comparison value `< 700`.
3. T1 inserts segment's rows; any key T2 just expired that this segment carries lands with no prior pointer, becoming a first-row insert → duplicate visible row.

Dedup has the same race in the segment-level pre-bump inside `skipSegmentOutOfTTL(segment, updateWatermark=true)`.

## Fix

Move the watermark bump to **after** the add/preload/replace call returns. The out-of-TTL skip path bumps the watermark before returning as before, since it inserts no rows and cannot race with the sweep.

For dedup, drop the `updateWatermark` parameter on `skipSegmentOutOfTTL` (was always `true` for adds and `false` for removes) and introduce a small `updateLargestSeenTime` helper that callers invoke at the correct point.

If the add throws, the watermark stays unchanged. Bumping on failure would let the sweep expire other keys against a phantom watermark justified by a segment we did not actually process; Helix retries the failed transition and the retry re-computes and bumps legitimately.

Per-partition state transitions are serialized by Helix, so concurrent add invocations on the same partition are not possible; the only concurrency here is with the sweep thread.