### PR TITLE
Reuse compiled constant string casts during planning

### DIFF
--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkConstantCastPlanning.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkConstantCastPlanning.java
@@ -1,0 +1,145 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.config.provider.StaticTableCache;
+import org.apache.pinot.query.QueryEnvironment;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+
+/// Measures SQL parsing, validation and logical optimization of timestamp range filters, with and without a window
+/// selecting the latest version of each event. CAST, EPOCH_STRING_CAST and TIMESTAMP_LITERAL use equivalent constants;
+/// EPOCH_MILLIS uses a LONG time column as a control without timestamp casts. No cluster or query execution is needed.
+/// Each benchmark thread owns its environment and cycles through prebuilt queries with different account IDs, keeping
+/// query-string construction outside the measured operation.
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(2)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@State(Scope.Thread)
+public class BenchmarkConstantCastPlanning {
+  private static final String TABLE_NAME = "events";
+  private static final int NUM_QUERIES = 1024;
+
+  @Param({"FILTER", "WINDOW"})
+  private String _queryShape;
+
+  @Param({"CAST", "EPOCH_STRING_CAST", "TIMESTAMP_LITERAL", "EPOCH_MILLIS"})
+  private String _literalForm;
+
+  private QueryEnvironment _queryEnvironment;
+  private String[] _queries;
+  private int _nextQuery;
+
+  @Setup
+  public void setUp() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("account_id", DataType.LONG)
+        .addSingleValueDimension("version", DataType.LONG)
+        .addSingleValueDimension("sequence_id", DataType.LONG)
+        .addMetric("reading", DataType.DOUBLE)
+        .addDateTime("event_time", DataType.TIMESTAMP, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .addDateTime("event_time_ms", DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .build();
+    schema.setEnableColumnBasedNullHandling(true);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+    StaticTableCache tableCache = new StaticTableCache(List.of(tableConfig), List.of(schema), List.of(), false);
+    _queryEnvironment = new QueryEnvironment(QueryEnvironment.configBuilder()
+        .requestId(0L)
+        .database(CommonConstants.DEFAULT_DATABASE)
+        .tableCache(tableCache)
+        .isNullHandlingEnabled(true)
+        .defaultUsePhysicalOptimizer(false)
+        .build());
+
+    String timeColumn = "event_time";
+    String lowerBound;
+    String upperBound;
+    switch (_literalForm) {
+      case "CAST":
+        lowerBound = "CAST('2024-01-01 00:00:00' AS TIMESTAMP)";
+        upperBound = "CAST('2024-02-01 00:00:00' AS TIMESTAMP)";
+        break;
+      case "EPOCH_STRING_CAST":
+        lowerBound = "CAST('1704067200000' AS TIMESTAMP)";
+        upperBound = "CAST('1706745600000' AS TIMESTAMP)";
+        break;
+      case "TIMESTAMP_LITERAL":
+        lowerBound = "TIMESTAMP '2024-01-01 00:00:00'";
+        upperBound = "TIMESTAMP '2024-02-01 00:00:00'";
+        break;
+      case "EPOCH_MILLIS":
+        timeColumn = "event_time_ms";
+        lowerBound = "1704067200000";
+        upperBound = "1706745600000";
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown literal form: " + _literalForm);
+    }
+
+    _queries = new String[NUM_QUERIES];
+    for (int i = 0; i < NUM_QUERIES; i++) {
+      String filter = " FROM " + TABLE_NAME + " WHERE account_id = " + (1000000L + i)
+          + " AND " + timeColumn + " >= " + lowerBound + " AND " + timeColumn + " < " + upperBound;
+      switch (_queryShape) {
+        case "FILTER":
+          _queries[i] = "SELECT " + timeColumn + ", reading" + filter + " ORDER BY " + timeColumn + " LIMIT 1000";
+          break;
+        case "WINDOW":
+          _queries[i] = "SELECT " + timeColumn + ", reading FROM (SELECT " + timeColumn
+              + ", reading, ROW_NUMBER() OVER (PARTITION BY account_id, " + timeColumn
+              + " ORDER BY version DESC, sequence_id DESC) AS row_num" + filter
+              + ") WHERE row_num = 1 ORDER BY " + timeColumn + " LIMIT 1000";
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown query shape: " + _queryShape);
+      }
+    }
+    _nextQuery = 0;
+  }
+
+  @Benchmark
+  public Set<String> compile() {
+    String query = _queries[_nextQuery];
+    _nextQuery = (_nextQuery + 1) & (NUM_QUERIES - 1);
+    try (QueryEnvironment.CompiledQuery compiledQuery = _queryEnvironment.compile(query)) {
+      return compiledQuery.getTableNames();
+    }
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rex/PinotRexExecutor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rex/PinotRexExecutor.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.calcite.rex;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.calcite.avatica.util.DateTimeUtils;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexExecutor;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+
+/// Reduces string literal casts to TIMESTAMP without compiling a generated Java class for each reduction. All other
+/// expressions use Calcite's executor. The singleton is thread-safe: each reduction keeps its results local, and the
+/// default Calcite executor creates a separate executable for each invocation.
+public final class PinotRexExecutor implements RexExecutor {
+  public static final PinotRexExecutor INSTANCE = new PinotRexExecutor(RexUtil.EXECUTOR);
+
+  private final RexExecutor _fallback;
+
+  @VisibleForTesting
+  PinotRexExecutor(RexExecutor fallback) {
+    _fallback = fallback;
+  }
+
+  @Override
+  public void reduce(RexBuilder rexBuilder, List<RexNode> constExps, List<RexNode> reducedValues) {
+    // Calcite treats reduction as all-or-nothing. Delegate the entire batch if any expression is unsupported, so a
+    // failure in the fallback cannot leave the batch partially reduced.
+    for (RexNode expression : constExps) {
+      if (!isStringToTimestampCast(expression)) {
+        _fallback.reduce(rexBuilder, constExps, reducedValues);
+        return;
+      }
+    }
+    List<RexNode> literals = new ArrayList<>(constExps.size());
+    try {
+      for (RexNode expression : constExps) {
+        RexLiteral operand = (RexLiteral) ((RexCall) expression).getOperands().get(0);
+        // These are the same conversion and literal construction used by Calcite's generated CAST and RexExecutable.
+        // In particular, do not use Pinot's timestamp parser: its accepted inputs differ from Calcite's.
+        Long timestamp = operand.isNull() ? null
+            : DateTimeUtils.timestampStringToUnixDate(RexLiteral.stringValue(operand));
+        literals.add(rexBuilder.makeLiteral(timestamp, expression.getType(), true));
+      }
+    } catch (RuntimeException e) {
+      // Calcite also leaves the entire batch unchanged when parsing or literal construction fails. Retrying the same
+      // conversion through generated code cannot reduce it; leave error handling to the later planning/execution path.
+      reducedValues.addAll(constExps);
+      return;
+    }
+    reducedValues.addAll(literals);
+  }
+
+  private static boolean isStringToTimestampCast(RexNode expression) {
+    if (!(expression instanceof RexCall)) {
+      return false;
+    }
+    RexCall call = (RexCall) expression;
+    if (call.getOperator() != SqlStdOperatorTable.CAST || call.getOperands().size() != 1
+        || call.getType().getSqlTypeName() != SqlTypeName.TIMESTAMP) {
+      return false;
+    }
+    RexNode operand = call.getOperands().get(0);
+    SqlTypeName sourceType = operand.getType().getSqlTypeName();
+    return operand instanceof RexLiteral && (sourceType == SqlTypeName.CHAR || sourceType == SqlTypeName.VARCHAR);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -44,6 +44,7 @@ import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexExecutor;
 import org.apache.calcite.runtime.CalciteContextException;
 import org.apache.calcite.sql.SqlExplain;
 import org.apache.calcite.sql.SqlExplainFormat;
@@ -62,6 +63,7 @@ import org.apache.pinot.calcite.rel.rules.PinotJoinToDynamicBroadcastRule;
 import org.apache.pinot.calcite.rel.rules.PinotRelDistributionTraitRule;
 import org.apache.pinot.calcite.rel.rules.PinotRuleUtils;
 import org.apache.pinot.calcite.rel.rules.PinotSortExchangeCopyRule;
+import org.apache.pinot.calcite.rex.PinotRexExecutor;
 import org.apache.pinot.calcite.sql.fun.PinotOperatorTable;
 import org.apache.pinot.calcite.sql2rel.PinotConvertletTable;
 import org.apache.pinot.calcite.sql2rel.PinotRelDecorrelator;
@@ -446,6 +448,13 @@ public class QueryEnvironment {
   ///
   /// It is important to notice that the returned tree is not yet [optimized][#optimize(RelRoot, PlannerContext)].
   private RelRoot toRelation(SqlNode sqlNode, PlannerContext plannerContext) {
+    RelOptPlanner planner = plannerContext.getRelOptPlanner();
+    RexExecutor originalExecutor = planner.getExecutor();
+    if (originalExecutor == null) {
+      // SqlToRelConverter transforms its RelBuilder, discarding executors provided only through the builder context.
+      // Install on the per-query planner so conversion and field trimming avoid generated timestamp cast reducers.
+      planner.setExecutor(PinotRexExecutor.INSTANCE);
+    }
     try {
       RexBuilder rexBuilder = new RexBuilder(_typeFactory);
       RelOptCluster cluster = RelOptCluster.create(plannerContext.getRelOptPlanner(), rexBuilder);
@@ -481,6 +490,9 @@ public class QueryEnvironment {
     } catch (Throwable e) {
       throw QueryErrorCode.QUERY_PLANNING.asException(
           "Error converting query to relational expression: " + e.getMessage(), e);
+    } finally {
+      // Keep the executor policy of the subsequent optimization phase unchanged.
+      planner.setExecutor(originalExecutor);
     }
   }
 

--- a/pinot-query-planner/src/test/java/org/apache/pinot/calcite/rex/PinotRexExecutorTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/calcite/rex/PinotRexExecutorTest.java
@@ -1,0 +1,311 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.calcite.rex;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import org.apache.calcite.DataContext;
+import org.apache.calcite.DataContexts;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexExecutor;
+import org.apache.calcite.rex.RexExecutorImpl;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.Hook;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.NlsString;
+import org.apache.pinot.calcite.rel.rules.PinotRuleUtils;
+import org.apache.pinot.query.type.TypeFactory;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+
+/// Compares timestamp constant reduction with Calcite and verifies that supported casts bypass code generation.
+public class PinotRexExecutorTest {
+  private static final RexExecutor CALCITE_EXECUTOR = new RexExecutorImpl(DataContexts.EMPTY);
+  private static final RexExecutor FAILING_FALLBACK = (builder, expressions, results) -> {
+    throw new AssertionError("Supported timestamp casts must not use the fallback: " + expressions);
+  };
+
+  @DataProvider
+  public Object[][] timestampLiterals() {
+    List<Object[]> cases = new ArrayList<>();
+    for (SqlTypeName sourceType : List.of(SqlTypeName.CHAR, SqlTypeName.VARCHAR)) {
+      for (String value : List.of("2026-09-01 00:00:00", "1970-01-01 00:00:00", "1969-12-31 23:59:59.999",
+          "2000-02-29 12:34:56.123", "2026-09-01 12:34:56.1", "2026-09-01 12:34:56.123456789",
+          "2026-09-01 23:59:59.9999", "1969-12-31 23:59:59.9999")) {
+        cases.add(new Object[]{sourceType, value, 3});
+      }
+      for (int precision : List.of(0, 1, 2)) {
+        cases.add(new Object[]{sourceType, "1969-12-31 23:59:59.987654", precision});
+        cases.add(new Object[]{sourceType, "2026-09-01 12:34:56.987654", precision});
+      }
+      cases.add(new Object[]{sourceType, "2026-09-01 23:59:59.9999", 0});
+      cases.add(new Object[]{sourceType, "1969-12-31 23:59:59.9999", 0});
+    }
+    return cases.toArray(new Object[0][]);
+  }
+
+  @Test(dataProvider = "timestampLiterals")
+  public void testSupportedCastsDoNotUseFallback(SqlTypeName sourceType, String value, int precision) {
+    LiteralRexBuilder builder = new LiteralRexBuilder();
+    RexNode expression = timestampCast(builder, sourceType, value, precision);
+    assertEquals(expression.getKind(), SqlKind.CAST);
+    List<RexNode> expected = reduce(CALCITE_EXECUTOR, builder, List.of(expression));
+    assertFalse(expected.get(0).equals(expression), "The Calcite control must reduce the test expression");
+
+    List<RexNode> actual = reduce(new PinotRexExecutor(FAILING_FALLBACK), builder, List.of(expression));
+    assertEquals(actual, expected);
+    assertEquals(actual.get(0).getType(), expected.get(0).getType());
+  }
+
+  @Test
+  public void testNullCastsPreserveTypeAndNullabilityWithoutFallback() {
+    LiteralRexBuilder builder = new LiteralRexBuilder();
+    for (SqlTypeName sourceType : List.of(SqlTypeName.CHAR, SqlTypeName.VARCHAR)) {
+      RelDataType type = builder.getTypeFactory().createSqlType(sourceType, 20);
+      RelDataType target = builder.getTypeFactory().createTypeWithNullability(
+          builder.getTypeFactory().createSqlType(SqlTypeName.TIMESTAMP, 3), true);
+      RexNode expression = builder.makeAbstractCast(target, builder.makeNullLiteral(type), false);
+      List<RexNode> expected = reduce(CALCITE_EXECUTOR, builder, List.of(expression));
+      List<RexNode> actual = reduce(new PinotRexExecutor(FAILING_FALLBACK), builder, List.of(expression));
+      assertEquals(actual, expected);
+      assertTrue(RexLiteral.isNullLiteral(actual.get(0)));
+      assertEquals(actual.get(0).getType(), expected.get(0).getType());
+    }
+  }
+
+  @DataProvider
+  public Object[][] timestampEdgeInputs() {
+    return new Object[][]{
+        {"2026-09-01"}, {" 2026-09-01 12:34:56.123 "}, {"2026-09-01 12:34:56.123   "},
+        {"\t2026-09-01 12:34:56.123\n"}, {""}, {"not-a-timestamp"}, {"2026-02-30 00:00:00"},
+        {"2026-09-01 25:00:00"}, {"2026-09-01T12:34:56Z"}, {"2026-09-01 12:34:56+02:00"},
+        {"1788266096123"}
+    };
+  }
+
+  @Test(dataProvider = "timestampEdgeInputs")
+  public void testWhitespaceAndInvalidInputsMatchCalcite(String value) {
+    LiteralRexBuilder builder = new LiteralRexBuilder();
+    RexNode expression = timestampCast(builder, SqlTypeName.CHAR, value, 3);
+    List<RexNode> input = List.of(expression);
+    List<RexNode> expected = reduce(CALCITE_EXECUTOR, builder, input);
+    CountingFallback fallback = new CountingFallback(CALCITE_EXECUTOR);
+
+    List<RexNode> actual = reduce(new PinotRexExecutor(fallback), builder, input);
+    assertEquals(actual, expected);
+    assertEquals(fallback._calls.get(), 0, "Eligible casts must bypass generated code even when conversion fails");
+    if (expected.equals(input)) {
+      assertSame(actual.get(0), expression, "Failed casts must retain the original expression");
+    }
+  }
+
+  @Test
+  public void testUnsupportedExpressionsDelegateTheWholeBatchInOrder() {
+    LiteralRexBuilder builder = new LiteralRexBuilder();
+    RexNode fast = timestampCast(builder, SqlTypeName.CHAR, "2026-09-01 12:34:56.123", 3);
+    RelDataType timestamp = builder.getTypeFactory().createSqlType(SqlTypeName.TIMESTAMP, 3);
+    RexLiteral string = builder.stringLiteral("2026-09-01 12:34:56.123", SqlTypeName.CHAR);
+    List<RexNode> unsupported = List.of(
+        builder.makeAbstractCast(builder.getTypeFactory().createSqlType(SqlTypeName.INTEGER),
+            builder.makeLiteral("123"), false),
+        builder.makeAbstractCast(timestamp, string, true),
+        builder.makeAbstractCast(timestamp, string, false, builder.makeLiteral("YYYY-MM-DD HH24:MI:SS.FF")),
+        builder.makeAbstractCast(timestamp, builder.makeAbstractCast(
+            builder.getTypeFactory().createSqlType(SqlTypeName.VARCHAR, 30), string, false), false),
+        builder.makeCall(timestamp, new SqlSpecialOperator("CAST", SqlKind.CAST), List.of(string)));
+
+    for (RexNode expression : unsupported) {
+      List<RexNode> input = List.of(fast, expression, fast);
+      CountingFallback fallback = new CountingFallback(CALCITE_EXECUTOR);
+      List<RexNode> actual = reduce(new PinotRexExecutor(fallback), builder, input);
+      assertEquals(actual, reduce(CALCITE_EXECUTOR, builder, input));
+      assertEquals(fallback._calls.get(), 1);
+      assertSame(fallback._lastInput, input, "Fallback must receive the original full batch");
+      assertSame(input.get(0), fast, "The immutable input must not be modified");
+    }
+  }
+
+  @Test
+  public void testFailedCastDoesNotPartiallyReduceBatch() {
+    LiteralRexBuilder builder = new LiteralRexBuilder();
+    RexNode fast = timestampCast(builder, SqlTypeName.CHAR, "2026-09-01 12:34:56.123", 3);
+    RexNode invalid = timestampCast(builder, SqlTypeName.VARCHAR, "not-a-timestamp", 3);
+    for (List<RexNode> input : List.of(List.of(fast, invalid), List.of(invalid, fast))) {
+      CountingFallback fallback = new CountingFallback(CALCITE_EXECUTOR);
+      List<RexNode> actual = reduce(new PinotRexExecutor(fallback), builder, input);
+      assertEquals(actual, reduce(CALCITE_EXECUTOR, builder, input));
+      assertEquals(actual, input, "Calcite keeps every expression unchanged when one expression fails");
+      assertEquals(fallback._calls.get(), 0, "Failed eligible casts must not retry through generated code");
+      for (int i = 0; i < input.size(); i++) {
+        assertSame(actual.get(i), input.get(i), "The entire failed batch must retain its original expressions");
+      }
+    }
+  }
+
+  @Test
+  public void testTimezoneDependentTargetsUseTheirFallbackContext() {
+    LiteralRexBuilder builder = new LiteralRexBuilder();
+    RexNode expression = builder.makeAbstractCast(
+        builder.getTypeFactory().createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 3),
+        builder.stringLiteral("2026-09-01 12:34:56.123", SqlTypeName.CHAR), false);
+    List<RexNode> input = List.of(expression);
+    for (String zone : List.of("UTC", "America/Los_Angeles", "Asia/Kolkata")) {
+      RexExecutor baseline = new RexExecutorImpl(DataContexts.of(
+          Map.of(DataContext.Variable.TIME_ZONE.camelName, TimeZone.getTimeZone(zone))));
+      CountingFallback fallback = new CountingFallback(baseline);
+      assertEquals(reduce(new PinotRexExecutor(fallback), builder, input), reduce(baseline, builder, input), zone);
+      assertEquals(fallback._calls.get(), 1);
+      assertSame(fallback._lastInput, input);
+    }
+  }
+
+  @Test
+  public void testSharedExecutorHasNoCrossRequestState() throws Exception {
+    LiteralRexBuilder builder = new LiteralRexBuilder();
+    List<RexNode> input = List.of(
+        timestampCast(builder, SqlTypeName.CHAR, "1969-12-31 23:59:59.999", 3),
+        timestampCast(builder, SqlTypeName.VARCHAR, "2026-09-01 12:34:56.123", 3));
+    List<RexNode> expected = reduce(CALCITE_EXECUTOR, builder, input);
+    PinotRexExecutor executor = new PinotRexExecutor(FAILING_FALLBACK);
+    ExecutorService threads = Executors.newFixedThreadPool(4);
+    try {
+      List<Callable<Void>> tasks = new ArrayList<>();
+      for (int task = 0; task < 16; task++) {
+        tasks.add(() -> {
+          LiteralRexBuilder localBuilder = new LiteralRexBuilder();
+          for (int i = 0; i < 10; i++) {
+            assertEquals(reduce(executor, localBuilder, input), expected);
+          }
+          return null;
+        });
+      }
+      for (Future<Void> result : threads.invokeAll(tasks)) {
+        result.get();
+      }
+    } finally {
+      threads.shutdownNow();
+    }
+  }
+
+  @Test
+  @SuppressWarnings("try") // The resources scope the thread-local hooks; their values are intentionally unused.
+  public void testRelBuilderTransformPreservesOptimizedExecutor() {
+    AtomicInteger generatedReductions = new AtomicInteger();
+    RelNode expected;
+    try (Hook.Closeable ignored = Hook.EXPRESSION_REDUCER.addThread(
+        (Consumer<Object>) event -> generatedReductions.incrementAndGet())) {
+      expected = projectTimestampCast(CALCITE_EXECUTOR);
+    }
+    assertTrue(generatedReductions.get() > 0, "The control must exercise Calcite's generated reducer");
+
+    generatedReductions.set(0);
+    RelNode actual;
+    try (Hook.Closeable ignored = Hook.EXPRESSION_REDUCER.addThread(
+        (Consumer<Object>) event -> generatedReductions.incrementAndGet())) {
+      actual = projectTimestampCast(PinotRexExecutor.INSTANCE);
+    }
+    assertEquals(RelOptUtil.toString(actual), RelOptUtil.toString(expected));
+    assertEquals(generatedReductions.get(), 0, "RelBuilder.transform must preserve the planner's optimized executor");
+  }
+
+  @Test
+  public void testRelBuilderTransformPreservesExplicitExecutor() {
+    CountingFallback explicitExecutor = new CountingFallback(CALCITE_EXECUTOR);
+    RelNode actual = projectTimestampCast(explicitExecutor);
+    assertTrue(explicitExecutor._calls.get() > 0, "An explicit planner executor must retain precedence");
+    assertEquals(RelOptUtil.toString(actual), RelOptUtil.toString(projectTimestampCast(CALCITE_EXECUTOR)));
+  }
+
+  private static RelNode projectTimestampCast(RexExecutor executor) {
+    LiteralRexBuilder builder = new LiteralRexBuilder();
+    VolcanoPlanner planner = new VolcanoPlanner();
+    planner.setExecutor(executor);
+    RelBuilder relBuilder = PinotRuleUtils.PINOT_REL_FACTORY.create(RelOptCluster.create(planner, builder), null)
+        .transform(config -> config.withPruneInputOfAggregate(true));
+    RelNode result = relBuilder.values(new String[]{"unused"}, 0)
+        .project(timestampCast(builder, SqlTypeName.CHAR, "2026-09-01 12:34:56.123", 3)).build();
+    assertSame(planner.getExecutor(), executor, "RelBuilder.transform must not replace the planner executor");
+    return result;
+  }
+
+  private static RexNode timestampCast(LiteralRexBuilder builder, SqlTypeName sourceType, String value,
+      int precision) {
+    // makeCast may fold a literal before it reaches the executor, which would make a dispatch test vacuous.
+    return builder.makeAbstractCast(builder.getTypeFactory().createSqlType(SqlTypeName.TIMESTAMP, precision),
+        builder.stringLiteral(value, sourceType), false);
+  }
+
+  private static List<RexNode> reduce(RexExecutor executor, RexBuilder builder, List<RexNode> expressions) {
+    List<RexNode> reduced = new ArrayList<>();
+    executor.reduce(builder, expressions, reduced);
+    return reduced;
+  }
+
+  private static class CountingFallback implements RexExecutor {
+    private final RexExecutor _delegate;
+    private final AtomicInteger _calls = new AtomicInteger();
+    private List<RexNode> _lastInput;
+
+    CountingFallback(RexExecutor delegate) {
+      _delegate = delegate;
+    }
+
+    @Override
+    public void reduce(RexBuilder builder, List<RexNode> expressions, List<RexNode> reduced) {
+      _calls.incrementAndGet();
+      _lastInput = expressions;
+      _delegate.reduce(builder, expressions, reduced);
+    }
+  }
+
+  private static class LiteralRexBuilder extends RexBuilder {
+    LiteralRexBuilder() {
+      super(new TypeFactory());
+    }
+
+    RexLiteral stringLiteral(String value, SqlTypeName sourceType) {
+      // Preserve VARCHAR as the source SQL type; the public literal helper normally lowers it to CHAR or a CAST.
+      return makeLiteral(new NlsString(value, null, null),
+          getTypeFactory().createSqlType(sourceType, Math.max(1, value.length())), SqlTypeName.CHAR);
+    }
+  }
+}

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/ConstantCastPlanningTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/ConstantCastPlanningTest.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.runtime.Hook;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.util.SqlBasicVisitor;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+
+/// Verifies that SQL-to-rel conversion reduces constant timestamp casts with its scoped executor without changing the
+/// resulting plan, and restores the planner's executor afterward. The expression-reduction hook is thread-local and
+/// closed after each compilation.
+public class ConstantCastPlanningTest extends QueryEnvironmentTestBase {
+  @DataProvider
+  public Object[][] timestampQueries() {
+    return new Object[][]{
+        {false, "account_1", false},
+        {false, "account_2", false},
+        {true, "account_1", false},
+        {true, "account_2", false},
+        {false, "account_1", true},
+        {false, "account_2", true},
+        {true, "account_1", true},
+        {true, "account_2", true}
+    };
+  }
+
+  @Test(dataProvider = "timestampQueries")
+  // The hook resource installs and removes the callback; it is not otherwise referenced.
+  @SuppressWarnings("try")
+  public void testConstantTimestampCastPlanning(boolean window, String accountId, boolean epochString) {
+    String lowerBound = epochString ? "1704067200000" : "2024-01-01 00:00:00";
+    String upperBound = epochString ? "1706745600000" : "2024-02-01 00:00:00";
+    String castQuery = query(window, accountId, "CAST('" + lowerBound + "' AS TIMESTAMP)",
+        "CAST('" + upperBound + "' AS TIMESTAMP)");
+    String literalQuery = query(window, accountId, "TIMESTAMP '2024-01-01 00:00:00'",
+        "TIMESTAMP '2024-02-01 00:00:00'");
+    SqlNodeAndOptions parsedQuery = CalciteSqlParser.compileToSqlNodeAndOptions(castQuery);
+    AtomicInteger parsedCasts = new AtomicInteger();
+    parsedQuery.getSqlNode().accept(new SqlBasicVisitor<Void>() {
+      @Override
+      public Void visit(SqlCall call) {
+        if (call.getKind() == SqlKind.CAST) {
+          parsedCasts.incrementAndGet();
+        }
+        return super.visit(call);
+      }
+    });
+    assertEquals(parsedCasts.get(), 2, "The query must reach compilation with both string-to-timestamp casts");
+
+    AtomicInteger reductions = new AtomicInteger();
+    try (QueryEnvironment.CompiledQuery literalPlan = _queryEnvironment.compile(literalQuery);
+        Hook.Closeable ignored = Hook.EXPRESSION_REDUCER.addThread(value -> {
+          reductions.incrementAndGet();
+        });
+        QueryEnvironment.CompiledQuery castPlan = _queryEnvironment.compile(castQuery, parsedQuery)) {
+      assertEquals(RelOptUtil.toString(castPlan.getRelNode()), RelOptUtil.toString(literalPlan.getRelNode()));
+      assertEquals(castPlan.getRelRoot().validatedRowType, literalPlan.getRelRoot().validatedRowType);
+      assertEquals(castPlan.getTableNames(), literalPlan.getTableNames());
+      assertNull(castPlan.getPlannerContext().getRelOptPlanner().getExecutor(),
+          "SQL-to-rel conversion must restore the planner's executor before optimization");
+      assertEquals(reductions.get(), 0, "Constant timestamp casts must not invoke Calcite's generated-code reducer");
+    }
+  }
+
+  private static String query(boolean window, String accountId, String lowerBound, String upperBound) {
+    String filter = " FROM a WHERE col1 = '" + accountId + "' AND ts_timestamp >= " + lowerBound
+        + " AND ts_timestamp < " + upperBound;
+    if (window) {
+      return "SELECT ts_timestamp, col3 FROM (SELECT ts_timestamp, col3, ROW_NUMBER() OVER "
+          + "(PARTITION BY col1, ts_timestamp ORDER BY col3 DESC, col7 DESC) AS row_num" + filter
+          + ") WHERE row_num = 1 ORDER BY ts_timestamp LIMIT 1000";
+    }
+    return "SELECT ts_timestamp, col3" + filter + " ORDER BY ts_timestamp LIMIT 1000";
+  }
+}


### PR DESCRIPTION
Constant string casts can repeatedly compile equivalent Calcite conversion code during SQL-to-rel planning. For example, queries using `CAST('123' AS INTEGER)` or quoted IDs on numeric columns pay for generated Java reduction even when only the literal value changes.

Cache Calcite conversion templates for ordinary casts from CHAR/VARCHAR literals to eligible scalar targets. This replaces the TIMESTAMP/BIGINT-specific converters with Calcite's own conversion code and literal construction, extending reuse to numeric, boolean, date/time, string, binary and UUID targets. A cache miss compiles a template with an input reference; matching casts reuse the resulting function with call-local input values. The bounded 256-entry cache keys on full source and target types plus the type system, retaining precision, scale, nullability, charset and collation.

Unsupported expressions, timezone-dependent and structured targets delegate the whole batch to the existing executor. Conversion or literal-construction failures retain the original batch, including numeric epoch strings that need Pinot's later timestamp handling. Cached functions are immutable and each call owns its data context. The executor is installed only during SQL-to-rel conversion, restored afterward, and explicitly supplied executors retain precedence.

### Benchmarks

Fresh comparison of three independently packaged revisions, using identical benchmark source and bytecode:

- Original implementation: `c6116095f7d3834613649c770d75fed7dd5a874a`.
- Previous TIMESTAMP/BIGINT PR: `2f33cd0318e79f02e20161a61814369f6ce14306`.
- Generic implementation: `cf7cff8b605cdfec1a11b8b0d301dc0f339536ed`.

For INTEGER, DOUBLE, DECIMAL and BOOLEAN casts, the generic implementation uses **about 71–74% less planning time** and **44–46% fewer allocated bytes** than the previous PR. The BIGINT and timestamp cast means remain within 0.21% of the previous PR; these small differences are unresolved on this shared host. Relative to the original implementation, generic BIGINT casts use 72.6% less planning time and both timestamp cast paths use about 63.8% less.

Warmed planning latency, lower is better. Errors are JMH-style 99.9% half-widths over ten measured iteration means:

| Workload | Original µs/op | Previous PR µs/op | Generic µs/op | Change vs previous PR |
|---|---:|---:|---:|---:|
| BIGINT CAST | 681.28 ± 284.72 | 186.70 ± 17.41 | 186.65 ± 21.36 | -0.03% |
| BOOLEAN CAST | 610.68 ± 33.92 | 660.03 ± 152.83 | 187.65 ± 22.46 | -71.57% |
| DECIMAL CAST | 834.27 ± 102.02 | 816.55 ± 82.43 | 216.31 ± 11.59 | -73.51% |
| DOUBLE CAST | 639.19 ± 158.95 | 634.17 ± 73.94 | 182.44 ± 4.98 | -71.23% |
| INTEGER CAST | 658.10 ± 232.25 | 691.27 ± 215.99 | 190.92 ± 23.45 | -72.38% |
| TIMESTAMP string CAST (window) | 1,403.86 ± 139.28 | 507.42 ± 7.27 | 508.45 ± 14.53 | +0.20% |
| Epoch-string CAST (window; failed conversion) | 1,448.41 ± 232.59 | 525.00 ± 23.31 | 524.77 ± 15.49 | -0.04% |

The epoch-string row is a failed Calcite conversion retained for later Pinot planning. Timestamp rows use window queries; scalar rows use simple filtered queries, so their absolute times represent different workloads.

Allocated bytes per compilation:

| Workload | Original B/op | Previous PR B/op | Generic B/op | Change vs previous PR |
|---|---:|---:|---:|---:|
| BIGINT CAST | 835,195 | 467,255 | 466,424 | -0.18% |
| BOOLEAN CAST | 821,412 | 822,517 | 456,066 | -44.55% |
| DECIMAL CAST | 974,598 | 974,880 | 527,311 | -45.91% |
| DOUBLE CAST | 833,116 | 834,391 | 464,727 | -44.30% |
| INTEGER CAST | 834,525 | 834,835 | 465,361 | -44.26% |
| TIMESTAMP string CAST (window) | 1,333,518 | 857,388 | 859,315 | +0.22% |
| Epoch-string CAST (window; failed conversion) | 1,337,392 | 861,934 | 864,551 | +0.30% |

<details>
<summary>Literal controls and independent fork means</summary>

| Workload | Original µs/op | Previous PR µs/op | Generic µs/op |
|---|---:|---:|---:|
| BIGINT LITERAL | 172.35 ± 17.88 | 183.40 ± 55.04 | 171.86 ± 3.50 |
| BOOLEAN LITERAL | 177.52 ± 16.63 | 177.21 ± 31.54 | 169.85 ± 4.85 |
| DECIMAL LITERAL | 189.52 ± 14.66 | 182.93 ± 8.35 | 180.69 ± 3.26 |
| DOUBLE LITERAL | 171.96 ± 11.57 | 171.25 ± 3.76 | 170.93 ± 6.33 |
| INTEGER LITERAL | 163.86 ± 4.24 | 177.10 ± 27.78 | 173.71 ± 4.43 |
| Typed TIMESTAMP literal (window) | 485.47 ± 39.00 | 519.76 ± 57.64 | 540.34 ± 154.81 |

All samples are retained, including isolated high timings. The generic typed-timestamp control includes one 825 µs sample; its second fork averages 499.56 µs. The previous PR's BIGINT literal control includes one 287 µs sample. These results do not establish precise bounds on small regressions.

| Workload | Original A / B µs/op | Previous PR A / B µs/op | Generic A / B µs/op |
|---|---:|---:|---:|
| BIGINT CAST | 631.77 / 730.79 | 185.14 / 188.27 | 189.45 / 183.86 |
| BIGINT LITERAL | 167.34 / 177.36 | 194.95 / 171.85 | 172.92 / 170.80 |
| BOOLEAN CAST | 602.57 / 618.80 | 628.29 / 691.76 | 195.30 / 180.01 |
| BOOLEAN LITERAL | 181.21 / 173.83 | 172.74 / 181.69 | 167.77 / 171.94 |
| DECIMAL CAST | 872.24 / 796.30 | 822.87 / 810.22 | 213.34 / 219.27 |
| DECIMAL LITERAL | 194.65 / 184.39 | 181.40 / 184.46 | 181.12 / 180.26 |
| DOUBLE CAST | 664.81 / 613.57 | 649.57 / 618.78 | 182.19 / 182.68 |
| DOUBLE LITERAL | 173.73 / 170.19 | 171.88 / 170.61 | 172.28 / 169.59 |
| INTEGER CAST | 708.28 / 607.92 | 763.01 / 619.53 | 201.24 / 180.60 |
| INTEGER LITERAL | 165.00 / 162.72 | 175.52 / 178.67 | 172.39 / 175.03 |
| TIMESTAMP string CAST (window) | 1,334.80 / 1,472.91 | 506.91 / 507.93 | 512.16 / 504.74 |
| Epoch-string CAST (window; failed conversion) | 1,348.25 / 1,548.57 | 515.76 / 534.24 | 522.85 / 526.69 |
| Typed TIMESTAMP literal (window) | 489.86 / 481.08 | 497.57 / 541.96 | 581.13 / 499.56 |

</details>

Apple M4 Pro (14 cores, 24 GiB RAM), macOS 26.6.2, OpenJDK 25.0.4, JMH 1.37, one benchmark thread, 1 GiB heap and `ActiveProcessorCount=4`. Each scenario has two independent JVM forks, each with five 3-second warmups and five 2-second measurements, using the GC profiler. Pass A ran original/previous/generic; pass B reversed the order. No task-owned builds or tests overlapped measurement; unrelated background applications remained active. Iterations within a JVM may be correlated, so pooled errors are descriptive and do not represent ten independent processes.

Both harnesses call `QueryEnvironment.compile` and close each compiled query, covering parsing, validation, SQL-to-rel conversion and logical optimization. They cycle through 1,024 prebuilt queries; numeric scalar cast values vary and boolean values alternate. Environment construction and query-string construction are outside timing. Warmup populates the template cache; this does not measure first-use compilation, signature churn, broker QPS or query execution. Short pilot runs are excluded. Some original/previous-PR CAST cases retain modest settling after the fixed warmup. Percentages describe this measured protocol, rather than fully stabilized steady-state bounds.

[Full report, raw JMH JSON/stdout, SHA-256 manifests, preflight checks and reproduction commands](https://gist.github.com/xiangfu0/06af6b946d65166924f474c3a08cb7b4).

### Validation

- **1,221 tests passed:** 338 executor cases, 41 constant-planning cases, 240 query-compilation cases, 10 type-coercion cases and 592 resource-based query plans.
- Differential tests cover CHAR/VARCHAR sources and scalar target families, nulls, invalid/overflowing values, precision/scale, mixed batches and fallback behavior. Non-null unsigned casts remain unreduced when Calcite cannot materialize their literals.
- Cache tests verify reuse across changing values, isolation by full type signature and type system, bounded eviction, and concurrent calls. Planning tests compare plans, row types, table sets and stage construction, and verify executor restoration and custom-executor precedence.
- Benchmark preflight compared CAST and literal forms for four distinct queries of each scalar type on all three revisions; plans, validated row types and table sets matched. Reducer-hook checks detect fallback reduction, not initial template compilation; cache misses still compile.
- Scoped Spotless, license formatting, Checkstyle, license validation and deprecation/lint-enabled test compilation passed, with no compiler warnings on added lines.

```sh
JAVA_HOME=/opt/homebrew/opt/openjdk@25 ./mvnw -pl pinot-query-planner -am \
  -Dtest=PinotRexExecutorTest,ConstantCastPlanningTest,QueryCompilationTest,PinotTypeCoercionTest,ResourceBasedQueryPlansTest \
  -Dsurefire.failIfNoSpecifiedTests=false -Ppinot-fastdev \
  -Dcheckstyle.skip -Dspotless.check.skip -Dlicense.skip -Denforcer.skip test
```

Current-head CI: the linter and Java 11 client checks passed. The [binary compatibility job](https://github.com/apache/pinot/actions/runs/34906857152/job/104185438724) fails on an upstream `TableConfig` constructor removal introduced by [#16033](https://github.com/apache/pinot/pull/16033), between this PR's event base and the newer master included in CI's synthetic merge. This PR does not modify `TableConfig`.
