### PR TITLE
Fix shared Kinesis request limiter lifecycle and namespace isolation

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/README.md
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/README.md
@@ -1,0 +1,49 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Kinesis request limiting
+
+The `requests_per_second_limit` stream setting accepts positive fractional values
+(for example, `0.25`) and defaults to `1.0`. The budget is shared within a server
+JVM across consumers with the same stream name, shard, AWS operation, region,
+endpoint override, and credential namespace. `GetRecords` and `GetShardIterator`
+have separate budgets. Colocated tables sharing a budget do not each receive the
+full configured rate.
+
+For each budget, the effective rate is the lowest configured rate among consumers
+that have requested that operation and have not closed. Closing the lowest-rate
+consumer restores the minimum of the remaining consumers. Closing the last
+consumer removes its registrations. The idle limiter retains permit timing for up
+to one hour, preserving the previous cache lifetime across short-lived consumers.
+Reopening during that period recomputes the rate from the new registrations. Updated table settings take effect when consumers
+are recreated; the limiter does not mutate a running consumer's configuration.
+Permits already reserved before a rate change retain their existing wait time.
+
+Credential namespaces follow client configuration: assumed-role ARN, explicit
+access-key ID (when both access and secret keys are set), or the JVM's default
+credential chain. Secret keys and temporary session credentials are not stored in
+the limiter key. This avoids extra AWS identity requests and IAM permissions.
+Different role ARNs or access-key IDs for the same AWS stream use separate budgets;
+default-chain consumers in the same JVM share a namespace. Endpoint overrides are
+compared as configured. This is configuration isolation, not AWS account discovery.
+
+The limiter does not coordinate across server JVMs or other applications. Size
+the configured rate for all Pinot replicas, separate credential namespaces, and
+other AWS readers. A denied permit returns a no-progress batch within the fetch
+budget. AWS calls and SDK retries still have their own timeout behavior.

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
@@ -23,13 +23,17 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.util.concurrent.RateLimiter;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.ThrottledLogger;
 import org.apache.pinot.spi.stream.BytesStreamMessage;
 import org.apache.pinot.spi.stream.PartitionGroupConsumer;
@@ -52,24 +56,26 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
   private static final int INITIAL_RATE_LIMIT_BACKOFF_MS = 1000;
   private static final int MAX_RATE_LIMIT_BACKOFF_MS = 5000;
   private static final int RATE_LIMIT_BACKOFF_JITTER_BOUND_MS = 250;
-  private static final RequestRateLimiter SHARED_REQUEST_RATE_LIMITER = new SharedKinesisRequestRateLimiter();
+  private static final SharedKinesisRequestRateLimiter SHARED_REQUEST_RATE_LIMITER =
+      new SharedKinesisRequestRateLimiter();
   private static final double RATE_LIMIT_LOG_RATE_PER_MIN = 5.0;
 
   private final ThrottledLogger _throttledLogger = new ThrottledLogger(LOGGER, RATE_LIMIT_LOG_RATE_PER_MIN);
   private String _nextStartSequenceNumber = null;
   private String _nextShardIterator = null;
   private final RequestRateLimiter _requestRateLimiter;
+  private boolean _closed;
 
   public KinesisConsumer(KinesisConfig config) {
     super(config);
-    _requestRateLimiter = SHARED_REQUEST_RATE_LIMITER;
+    _requestRateLimiter = SHARED_REQUEST_RATE_LIMITER.forConsumer(config);
     LOGGER.info("Created Kinesis consumer with topic: {}, RPS limit: {}, max records per fetch: {}",
         config.getStreamTopicName(), config.getRpsLimitPerSecond(), config.getNumMaxRecordsToFetch());
   }
 
   @VisibleForTesting
   public KinesisConsumer(KinesisConfig config, KinesisClient kinesisClient) {
-    this(config, kinesisClient, SHARED_REQUEST_RATE_LIMITER);
+    this(config, kinesisClient, SHARED_REQUEST_RATE_LIMITER.forConsumer(config));
   }
 
   @VisibleForTesting
@@ -88,6 +94,9 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
   /// This needs to be handled by the client based on appropriate retry strategy.
   @Override
   public synchronized KinesisMessageBatch fetchMessages(StreamPartitionMsgOffset startMsgOffset, int timeoutMs) {
+    if (_closed) {
+      throw new IllegalStateException("Kinesis consumer is closed");
+    }
     KinesisPartitionGroupOffset startOffset = (KinesisPartitionGroupOffset) startMsgOffset;
     long deadlineMs = currentTimeMillis() + Math.max(timeoutMs, 0);
     int attempts = 0;
@@ -180,8 +189,7 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
       Supplier<T> requestSupplier) {
     long remainingMs = deadlineMs - currentTimeMillis();
     if (remainingMs <= 0
-        || !_requestRateLimiter.tryAcquire(_config.getStreamTopicName(), shardId, requestType,
-            _config.getRpsLimitPerSecond(), remainingMs)) {
+        || !_requestRateLimiter.tryAcquire(shardId, requestType, remainingMs)) {
       throw new KinesisRequestTimeoutException(requestType);
     }
     try {
@@ -255,8 +263,15 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
   }
 
   @Override
-  public void close() {
-    super.close();
+  public synchronized void close() {
+    if (!_closed) {
+      _closed = true;
+      try {
+        super.close();
+      } finally {
+        _requestRateLimiter.close();
+      }
+    }
   }
 
   enum RequestType {
@@ -266,7 +281,10 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
 
   @VisibleForTesting
   interface RequestRateLimiter {
-    boolean tryAcquire(String streamName, String shardId, RequestType requestType, double rpsLimit, long timeoutMs);
+    boolean tryAcquire(String shardId, RequestType requestType, long timeoutMs);
+
+    default void close() {
+    }
   }
 
   private static class KinesisRateLimitException extends RuntimeException {
@@ -299,58 +317,124 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
     }
   }
 
-  /// Shared per-JVM request limiter for Kinesis read operations.
-  ///
-  /// This class is thread-safe. Limiters are keyed by stream, shard, and operation so multiple consumers on the same
-  /// server share a single smooth request budget for the same AWS shard operation.
+  /// Shared per-JVM request budgets. Registrations and effective-rate changes are serialized per key; permit waits
+  /// happen outside the registry update. Entries live until their last registered consumer closes.
   @VisibleForTesting
-  static class SharedKinesisRequestRateLimiter implements RequestRateLimiter {
-    private static final int RATE_LIMITER_EXPIRATION_HOURS = 1;
-    private final Cache<RequestRateLimiterKey, RateLimiter> _rateLimiters;
+  static class SharedKinesisRequestRateLimiter {
+    private static final int IDLE_EXPIRATION_HOURS = 1;
+    private final ConcurrentHashMap<RequestRateLimiterKey, SharedLimiter> _rateLimiters = new ConcurrentHashMap<>();
+    // Preserve permit debt across short-lived consumers without retaining registrations after close.
+    private final Cache<RequestRateLimiterKey, RateLimiter> _idleRateLimiters =
+        CacheBuilder.newBuilder().expireAfterWrite(Duration.ofHours(IDLE_EXPIRATION_HOURS)).build();
 
-    SharedKinesisRequestRateLimiter() {
-      this(CacheBuilder.newBuilder().expireAfterAccess(RATE_LIMITER_EXPIRATION_HOURS, TimeUnit.HOURS).build());
+    RequestRateLimiter forConsumer(KinesisConfig config) {
+      return new ConsumerRequestRateLimiter(config);
     }
 
     @VisibleForTesting
-    SharedKinesisRequestRateLimiter(Cache<RequestRateLimiterKey, RateLimiter> rateLimiters) {
-      _rateLimiters = rateLimiters;
-    }
-
-    @Override
-    public boolean tryAcquire(String streamName, String shardId, RequestType requestType, double rpsLimit,
-        long timeoutMs) {
-      if (timeoutMs <= 0) {
-        return false;
-      }
-      RequestRateLimiterKey key = new RequestRateLimiterKey(streamName, shardId, requestType);
-      RateLimiter rateLimiter = _rateLimiters.asMap().computeIfAbsent(key, ignored -> RateLimiter.create(rpsLimit));
-      if (rpsLimit < rateLimiter.getRate()) {
-        rateLimiter.setRate(rpsLimit);
-      }
-      return rateLimiter.tryAcquire(timeoutMs, TimeUnit.MILLISECONDS);
+    double getRateForTesting(KinesisConfig config, String shardId, RequestType requestType) {
+      SharedLimiter limiter = _rateLimiters.get(new RequestRateLimiterKey(config, shardId, requestType));
+      return limiter == null ? 0.0 : limiter._rateLimiter.getRate();
     }
 
     @VisibleForTesting
-    double getRateForTesting(String streamName, String shardId, RequestType requestType) {
-      RateLimiter rateLimiter =
-          _rateLimiters.getIfPresent(new RequestRateLimiterKey(streamName, shardId, requestType));
-      return rateLimiter == null ? 0.0 : rateLimiter.getRate();
-    }
-
-    @VisibleForTesting
-    long getLimiterCountForTesting() {
+    int getLimiterCountForTesting() {
       return _rateLimiters.size();
+    }
+
+    /// Each handle belongs to one consumer. Synchronization also makes close safe for direct users of the handle.
+    private class ConsumerRequestRateLimiter implements RequestRateLimiter {
+      private final KinesisConfig _config;
+      private final Map<RequestRateLimiterKey, SharedLimiter> _registrations = new HashMap<>();
+      private boolean _closed;
+
+      ConsumerRequestRateLimiter(KinesisConfig config) {
+        _config = config;
+      }
+
+      @Override
+      public synchronized boolean tryAcquire(String shardId, RequestType requestType, long timeoutMs) {
+        if (_closed) {
+          throw new IllegalStateException("Kinesis request limiter is closed");
+        }
+        if (timeoutMs <= 0) {
+          return false;
+        }
+        RequestRateLimiterKey key = new RequestRateLimiterKey(_config, shardId, requestType);
+        SharedLimiter limiter = _registrations.computeIfAbsent(key, ignored ->
+            _rateLimiters.compute(key, (unused, current) -> {
+              SharedLimiter shared = current;
+              if (shared == null) {
+                RateLimiter idle = _idleRateLimiters.asMap().remove(key);
+                shared = new SharedLimiter(idle == null ? RateLimiter.create(_config.getRpsLimitPerSecond()) : idle);
+              }
+              shared._consumers.put(this, _config.getRpsLimitPerSecond());
+              shared.updateRate();
+              return shared;
+            }));
+        return limiter._rateLimiter.tryAcquire(timeoutMs, TimeUnit.MILLISECONDS);
+      }
+
+      @Override
+      public synchronized void close() {
+        if (_closed) {
+          return;
+        }
+        _closed = true;
+        for (RequestRateLimiterKey key : _registrations.keySet()) {
+          _rateLimiters.computeIfPresent(key, (unused, shared) -> {
+            shared._consumers.remove(this);
+            if (shared._consumers.isEmpty()) {
+              _idleRateLimiters.put(key, shared._rateLimiter);
+              return null;
+            }
+            shared.updateRate();
+            return shared;
+          });
+        }
+        _registrations.clear();
+      }
+    }
+
+    /// Access the registrations only inside the registry's per-key compute operations.
+    private static class SharedLimiter {
+      private final RateLimiter _rateLimiter;
+      private final Map<RequestRateLimiter, Double> _consumers = new HashMap<>();
+
+      SharedLimiter(RateLimiter rateLimiter) {
+        _rateLimiter = rateLimiter;
+      }
+
+      void updateRate() {
+        double rate = _consumers.values().stream().mapToDouble(Double::doubleValue).min().orElseThrow();
+        if (Double.compare(rate, _rateLimiter.getRate()) != 0) {
+          _rateLimiter.setRate(rate);
+        }
+      }
     }
   }
 
+  /// Configuration namespace for a stream. Never retains secret keys or temporary session credentials.
+  /// Different credential configurations are deliberately isolated without an extra AWS identity lookup.
   private static class RequestRateLimiterKey {
     private final String _streamName;
+    private final String _region;
+    private final String _endpoint;
+    private final String _credentialScope;
     private final String _shardId;
     private final RequestType _requestType;
 
-    RequestRateLimiterKey(String streamName, String shardId, RequestType requestType) {
-      _streamName = streamName;
+    RequestRateLimiterKey(KinesisConfig config, String shardId, RequestType requestType) {
+      _streamName = config.getStreamTopicName();
+      _region = config.getAwsRegion();
+      _endpoint = StringUtils.isBlank(config.getEndpoint()) ? "" : config.getEndpoint();
+      if (config.isIamRoleBasedAccess()) {
+        _credentialScope = "role:" + config.getRoleArn();
+      } else if (StringUtils.isNotBlank(config.getAccessKey()) && StringUtils.isNotBlank(config.getSecretKey())) {
+        _credentialScope = "access-key:" + config.getAccessKey();
+      } else {
+        _credentialScope = "default";
+      }
       _shardId = shardId;
       _requestType = requestType;
     }
@@ -364,13 +448,14 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
         return false;
       }
       RequestRateLimiterKey that = (RequestRateLimiterKey) o;
-      return _streamName.equals(that._streamName) && _shardId.equals(that._shardId)
-          && _requestType == that._requestType;
+      return _streamName.equals(that._streamName) && _region.equals(that._region)
+          && _endpoint.equals(that._endpoint) && _credentialScope.equals(that._credentialScope)
+          && _shardId.equals(that._shardId) && _requestType == that._requestType;
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(_streamName, _shardId, _requestType);
+      return Objects.hash(_streamName, _region, _endpoint, _credentialScope, _shardId, _requestType);
     }
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerTest.java
@@ -23,6 +23,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.testng.annotations.BeforeClass;
@@ -38,6 +43,7 @@ import software.amazon.awssdk.services.kinesis.model.Record;
 import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -45,6 +51,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 
 public class KinesisConsumerTest {
@@ -60,7 +67,7 @@ public class KinesisConsumerTest {
   private static final int MAX_RECORDS_TO_FETCH = 20;
   private static final double DOUBLE_COMPARISON_DELTA = 0.000001;
   private static final KinesisConsumer.RequestRateLimiter NO_OP_REQUEST_RATE_LIMITER =
-      (streamName, shardId, requestType, rpsLimit, timeoutMs) -> true;
+      (shardId, requestType, timeoutMs) -> true;
 
   private KinesisConfig _kinesisConfig;
   private List<Record> _records;
@@ -278,22 +285,157 @@ public class KinesisConsumerTest {
   }
 
   @Test
-  public void testSharedLimiterUsesSameLimiterForSameStreamShardOperation() {
-    KinesisConsumer.SharedKinesisRequestRateLimiter requestRateLimiter =
-        new KinesisConsumer.SharedKinesisRequestRateLimiter();
+  public void testSharedLimiterRestoresRateAndRemovesLastRegistration() {
+    KinesisConsumer.SharedKinesisRequestRateLimiter registry = new KinesisConsumer.SharedKinesisRequestRateLimiter();
+    KinesisConfig lowConfig = getKinesisConfig(Map.of(KinesisConfig.RPS_LIMIT, "0.25"));
+    KinesisConsumer.RequestRateLimiter low = registry.forConsumer(lowConfig);
+    KinesisConsumer.RequestRateLimiter high = registry.forConsumer(_kinesisConfig);
+    KinesisConsumer.RequestType operation = KinesisConsumer.RequestType.GET_RECORDS;
+    low.tryAcquire("0", operation, 1);
+    high.tryAcquire("0", operation, 1);
+    assertEquals(registry.getLimiterCountForTesting(), 1);
+    assertEquals(registry.getRateForTesting(_kinesisConfig, "0", operation), 0.25);
+    low.close();
+    assertEquals(registry.getRateForTesting(_kinesisConfig, "0", operation), 1.0);
+    low.close();
+    assertEquals(registry.getLimiterCountForTesting(), 1);
+    high.close();
+    assertEquals(registry.getLimiterCountForTesting(), 0);
 
-    assertTrue(requestRateLimiter.tryAcquire(STREAM_NAME, "0", KinesisConsumer.RequestType.GET_RECORDS, 1_000_000.0,
-        1000));
-    assertTrue(requestRateLimiter.tryAcquire(STREAM_NAME, "0", KinesisConsumer.RequestType.GET_RECORDS, 500_000.0,
-        1000));
+    KinesisConsumer.RequestRateLimiter replacement = registry.forConsumer(_kinesisConfig);
+    replacement.tryAcquire("0", operation, 1);
+    assertEquals(registry.getRateForTesting(_kinesisConfig, "0", operation), 1.0);
+    replacement.close();
+    expectThrows(IllegalStateException.class, () -> low.tryAcquire("0", operation, 1));
+    assertEquals(registry.getLimiterCountForTesting(), 0);
+  }
 
-    assertEquals(requestRateLimiter.getLimiterCountForTesting(), 1);
-    assertEquals(requestRateLimiter.getRateForTesting(STREAM_NAME, "0", KinesisConsumer.RequestType.GET_RECORDS),
-        500_000.0, DOUBLE_COMPARISON_DELTA);
+  @Test
+  public void testSharedLimiterEnforcesFractionalBudgetAndSeparatesOperations() {
+    KinesisConsumer.SharedKinesisRequestRateLimiter registry = new KinesisConsumer.SharedKinesisRequestRateLimiter();
+    // A long permit interval makes the rejection independent of scheduler pauses during the test.
+    KinesisConfig config = getKinesisConfig(Map.of(KinesisConfig.RPS_LIMIT, "0.000001"));
+    KinesisConsumer.RequestRateLimiter first = registry.forConsumer(config);
+    KinesisConsumer.RequestRateLimiter second = registry.forConsumer(config);
+    KinesisConsumer.RequestType records = KinesisConsumer.RequestType.GET_RECORDS;
+    assertFalse(first.tryAcquire("0", records, 0));
+    assertEquals(registry.getLimiterCountForTesting(), 0);
+    assertTrue(first.tryAcquire("0", records, 1));
+    assertFalse(second.tryAcquire("0", records, 1));
+    assertTrue(second.tryAcquire("1", records, 1));
+    assertTrue(second.tryAcquire("0", KinesisConsumer.RequestType.GET_SHARD_ITERATOR, 1));
+    assertEquals(registry.getLimiterCountForTesting(), 3);
+    first.close();
+    second.close();
+    assertEquals(registry.getLimiterCountForTesting(), 0);
+  }
 
-    assertTrue(requestRateLimiter.tryAcquire(STREAM_NAME, "0", KinesisConsumer.RequestType.GET_SHARD_ITERATOR,
-        250_000.0, 1000));
-    assertEquals(requestRateLimiter.getLimiterCountForTesting(), 2);
+  @Test
+  public void testConsumerReplacementPreservesPermitDebt() {
+    KinesisConsumer.SharedKinesisRequestRateLimiter registry = new KinesisConsumer.SharedKinesisRequestRateLimiter();
+    KinesisConfig config = getKinesisConfig(Map.of(KinesisConfig.RPS_LIMIT, "0.000001"));
+    KinesisConsumer.RequestRateLimiter first = registry.forConsumer(config);
+    assertTrue(first.tryAcquire("0", KinesisConsumer.RequestType.GET_RECORDS, 1));
+    first.close();
+    assertEquals(registry.getLimiterCountForTesting(), 0);
+    for (int i = 0; i < 3; i++) {
+      KinesisConsumer.RequestRateLimiter replacement = registry.forConsumer(config);
+      assertFalse(replacement.tryAcquire("0", KinesisConsumer.RequestType.GET_RECORDS, 1));
+      replacement.close();
+      assertEquals(registry.getLimiterCountForTesting(), 0);
+    }
+  }
+
+  @Test
+  public void testSharedLimiterSeparatesConnectionNamespaces() {
+    KinesisConsumer.SharedKinesisRequestRateLimiter registry = new KinesisConsumer.SharedKinesisRequestRateLimiter();
+    List<Map<String, String>> namespaces = List.of(
+        Map.of(),
+        Map.of(KinesisConfig.REGION, "us-east-1"),
+        Map.of(KinesisConfig.ENDPOINT, "http://localhost:4566"),
+        Map.of(KinesisConfig.ACCESS_KEY, "account-a-key", KinesisConfig.SECRET_KEY, "secret-a"),
+        Map.of(KinesisConfig.ACCESS_KEY, "account-b-key", KinesisConfig.SECRET_KEY, "secret-b"),
+        Map.of(KinesisConfig.IAM_ROLE_BASED_ACCESS_ENABLED, "true", KinesisConfig.ROLE_ARN,
+            "arn:aws:iam::111111111111:role/reader"),
+        Map.of(KinesisConfig.IAM_ROLE_BASED_ACCESS_ENABLED, "true", KinesisConfig.ROLE_ARN,
+            "arn:aws:iam::222222222222:role/reader"));
+    List<KinesisConsumer.RequestRateLimiter> consumers = new ArrayList<>();
+    for (Map<String, String> namespace : namespaces) {
+      Map<String, String> overrides = new HashMap<>(namespace);
+      overrides.put(KinesisConfig.RPS_LIMIT, "0.000001");
+      KinesisConfig config = getKinesisConfig(overrides);
+      KinesisConsumer.RequestRateLimiter consumer = registry.forConsumer(config);
+      consumers.add(consumer);
+      assertTrue(consumer.tryAcquire("0", KinesisConsumer.RequestType.GET_RECORDS, 1));
+      KinesisConsumer.RequestRateLimiter sameNamespace = registry.forConsumer(getKinesisConfig(overrides));
+      consumers.add(sameNamespace);
+      assertFalse(sameNamespace.tryAcquire("0", KinesisConsumer.RequestType.GET_RECORDS, 1));
+    }
+    assertEquals(registry.getLimiterCountForTesting(), namespaces.size());
+    consumers.forEach(KinesisConsumer.RequestRateLimiter::close);
+    assertEquals(registry.getLimiterCountForTesting(), 0);
+  }
+
+  @Test
+  public void testConcurrentRegistrationAndRemovalPreserveMinimum() throws Exception {
+    KinesisConsumer.SharedKinesisRequestRateLimiter registry = new KinesisConsumer.SharedKinesisRequestRateLimiter();
+    int count = 8;
+    CyclicBarrier barrier = new CyclicBarrier(count);
+    ExecutorService executor = Executors.newFixedThreadPool(count);
+    List<KinesisConsumer.RequestRateLimiter> consumers = new ArrayList<>();
+    List<Future<?>> futures = new ArrayList<>();
+    try {
+      for (int i = 1; i <= count; i++) {
+        KinesisConfig config = getKinesisConfig(Map.of(KinesisConfig.RPS_LIMIT, String.valueOf(i * 0.125)));
+        KinesisConsumer.RequestRateLimiter consumer = registry.forConsumer(config);
+        consumers.add(consumer);
+        futures.add(executor.submit(() -> {
+          barrier.await(10, TimeUnit.SECONDS);
+          consumer.tryAcquire("0", KinesisConsumer.RequestType.GET_RECORDS, 1);
+          return null;
+        }));
+      }
+      for (Future<?> future : futures) {
+        future.get(10, TimeUnit.SECONDS);
+      }
+      assertEquals(registry.getLimiterCountForTesting(), 1);
+      assertEquals(registry.getRateForTesting(_kinesisConfig, "0", KinesisConsumer.RequestType.GET_RECORDS), 0.125);
+      futures.clear();
+      // Keep the highest-rate consumer active while all the lower-rate consumers close concurrently.
+      for (int i = 0; i < count - 1; i++) {
+        KinesisConsumer.RequestRateLimiter consumer = consumers.get(i);
+        futures.add(executor.submit(consumer::close));
+      }
+      for (Future<?> future : futures) {
+        future.get(10, TimeUnit.SECONDS);
+      }
+      assertEquals(registry.getRateForTesting(_kinesisConfig, "0", KinesisConsumer.RequestType.GET_RECORDS), 1.0);
+    } finally {
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+      consumers.forEach(KinesisConsumer.RequestRateLimiter::close);
+    }
+    assertEquals(registry.getLimiterCountForTesting(), 0);
+  }
+
+  @Test
+  public void testConsumerCloseReleasesRegistrationsEvenWhenClientCloseFails() {
+    KinesisConsumer.SharedKinesisRequestRateLimiter registry = new KinesisConsumer.SharedKinesisRequestRateLimiter();
+    KinesisClient client = mock(KinesisClient.class);
+    when(client.getShardIterator(any(GetShardIteratorRequest.class))).thenReturn(
+        GetShardIteratorResponse.builder().shardIterator(PLACEHOLDER).build());
+    when(client.getRecords(any(GetRecordsRequest.class))).thenReturn(
+        GetRecordsResponse.builder().nextShardIterator(PLACEHOLDER).records(_records).build());
+    KinesisConsumer consumer = new KinesisConsumer(_kinesisConfig, client, registry.forConsumer(_kinesisConfig));
+    KinesisPartitionGroupOffset offset = new KinesisPartitionGroupOffset("0", "1");
+    assertEquals(consumer.fetchMessages(offset, TIMEOUT).getMessageCount(), NUM_RECORDS);
+    assertEquals(registry.getLimiterCountForTesting(), 2);
+    doThrow(new IllegalStateException("client close failed")).when(client).close();
+    expectThrows(IllegalStateException.class, consumer::close);
+    assertEquals(registry.getLimiterCountForTesting(), 0);
+    consumer.close();
+    verify(client, times(1)).close();
+    expectThrows(IllegalStateException.class, () -> consumer.fetchMessages(offset, TIMEOUT));
   }
 
   private KinesisConsumer newTestConsumer(KinesisClient kinesisClient) {
@@ -343,8 +485,7 @@ public class KinesisConsumerTest {
     private final List<Long> _timeoutMsList = new ArrayList<>();
 
     @Override
-    public boolean tryAcquire(String streamName, String shardId, KinesisConsumer.RequestType requestType,
-        double rpsLimit, long timeoutMs) {
+    public boolean tryAcquire(String shardId, KinesisConsumer.RequestType requestType, long timeoutMs) {
       _requestTypes.add(requestType);
       _timeoutMsList.add(timeoutMs);
       return true;
@@ -367,9 +508,8 @@ public class KinesisConsumerTest {
     }
 
     @Override
-    public boolean tryAcquire(String streamName, String shardId, KinesisConsumer.RequestType requestType,
-        double rpsLimit, long timeoutMs) {
-      super.tryAcquire(streamName, shardId, requestType, rpsLimit, timeoutMs);
+    public boolean tryAcquire(String shardId, KinesisConsumer.RequestType requestType, long timeoutMs) {
+      super.tryAcquire(shardId, requestType, timeoutMs);
       if (requestType == KinesisConsumer.RequestType.GET_SHARD_ITERATOR) {
         _kinesisConsumer.advanceTimeMs(4000);
         return true;


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Fixes Kinesis request limiter to restore rates after consumer closes, isolates budgets by credential namespace, and preserves permit debt for one hour\.

```mermaid
flowchart TD
  N0["KinesisConsumer#46;fetchMessages #40;F2#41;"]:::stAdded
  N1["RequestRateLimiter#46;tryAcquire #40;interface#41; #40;F2#41;"]:::stModified
  N2["ConsumerRequestRateLimiter#46;tryAcquire #40;F2#41;"]:::stAdded
  N3["SharedLimiter#46;updateRate #40;F2#41;"]:::stAdded
  N4["ConsumerRequestRateLimiter#46;close #40;F2#41;"]:::stAdded
  N5["SharedKinesisRequestRateLimiter#46;forConsumer #40;F2#41;"]:::stAdded
  N6["RequestRateLimiterKey constructor #40;F2#41;"]:::stModified
  N7["KinesisConsumer#46;close #40;F2#41;"]:::stModified
  N0 -->|"calls tryAcquire on shared limiter via #95;requestRateLimiter#46; "| N1
  N1 -->|"implemented by ConsumerRequestRateLimiter"| N2
  N2 -->|"constructs RequestRateLimiterKey with region#47;endpoint#47;cred"| N6
  N2 -->|"after registration calls SharedLimiter#46;updateRate"| N3
  N4 -->|"on close#44; if shared limiter still has consumers#44; calls upd"| N3
  N5 -->|"returns a ConsumerRequestRateLimiter for the given config"| N2
  N7 -->|"calls #95;requestRateLimiter#46;close#40;#41; which delegates to Consu"| N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-plugins/pinot\-stream\-ingestion/pinot\-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer\.java — [before](https://github.com/apache/pinot/blob/940284ded368397eee14d78c5042b904168de801/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java) · [after](https://github.com/apache/pinot/blob/fd74053c7e4d048cf9d27908c5acec85b4c38553/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6Ijk0MDI4NGRlZDM2ODM5N2VlZTE0ZDc4YzUwNDJiOTA0MTY4ZGU4MDEiLCJjb250ZXh0X2hhc2giOiJjY2Y1NjczZDc2MzcyMTJmNzcwOTg3NTY2OTNmMDBlYWY2ODc0Y2ZkZjIzZTBkODc5M2U1MTY5ZGZkNTc0ZmRhIiwiZ2VuZXJhdGVkX2F0IjoxNzg5Nzc5NzIyLCJoZWFkX3NoYSI6ImZkNzQwNTNjN2U0ZDA0OGNmOWQyNzkwOGM1YWNlYzg1YjRjMzg1NTMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI5NDAyODRkZWQzNjgzOTdlZWUxNGQ3OGM1MDQyYjkwNDE2OGRlODAxIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 415a8c78e2859e0dbb2bb2c83f975c5f07536087248cbe9491315772d4812cda -->
<!-- pinot-pr-flow:end -->

## Summary

Fixes shared Kinesis request budgets introduced in #18531. After a consumer configured at `0.25` RPS closes, the remaining consumers can return to their configured rate instead of staying capped until JVM restart. Consumers with different connection namespaces no longer throttle each other, and concurrent registrations cannot overwrite a stricter rate.

Each consumer owns lazy registrations for its shard/operation budgets. Registration and removal recompute the minimum active rate atomically per key; permit waiting stays outside that update. Closing the last consumer drops all consumer references but retains idle permit timing for one hour, so short-lived consumers cannot bypass rate limiting by reopening.

The key now includes region, endpoint override, and configured credential namespace (role ARN, explicit access-key ID, or default credential chain), in addition to stream/shard/operation. This requires no new AWS requests or IAM permissions. Different credentials for the same actual stream may use separate budgets; JVM-wide default-chain consumers share a namespace. The module README documents these boundaries and the existing per-JVM scope.

## Validation

- `KinesisConsumerTest`: 13 tests passed in the targeted Maven reactor on JDK 25.
- Regressions cover rate recovery and cleanup, fractional admission, namespace isolation, concurrent registration/removal, close/reopen permit debt, failed client close, and rejection after close.
- Module formatting, Checkstyle, license checks, and compiler warning check completed.
- Independent reviews covered configuration, state/concurrency, architecture, performance, correctness, tests, API naming, and scope.

No AWS integration or throughput benchmark was run. Already-reserved permits retain their previous wait time after a rate change. Existing configuration keys, defaults, and public constructors are unchanged.
