### PR TITLE
Broker startup pre-connect: remove the straggler-grace window

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/ServerPreConnector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/ServerPreConnector.java
@@ -52,11 +52,13 @@ import org.slf4j.LoggerFactory;
 /// no-op, so this is safe to call more than once.
 ///
 /// Bounded so it can never stall startup: a capped thread pool, a per-channel connect bound derived from
-/// the remaining budget, a per-channel wait clamped to the caller's deadline, and a straggler grace window
-/// ([#STRAGGLER_GRACE_MS]) that, once at least one channel is up, releases the caller when the rest stop
-/// arriving rather than waiting out the whole budget on one stuck server. A server that is unreachable or
-/// itself restarting is logged and skipped -- the existing lazy-connect path still serves it. This class
-/// is stateless and thread-safe.
+/// the remaining budget, and the caller's `deadlineMs` as the single release bound. There is no early
+/// release: [#preConnect] waits for each channel to resolve (connect or fail) up to the deadline, then
+/// returns. That keeps readiness honest -- the broker is released once its channels are actually warm, or
+/// the budget is spent -- rather than guessing from a quiet period that the rest are stuck, which cannot
+/// tell a slow-but-healthy connect from a dead one and so can release with healthy channels still cold. A
+/// failed or unreachable connect is logged and skipped and never stops the others from being waited for;
+/// the deadline is the only thing that ends the wait early. This class is stateless and thread-safe.
 ///
 /// It takes its dependencies as functions rather than concrete `RoutingManager`/`QueryRouter` types so
 /// the parallelism, budget and failure handling can be unit-tested without a live broker.
@@ -70,33 +72,10 @@ public class ServerPreConnector {
   /// query load, so the threads are almost entirely parked rather than contending for CPU.
   ///
   /// It is a throughput cap, not a safety bound: with more channels than threads the surplus queues
-  /// behind the workers, so the budget alone must not be what stops a stuck connect. That is why
+  /// behind the workers, so the deadline alone must not be what stops a stuck connect. That is why
   /// [ChannelConnector] takes a per-channel timeout.
   @VisibleForTesting
   static final int MAX_CONNECT_THREADS = 16;
-
-  /// Floor for the straggler window: the minimum quiet time, once at least one channel is up, to wait for
-  /// the next one before concluding the rest are stuck. The effective window scales up off the first
-  /// observed connect latency (to twice it, capped at [#STRAGGLER_GRACE_CAP_MS]) so that when there are more
-  /// channels than worker threads, the gap between completion waves is not misread as a straggler. A quiet
-  /// window this long means what is left is stuck rather than merely slow, so the caller is released and the
-  /// stragglers finish -- or time out -- on their own daemon threads. Until the first *successful* connect
-  /// the whole budget is available: with nothing up yet there is no way to tell "every server is slow" from
-  /// "a few are stuck", and a fast failure must not start the clock.
-  @VisibleForTesting
-  static final long STRAGGLER_GRACE_MS = 2_000L;
-
-  /// Ceiling for the straggler window. The window scales to twice the first observed connect latency (see
-  /// [#stragglerGraceMs]); without a ceiling a very slow *healthy* connect would stretch it arbitrarily -- a
-  /// 12 s connect would make the window 24 s, so a genuinely dead server would then hold the readiness gate
-  /// for almost the whole budget, defeating the protection the window exists for. Capping the window bounds
-  /// the dead-server delay to roughly one connect plus this ceiling, however slow the healthy connects are.
-  /// 10 s (5x the floor) covers realistic healthy connect latencies -- typical TLS connects are well under a
-  /// second and even a loaded server rarely takes this long -- while keeping the dead-server delay well under
-  /// the budget. A cluster whose connects are slower than this is under-counted, which is benign: those
-  /// channels still finish on the daemon threads and are published for the first query to reuse.
-  @VisibleForTesting
-  static final long STRAGGLER_GRACE_CAP_MS = 10_000L;
 
   /// Opens one broker-to-server channel. Implementations must bound their own wait by `timeoutMs` and
   /// must not throw; the return value reports whether the channel is connected.
@@ -125,10 +104,10 @@ public class ServerPreConnector {
   }
 
   /// Opens the supplied (server, table type) channels in parallel, bounded by `deadlineMs` (an absolute
-  /// [System#currentTimeMillis] value). Returns the number of channels connected **before the caller was
-  /// released** -- so a straggler that connects after the grace window (see [#STRAGGLER_GRACE_MS]) is not
-  /// counted, even though its channel is still published for the first query to reuse. Never throws: a
-  /// channel that fails or times out is logged and skipped.
+  /// [System#currentTimeMillis] value). Returns the number of channels connected by the deadline. A channel
+  /// still connecting when the deadline passes keeps warming on its daemon thread and is published for the
+  /// first query to reuse; it is simply not counted. Never throws: a channel that fails or times out is
+  /// logged and skipped, and never stops the others from being waited for.
   public int preConnect(long deadlineMs) {
     // Snapshot the target view once. The supplier may derive from a live routing view that another thread
     // updates during startup; snapshotting keeps the channel count consistent with the tasks actually
@@ -147,9 +126,6 @@ public class ServerPreConnector {
     // still queues for a worker, which is what the per-channel timeout bounds.
     CompletionService<Boolean> completionService = new ExecutorCompletionService<>(executor);
     int connected = 0;
-    boolean releasedEarly = false;
-    // The straggler window, scaled up off the first observed connect latency (see where it is set below).
-    long graceMs = STRAGGLER_GRACE_MS;
     try {
       for (ChannelTarget target : targets) {
         completionService.submit(() -> _connector.connect(target.serverInstance(), target.tableType(),
@@ -160,36 +136,19 @@ public class ServerPreConnector {
         if (remainingMs <= 0) {
           break;
         }
-        // Keep the whole budget available until the first *successful* connect: a quiet window only means
-        // "the rest are stuck" once at least one channel has actually come up. Keying the exemption on the
-        // first completion instead would let a single fast event -- an instantly refused connect, or one
-        // nearby server -- start the grace clock before the healthy-but-slower channels return, abandoning
-        // them. Once one channel is up, a quiet grace window is the signal that what is left is stuck rather
-        // than slow, and the caller is released -- one unreachable server otherwise holds the gate for the
-        // entire budget. (A cluster where no server ever connects still exits promptly when connects fail
-        // fast, and waits the budget only when every connect black-holes, which is the correct thing to do
-        // for a broker that can reach nothing.)
-        // `graceMs` is scaled off the first connect's latency (set below), so with more channels than
-        // workers the gap between completion waves is not misread as a straggler.
-        long waitMs = connected == 0 ? remainingMs : Math.min(remainingMs, graceMs);
         try {
-          Future<Boolean> future = completionService.poll(waitMs, TimeUnit.MILLISECONDS);
+          // Wait up to the whole remaining budget for the next channel. A completed channel returns
+          // immediately, so a fully healthy cluster is released as soon as its last channel is up -- not at
+          // the deadline. The only thing this actually blocks on is a channel that never completes (an
+          // unreachable server that black-holes to its own connect timeout); the deadline is the single
+          // bound on that, and one such server costs at most the budget, never the others' warm-up.
+          Future<Boolean> future = completionService.poll(remainingMs, TimeUnit.MILLISECONDS);
           if (future == null) {
-            // The grace cap was binding (we could have waited longer but chose not to) only when waitMs was
-            // clamped below the remaining budget; otherwise this is plain budget exhaustion.
-            releasedEarly = waitMs < remainingMs;
-            LOGGER.info("No pre-connect channel completed in {} ms with {}/{} still outstanding; releasing startup "
-                + "and leaving them to the lazy connect path", waitMs, channelCount - i, channelCount);
+            LOGGER.info("Pre-connect budget elapsed with {}/{} channel(s) still outstanding; releasing startup "
+                + "and leaving them to the lazy connect path", channelCount - i, channelCount);
             break;
           }
           if (Boolean.TRUE.equals(future.get())) {
-            if (connected == 0) {
-              // All tasks started together, so the first success approximates one connect's latency. With
-              // more channels than workers the surplus completes in waves one latency apart, so a window
-              // narrower than that latency would abandon healthy channels still queued behind the pool.
-              // Scale to twice the first latency, clamped to the floor and ceiling (see stragglerGraceMs).
-              graceMs = stragglerGraceMs(System.currentTimeMillis() - startMs);
-            }
             connected++;
           }
         } catch (InterruptedException e) {
@@ -197,36 +156,25 @@ public class ServerPreConnector {
           Thread.currentThread().interrupt();
           break;
         } catch (ExecutionException e) {
-          // A server that is unreachable or itself restarting must not block startup.
+          // A server that is unreachable or itself restarting must not stop us waiting for the others.
           LOGGER.debug("Pre-connect did not complete for one channel", e);
         }
       }
     } finally {
-      // shutdown(), not shutdownNow(): a channel we stopped waiting on is still connecting on a daemon
-      // thread. Interrupting a worker parked in connect().sync() abandons a ChannelFuture that can still
-      // complete, leaking a socket nobody references or closes. Letting the workers run means a late
-      // channel is still published for the first query to reuse, and each task is already bounded by its
-      // own deadline-derived timeout, so none outlives the budget.
+      // shutdown(), not shutdownNow(): a channel still connecting past the deadline is on a daemon thread.
+      // Interrupting a worker parked in connect().sync() abandons a ChannelFuture that can still complete,
+      // leaking a socket nobody references or closes. Letting the workers run means a late channel still
+      // warms in the background and is published for the first query to reuse, and each task is already
+      // bounded by its own deadline-derived timeout, so none outlives the budget.
       executor.shutdown();
     }
     long elapsedMs = System.currentTimeMillis() - startMs;
     if (connected < channelCount) {
-      LOGGER.warn("Broker pre-connected {}/{} channel(s) in {} ms ({}); the rest fall back to the lazy connect "
-          + "path", connected, channelCount, elapsedMs, releasedEarly ? "released early on a straggler grace window"
-          : "budget elapsed");
+      LOGGER.warn("Broker pre-connected {}/{} channel(s) in {} ms; the rest fall back to the lazy connect path",
+          connected, channelCount, elapsedMs);
     } else {
       LOGGER.info("Broker pre-connected {}/{} channel(s) in {} ms", connected, channelCount, elapsedMs);
     }
     return connected;
-  }
-
-  /// The straggler window for a run whose first channel came up after `observedConnectLatencyMs`. Scaled to
-  /// twice that latency so completion waves (more channels than workers) are not misread as stragglers, then
-  /// clamped to [[#STRAGGLER_GRACE_MS], [#STRAGGLER_GRACE_CAP_MS]]. The floor keeps a fast cluster's window
-  /// from collapsing below the base grace; the ceiling keeps a very slow *healthy* connect from stretching
-  /// the window so far that a genuinely dead server would hold the gate for most of the budget.
-  @VisibleForTesting
-  static long stragglerGraceMs(long observedConnectLatencyMs) {
-    return Math.max(STRAGGLER_GRACE_MS, Math.min(STRAGGLER_GRACE_CAP_MS, 2 * observedConnectLatencyMs));
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/ServerPreConnector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/ServerPreConnector.java
@@ -75,11 +75,14 @@ public class ServerPreConnector {
   @VisibleForTesting
   static final int MAX_CONNECT_THREADS = 16;
 
-  /// How long to keep waiting, once at least one channel is up, for the next one before concluding the
-  /// rest are stuck. A quiet window this long means what is left is stuck rather than merely slow, so the
-  /// caller is released and the stragglers finish -- or time out -- on their own daemon threads. Until the
-  /// first *successful* connect the whole budget is available: with nothing up yet there is no way to tell
-  /// "every server is slow" from "a few are stuck", and a fast failure must not start the clock.
+  /// Floor for the straggler window: the minimum quiet time, once at least one channel is up, to wait for
+  /// the next one before concluding the rest are stuck. The effective window scales up off the first
+  /// observed connect latency (to twice it) so that when there are more channels than worker threads, the
+  /// gap between completion waves is not misread as a straggler. A quiet window this long means what is
+  /// left is stuck rather than merely slow, so the caller is released and the stragglers finish -- or time
+  /// out -- on their own daemon threads. Until the first *successful* connect the whole budget is
+  /// available: with nothing up yet there is no way to tell "every server is slow" from "a few are stuck",
+  /// and a fast failure must not start the clock.
   @VisibleForTesting
   static final long STRAGGLER_GRACE_MS = 2_000L;
 
@@ -133,6 +136,8 @@ public class ServerPreConnector {
     CompletionService<Boolean> completionService = new ExecutorCompletionService<>(executor);
     int connected = 0;
     boolean releasedEarly = false;
+    // The straggler window, scaled up off the first observed connect latency (see where it is set below).
+    long graceMs = STRAGGLER_GRACE_MS;
     try {
       for (ChannelTarget target : targets) {
         completionService.submit(() -> _connector.connect(target.serverInstance(), target.tableType(),
@@ -152,7 +157,9 @@ public class ServerPreConnector {
         // entire budget. (A cluster where no server ever connects still exits promptly when connects fail
         // fast, and waits the budget only when every connect black-holes, which is the correct thing to do
         // for a broker that can reach nothing.)
-        long waitMs = connected == 0 ? remainingMs : Math.min(remainingMs, STRAGGLER_GRACE_MS);
+        // `graceMs` is scaled off the first connect's latency (set below), so with more channels than
+        // workers the gap between completion waves is not misread as a straggler.
+        long waitMs = connected == 0 ? remainingMs : Math.min(remainingMs, graceMs);
         try {
           Future<Boolean> future = completionService.poll(waitMs, TimeUnit.MILLISECONDS);
           if (future == null) {
@@ -164,6 +171,13 @@ public class ServerPreConnector {
             break;
           }
           if (Boolean.TRUE.equals(future.get())) {
+            if (connected == 0) {
+              // All tasks started together, so the first success approximates one connect's latency. With
+              // more channels than workers the surplus completes in waves one latency apart, so a window
+              // narrower than that latency would abandon healthy channels still queued behind the pool.
+              // Scale to twice the first latency, never below the floor.
+              graceMs = Math.max(STRAGGLER_GRACE_MS, 2 * (System.currentTimeMillis() - startMs));
+            }
             connected++;
           }
         } catch (InterruptedException e) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/ServerPreConnector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/ServerPreConnector.java
@@ -77,14 +77,26 @@ public class ServerPreConnector {
 
   /// Floor for the straggler window: the minimum quiet time, once at least one channel is up, to wait for
   /// the next one before concluding the rest are stuck. The effective window scales up off the first
-  /// observed connect latency (to twice it) so that when there are more channels than worker threads, the
-  /// gap between completion waves is not misread as a straggler. A quiet window this long means what is
-  /// left is stuck rather than merely slow, so the caller is released and the stragglers finish -- or time
-  /// out -- on their own daemon threads. Until the first *successful* connect the whole budget is
-  /// available: with nothing up yet there is no way to tell "every server is slow" from "a few are stuck",
-  /// and a fast failure must not start the clock.
+  /// observed connect latency (to twice it, capped at [#STRAGGLER_GRACE_CAP_MS]) so that when there are more
+  /// channels than worker threads, the gap between completion waves is not misread as a straggler. A quiet
+  /// window this long means what is left is stuck rather than merely slow, so the caller is released and the
+  /// stragglers finish -- or time out -- on their own daemon threads. Until the first *successful* connect
+  /// the whole budget is available: with nothing up yet there is no way to tell "every server is slow" from
+  /// "a few are stuck", and a fast failure must not start the clock.
   @VisibleForTesting
   static final long STRAGGLER_GRACE_MS = 2_000L;
+
+  /// Ceiling for the straggler window. The window scales to twice the first observed connect latency (see
+  /// [#stragglerGraceMs]); without a ceiling a very slow *healthy* connect would stretch it arbitrarily -- a
+  /// 12 s connect would make the window 24 s, so a genuinely dead server would then hold the readiness gate
+  /// for almost the whole budget, defeating the protection the window exists for. Capping the window bounds
+  /// the dead-server delay to roughly one connect plus this ceiling, however slow the healthy connects are.
+  /// 10 s (5x the floor) covers realistic healthy connect latencies -- typical TLS connects are well under a
+  /// second and even a loaded server rarely takes this long -- while keeping the dead-server delay well under
+  /// the budget. A cluster whose connects are slower than this is under-counted, which is benign: those
+  /// channels still finish on the daemon threads and are published for the first query to reuse.
+  @VisibleForTesting
+  static final long STRAGGLER_GRACE_CAP_MS = 10_000L;
 
   /// Opens one broker-to-server channel. Implementations must bound their own wait by `timeoutMs` and
   /// must not throw; the return value reports whether the channel is connected.
@@ -175,8 +187,8 @@ public class ServerPreConnector {
               // All tasks started together, so the first success approximates one connect's latency. With
               // more channels than workers the surplus completes in waves one latency apart, so a window
               // narrower than that latency would abandon healthy channels still queued behind the pool.
-              // Scale to twice the first latency, never below the floor.
-              graceMs = Math.max(STRAGGLER_GRACE_MS, 2 * (System.currentTimeMillis() - startMs));
+              // Scale to twice the first latency, clamped to the floor and ceiling (see stragglerGraceMs).
+              graceMs = stragglerGraceMs(System.currentTimeMillis() - startMs);
             }
             connected++;
           }
@@ -206,5 +218,15 @@ public class ServerPreConnector {
       LOGGER.info("Broker pre-connected {}/{} channel(s) in {} ms", connected, channelCount, elapsedMs);
     }
     return connected;
+  }
+
+  /// The straggler window for a run whose first channel came up after `observedConnectLatencyMs`. Scaled to
+  /// twice that latency so completion waves (more channels than workers) are not misread as stragglers, then
+  /// clamped to [[#STRAGGLER_GRACE_MS], [#STRAGGLER_GRACE_CAP_MS]]. The floor keeps a fast cluster's window
+  /// from collapsing below the base grace; the ceiling keeps a very slow *healthy* connect from stretching
+  /// the window so far that a genuinely dead server would hold the gate for most of the budget.
+  @VisibleForTesting
+  static long stragglerGraceMs(long observedConnectLatencyMs) {
+    return Math.max(STRAGGLER_GRACE_MS, Math.min(STRAGGLER_GRACE_CAP_MS, 2 * observedConnectLatencyMs));
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/ServerPreConnectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/ServerPreConnectorTest.java
@@ -302,6 +302,52 @@ public class ServerPreConnectorTest {
         "all healthy channels must connect even when they complete in waves slower than the grace floor");
   }
 
+  /// The grace window scales to twice the first connect latency, clamped to the floor and the ceiling: a
+  /// fast connect pins it at the floor, a mid connect scales linearly, and a very slow connect is capped so
+  /// a dead server cannot hold the gate for most of the budget.
+  @Test
+  public void stragglerGraceScalesBetweenFloorAndCeiling() {
+    // Fast connect: 2 * 50 = 100 ms is below the floor, so the floor wins.
+    assertEquals(ServerPreConnector.stragglerGraceMs(50L), ServerPreConnector.STRAGGLER_GRACE_MS);
+    // Mid connect: 2 * 2000 = 4000 ms sits between floor and ceiling and is used as-is.
+    assertEquals(ServerPreConnector.stragglerGraceMs(2_000L), 4_000L);
+    // Very slow connect: 2 * 8000 = 16000 ms exceeds the ceiling, so the ceiling caps it.
+    assertEquals(ServerPreConnector.stragglerGraceMs(8_000L), ServerPreConnector.STRAGGLER_GRACE_CAP_MS);
+  }
+
+  /// Mixed connect latencies -- one fast server, the rest slower than the grace floor -- under-count, and no
+  /// window size fixes it. The window is sized off the *first* (fastest) connect, so a fast one pins it at
+  /// the floor; the slower-but-healthy channels then arrive after the floor has elapsed and are released
+  /// before being counted. This is an inherent limit of a reactive grace window (the release decision fires
+  /// before the slow channels return) -- not something the ceiling changes -- and it is benign: the uncounted
+  /// channels still finish on the daemon threads and are published for the first query. Documents the
+  /// behavior so a later change does not "fix" it by inflating the window for every cluster.
+  @Test
+  public void mixedLatencyUnderCountsAndIsNotFixedByTheCeiling() {
+    List<ServerInstance> servers = mockServers(8);   // 8 channels, all start at once on the 16-worker pool
+    long slowMs = ServerPreConnector.STRAGGLER_GRACE_MS + 1000L;   // 3000 ms, slower than the 2000 ms floor
+    long budgetMs = 30_000L;
+    AtomicInteger n = new AtomicInteger();
+
+    int connected = new ServerPreConnector(() -> targets(servers, TableType.OFFLINE),
+        (server, tableType, timeoutMs) -> {
+          if (n.getAndIncrement() == 0) {
+            return true;   // one fast connect completes first and pins the window at the floor
+          }
+          try {
+            Thread.sleep(slowMs);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+          }
+          return true;
+        }).preConnect(System.currentTimeMillis() + budgetMs);
+
+    assertEquals(connected, 1,
+        "mixed latency under-counts: the fast connect pins the window at the floor, so the slower healthy "
+            + "channels are released before they are counted -- benign, and not fixable by the ceiling");
+  }
+
   /// The thread pool is a throughput cap, not a safety bound, so each connect has to carry its own
   /// deadline-derived timeout. Without it a channel queued behind a stuck worker could outlive the
   /// budget entirely.

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/ServerPreConnectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/ServerPreConnectorTest.java
@@ -169,14 +169,14 @@ public class ServerPreConnectorTest {
     assertTrue(elapsedMs < 3_000L, "preConnect took " + elapsedMs + " ms, expected it to honor the budget");
   }
 
-  /// One unreachable server must not hold startup for the whole budget: once the healthy channels are back
-  /// and nothing more arrives for the grace window, preConnect returns and leaves the straggler to finish
-  /// (or time out) on its own daemon thread. Without the grace window the final poll would block for the
-  /// rest of the budget.
+  /// An unreachable server that black-holes (never completes) holds pre-connect only until the deadline,
+  /// and the healthy channels are still counted. There is no early release: the deadline is the single
+  /// bound, so a broker with one dead server pays at most the budget on startup, and that cost is tuned
+  /// through the budget rather than a heuristic.
   @Test
-  public void oneStuckChannelDoesNotHoldStartupForTheWholeBudget() {
+  public void blackHoledChannelIsBoundedByTheDeadlineAndHealthyChannelsAreCounted() {
     List<ServerInstance> servers = mockServers(4);   // 4 x 2 table types = 8 channels
-    long budgetMs = 30_000L;
+    long budgetMs = 800L;
     AtomicInteger n = new AtomicInteger();
     long startMs = System.currentTimeMillis();
 
@@ -184,7 +184,7 @@ public class ServerPreConnectorTest {
         (server, tableType, timeoutMs) -> {
           if (n.getAndIncrement() == 0) {
             try {
-              Thread.sleep(timeoutMs);
+              Thread.sleep(5_000L);   // black-hole well past the budget; never connects in time
             } catch (InterruptedException e) {
               Thread.currentThread().interrupt();
             }
@@ -195,18 +195,18 @@ public class ServerPreConnectorTest {
     long elapsedMs = System.currentTimeMillis() - startMs;
 
     assertEquals(connected, 7, "the seven healthy channels must still be counted");
-    assertTrue(elapsedMs < 5 * ServerPreConnector.STRAGGLER_GRACE_MS,
-        "one stuck channel held startup for " + elapsedMs + " ms of a " + budgetMs + " ms budget");
+    // Bounded by the deadline: the one black-holed channel holds only until the budget, never longer.
+    assertTrue(elapsedMs < 3 * budgetMs,
+        "one black-holed channel held startup for " + elapsedMs + " ms of an " + budgetMs + " ms budget");
   }
 
-  /// The whole budget is available until the first successful connect: a cluster whose channels are all
-  /// slower than the grace window (but faster than the budget) must still connect every one, not bail at
-  /// the grace window having connected nothing. If the exemption were missing, the first poll would time
-  /// out at the grace window before any channel returned, and connected would be 0.
+  /// Slow-but-healthy channels are all counted: with the deadline as the only bound, a cluster whose every
+  /// channel is slow (but faster than the budget) still connects every one and is released once they are
+  /// all up -- not at the deadline, and never with any of them abandoned.
   @Test
-  public void slowFirstChannelIsStillCountedAndNotAbandonedByGraceWindow() {
+  public void slowHealthyChannelsAreAllCounted() {
     List<ServerInstance> servers = mockServers(3);      // 3 x 2 = 6 channels
-    long slowMs = ServerPreConnector.STRAGGLER_GRACE_MS + 500L;   // slower than grace, faster than budget
+    long slowMs = 2_500L;                               // slow, but faster than the budget
     long budgetMs = 30_000L;
     long startMs = System.currentTimeMillis();
 
@@ -222,27 +222,26 @@ public class ServerPreConnectorTest {
         }).preConnect(startMs + budgetMs);
     long elapsedMs = System.currentTimeMillis() - startMs;
 
-    assertEquals(connected, 6, "every channel must be counted even though all are slower than the grace window");
-    assertTrue(elapsedMs >= slowMs, "the first channel must be waited for past the grace window, not abandoned");
-    assertTrue(elapsedMs < budgetMs, "must not wait the whole budget once the channels are back");
+    assertEquals(connected, 6, "every channel must be counted even though all are slow");
+    assertTrue(elapsedMs >= slowMs, "the slow channels must be waited for, not abandoned");
+    assertTrue(elapsedMs < budgetMs, "must be released once the channels are back, not held to the deadline");
   }
 
-  /// A fast failure (an instantly refused connect) that completes before the healthy channels must NOT
-  /// consume the whole-budget exemption and cause the grace window to abandon the healthy-but-slower
-  /// channels. Since the exemption keys on the first *successful* connect, the fast failure does not start
-  /// the grace clock, and the five healthy channels are all waited for and counted. Regression test for a
-  /// grace-window bug where keying on the first *completion* undercounted to 0 here.
+  /// The core invariant: a failed connect must not stop us waiting for the others. One connect fails
+  /// instantly and completes first; the five healthy-but-slower channels must still all be waited for and
+  /// counted. (Under the old grace window, keying the release on the first *completion* undercounted this
+  /// to 0; waiting to the deadline makes it unconditional.)
   @Test
-  public void healthyButSlowChannelsNotAbandonedAfterFastFailure() {
+  public void aFastFailureDoesNotStopWaitingForTheOtherChannels() {
     List<ServerInstance> servers = mockServers(3);      // 3 x 2 = 6 channels
-    long slowMs = ServerPreConnector.STRAGGLER_GRACE_MS + 500L;   // slower than grace, faster than budget
+    long slowMs = 2_500L;                               // slow, but faster than the budget
     long budgetMs = 30_000L;
     AtomicInteger n = new AtomicInteger();
 
     int connected = new ServerPreConnector(() -> targets(servers, TableType.OFFLINE, TableType.REALTIME),
         (server, tableType, timeoutMs) -> {
           if (n.getAndIncrement() == 0) {
-            return false;   // one instant failure, completes first, must not start the grace clock
+            return false;   // one instant failure, completes first, must not end the wait
           }
           try {
             Thread.sleep(slowMs);
@@ -254,7 +253,7 @@ public class ServerPreConnectorTest {
         }).preConnect(System.currentTimeMillis() + budgetMs);
 
     assertEquals(connected, 5,
-        "the five healthy channels must be counted; a fast failure must not trigger the grace window");
+        "the five healthy channels must be counted; a fast failure must not stop us waiting for them");
   }
 
   /// More channels than worker threads: the surplus queues behind the pool and still all connect. Exercises
@@ -276,16 +275,15 @@ public class ServerPreConnectorTest {
     assertEquals(calls.get(), count * 2, "every channel must be attempted");
   }
 
-  /// More channels than worker threads, every one HEALTHY but slower than the grace floor. The surplus
-  /// completes in waves one connect-latency apart; a fixed grace window would misread the gap between waves
-  /// as a straggler and abandon later waves (only the first ~pool-size would count). Because the effective
-  /// window scales off the first observed connect latency, every wave is waited for and all connect.
-  /// Regression test for the wave under-count (48 healthy @ 3s counted only 16/48 with a fixed window).
+  /// More channels than worker threads, every one HEALTHY but slow. The surplus completes in waves one
+  /// connect-latency apart; because pre-connect waits to the deadline rather than releasing on a quiet
+  /// window, every wave is waited for and all connect. (The grace window this replaces under-counted this
+  /// to ~one wave when the inter-wave gap exceeded the window.)
   @Test
-  public void manyHealthyChannelsSlowerThanGraceFloorAllConnect() {
+  public void manyHealthyChannelsInWavesAllConnect() {
     int count = ServerPreConnector.MAX_CONNECT_THREADS * 3;   // 48 channels, pool caps at 16 -> 3 waves
     List<ServerInstance> servers = mockServers(count);
-    long slowMs = ServerPreConnector.STRAGGLER_GRACE_MS + 1000L;   // 3000 ms, slower than the 2000 ms floor
+    long slowMs = 3_000L;
 
     int connected = new ServerPreConnector(() -> targets(servers, TableType.OFFLINE),
         (server, tableType, timeoutMs) -> {
@@ -298,41 +296,24 @@ public class ServerPreConnectorTest {
           return true;
         }).preConnect(System.currentTimeMillis() + 60_000L);
 
-    assertEquals(connected, count,
-        "all healthy channels must connect even when they complete in waves slower than the grace floor");
+    assertEquals(connected, count, "all healthy channels must connect even when they complete in waves");
   }
 
-  /// The grace window scales to twice the first connect latency, clamped to the floor and the ceiling: a
-  /// fast connect pins it at the floor, a mid connect scales linearly, and a very slow connect is capped so
-  /// a dead server cannot hold the gate for most of the budget.
+  /// Mixed connect latencies -- one fast server, the rest slower -- now connect **all** channels. The old
+  /// grace window sized itself off the first (fastest) connect and released before the slower healthy
+  /// channels returned, counting only 1; waiting to the deadline waits for every one. Regression test for
+  /// that mixed-latency under-count.
   @Test
-  public void stragglerGraceScalesBetweenFloorAndCeiling() {
-    // Fast connect: 2 * 50 = 100 ms is below the floor, so the floor wins.
-    assertEquals(ServerPreConnector.stragglerGraceMs(50L), ServerPreConnector.STRAGGLER_GRACE_MS);
-    // Mid connect: 2 * 2000 = 4000 ms sits between floor and ceiling and is used as-is.
-    assertEquals(ServerPreConnector.stragglerGraceMs(2_000L), 4_000L);
-    // Very slow connect: 2 * 8000 = 16000 ms exceeds the ceiling, so the ceiling caps it.
-    assertEquals(ServerPreConnector.stragglerGraceMs(8_000L), ServerPreConnector.STRAGGLER_GRACE_CAP_MS);
-  }
-
-  /// Mixed connect latencies -- one fast server, the rest slower than the grace floor -- under-count, and no
-  /// window size fixes it. The window is sized off the *first* (fastest) connect, so a fast one pins it at
-  /// the floor; the slower-but-healthy channels then arrive after the floor has elapsed and are released
-  /// before being counted. This is an inherent limit of a reactive grace window (the release decision fires
-  /// before the slow channels return) -- not something the ceiling changes -- and it is benign: the uncounted
-  /// channels still finish on the daemon threads and are published for the first query. Documents the
-  /// behavior so a later change does not "fix" it by inflating the window for every cluster.
-  @Test
-  public void mixedLatencyUnderCountsAndIsNotFixedByTheCeiling() {
+  public void mixedLatencyAllChannelsConnect() {
     List<ServerInstance> servers = mockServers(8);   // 8 channels, all start at once on the 16-worker pool
-    long slowMs = ServerPreConnector.STRAGGLER_GRACE_MS + 1000L;   // 3000 ms, slower than the 2000 ms floor
+    long slowMs = 3_000L;
     long budgetMs = 30_000L;
     AtomicInteger n = new AtomicInteger();
 
     int connected = new ServerPreConnector(() -> targets(servers, TableType.OFFLINE),
         (server, tableType, timeoutMs) -> {
           if (n.getAndIncrement() == 0) {
-            return true;   // one fast connect completes first and pins the window at the floor
+            return true;   // one fast connect; must not curtail waiting for the slower healthy ones
           }
           try {
             Thread.sleep(slowMs);
@@ -343,9 +324,8 @@ public class ServerPreConnectorTest {
           return true;
         }).preConnect(System.currentTimeMillis() + budgetMs);
 
-    assertEquals(connected, 1,
-        "mixed latency under-counts: the fast connect pins the window at the floor, so the slower healthy "
-            + "channels are released before they are counted -- benign, and not fixable by the ceiling");
+    assertEquals(connected, 8,
+        "with the deadline as the only bound, a fast connect no longer abandons the slower healthy channels");
   }
 
   /// The thread pool is a throughput cap, not a safety bound, so each connect has to carry its own

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/ServerPreConnectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/ServerPreConnectorTest.java
@@ -276,6 +276,32 @@ public class ServerPreConnectorTest {
     assertEquals(calls.get(), count * 2, "every channel must be attempted");
   }
 
+  /// More channels than worker threads, every one HEALTHY but slower than the grace floor. The surplus
+  /// completes in waves one connect-latency apart; a fixed grace window would misread the gap between waves
+  /// as a straggler and abandon later waves (only the first ~pool-size would count). Because the effective
+  /// window scales off the first observed connect latency, every wave is waited for and all connect.
+  /// Regression test for the wave under-count (48 healthy @ 3s counted only 16/48 with a fixed window).
+  @Test
+  public void manyHealthyChannelsSlowerThanGraceFloorAllConnect() {
+    int count = ServerPreConnector.MAX_CONNECT_THREADS * 3;   // 48 channels, pool caps at 16 -> 3 waves
+    List<ServerInstance> servers = mockServers(count);
+    long slowMs = ServerPreConnector.STRAGGLER_GRACE_MS + 1000L;   // 3000 ms, slower than the 2000 ms floor
+
+    int connected = new ServerPreConnector(() -> targets(servers, TableType.OFFLINE),
+        (server, tableType, timeoutMs) -> {
+          try {
+            Thread.sleep(slowMs);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+          }
+          return true;
+        }).preConnect(System.currentTimeMillis() + 60_000L);
+
+    assertEquals(connected, count,
+        "all healthy channels must connect even when they complete in waves slower than the grace floor");
+  }
+
   /// The thread pool is a throughput cap, not a safety bound, so each connect has to carry its own
   /// deadline-derived timeout. Without it a channel queued behind a stuck worker could outlive the
   /// budget entirely.


### PR DESCRIPTION
## Summary

Removes the straggler-grace window from broker startup pre-connect and makes the caller's **deadline the
single release bound**: `preConnect` waits for each channel to resolve (connect or fail) up to the deadline,
then returns. No floor, no ceiling, no latency estimator, no early release.

This supersedes the original intent of this PR (which added a *ceiling* to the window). Review concluded the
window is the wrong mechanism, not a mistuned one, so the fix is to remove it rather than cap it.

No config, wire, metric, or public API changes. `STRAGGLER_GRACE_MS` was an internal `@VisibleForTesting`
constant introduced in #19407; the pre-connect config keys and the duration metric are untouched.

## Why remove it, not tune it

Pre-connect exists so the broker is not marked Ready until its channels are warm, bounded by a deadline. The
grace window released readiness *early*, on a quiet period — "nothing completed for the window, so the rest
must be stuck." That is a guess about a question that is undecidable at the moment it is asked: an
outstanding connect that hasn't returned is equally *slow-but-healthy* or *dead*. Only waiting resolves it.

Because it is a guess, it misfires — and the failure direction is exactly what the feature protects against:
the broker is marked Ready with healthy channels still cold. Two shapes were measured on the branch:

- **Waves** (more channels than the 16-thread pool, each healthy but slow): the gap between completion waves
  is read as a straggler, so only ~the first wave is counted (e.g. 16/48) though all are healthy.
- **Mixed latency** (one fast server, the rest slower): the window sizes itself off the *fastest* connect
  and releases before the slower healthy channels return (e.g. 1/48). No window value fixes this — the
  release necessarily fires before the slow connects complete.

Tuning (floor, ceiling, `2 * firstLatency`) only narrows where it misfires; it cannot remove the category,
because the underlying decision is undecidable when it is made. The deadline is already the safety valve, so
a second, earlier, heuristic one is not needed.

## Behaviour

- **Healthy clusters release as soon as their last channel is up**, not at the deadline — `poll` returns the
  instant a channel completes, so a fully healthy cluster is never held to the budget.
- **Waves and mixed latency now connect every channel** — waves are simply slower (48 @ 3 s land at 3/6/9 s,
  all counted); the mixed-latency under-count disappears because it was an artifact of the reactive window.
- **A dead/black-holed server holds readiness only until the deadline.** This is the one real cost and it is
  accepted: with nothing up on that channel, "slow-but-healthy" and "dead" are indistinguishable, so waiting
  is the only correct behaviour. The cost is bounded by the budget and tuned through it — one predictable
  number an operator can reason about — rather than a heuristic. (Lowering the pre-connect budget default is
  a reasonable follow-up if the serial-rollout cost matters; left as-is here.)

The single invariant this relies on: **a failed connect must not stop us waiting for the others.** One
refused or black-holed server costs that server, not the rest of the warm-up. It is pinned by a test.

## Testing

- **`aFastFailureDoesNotStopWaitingForTheOtherChannels`** — the core invariant: an instant failure completes
  first and must not curtail waiting for the five healthy-but-slower channels.
- **`blackHoledChannelIsBoundedByTheDeadlineAndHealthyChannelsAreCounted`** — a never-completing server holds
  only to the deadline; the seven healthy channels are still counted.
- **`manyHealthyChannelsInWavesAllConnect`** — 48 channels on the 16-thread pool, all slow, all counted.
- **`mixedLatencyAllChannelsConnect`** — one fast + rest slow now connects all 8 (was 1 under the window).
- **`slowHealthyChannelsAreAllCounted`**, `respectsBudgetAndDoesNotWaitForSlowConnects`, and the existing
  target-selection / timeout tests are unchanged in intent.
- The grace-window-internals test (`stragglerGraceScalesBetweenFloorAndCeiling`) is removed with the method.

## Backward compatibility

No config keys, metrics, wire protocol, or public API change. `STRAGGLER_GRACE_MS` (and the never-released
`STRAGGLER_GRACE_CAP_MS` added in this PR) were internal `@VisibleForTesting` constants. Behaviour changes
only in the pre-connect startup path, and strictly toward the feature's own contract: readiness is withheld
until channels are warm or the budget is spent, never released early on a guess.
