### PR TITLE
[pinot-server] Add consuming-segment decoder observability

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -441,6 +441,16 @@ rules:
     database: "$2"
     table: "$1$3"
     tableType: "$4"
+- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ServerMetrics\", name=\"pinot\\.server\\.consumingSegmentDecoder\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.([-\\w]+)\\.(\\d+)\\.([\\w$]+)\"><>(\\w+)"
+  name: "pinot_server_consumingSegmentDecoder_$8"
+  cache: true
+  labels:
+    database: "$2"
+    table: "$1$3"
+    tableType: "$4"
+    topic: "$5"
+    partition: "$6"
+    decoderClass: "$7"
 - pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ServerMetrics\", name=\"pinot\\.server\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.(\\w+)\"><>(\\w+)"
   name: "pinot_server_$5_$6"
   cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -49,6 +49,22 @@ rules:
   labels:
     database: "$3"
     table: "$2$4"
+# consumingSegmentDecoder gauge: tableNameWithType + topic + partitionGroupId + decoderClass. Composed as
+# consumingSegmentDecoder.<db?>.<table>_(OFFLINE|REALTIME).<topic>.<partitionGroupId>.<SimpleClassName>, a
+# dot-separated extension of the "tableNameWithType + partitionId" shape below with topic and decoder-class
+# dimensions. MUST precede that rule: the extra trailing segments prevent it from matching there, but anchoring
+# on the literal metric name keeps this rule from shadowing any other gauge. topic is [-\w]+ (dots are mangled to
+# '_' at the emit site), partition is numeric, and the decoder class is a simple name ([\w$]+, '$' for inner classes).
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?ServerMetrics\"?, name=\"?pinot\\.server\\.consumingSegmentDecoder\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.([-\\w]+)\\.(\\d+)\\.([\\w$]+)\"?><>(\\w+)"
+  name: "pinot_server_consumingSegmentDecoder_$8"
+  cache: true
+  labels:
+    database: "$2"
+    table: "$1$3"
+    tableType: "$4"
+    topic: "$5"
+    partition: "$6"
+    decoderClass: "$7"
 # Gauges that accept tableNameWithType + partitionId
 - pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ServerMetrics\", name=\"pinot\\.server\\.(\\w+)\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.(\\w+)\"><>(\\w+)"
   name: "pinot_server_$1_$7"

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -397,6 +397,18 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
     setValueOfGauge(value, fullGaugeName);
   }
 
+  /// Sets the value of a table gauge keyed by an arbitrary compound key, via the cached
+  /// [#setValueOfGauge(long, String)] path (reuses the registration; the composed name is still rebuilt each call).
+  ///
+  /// @param tableName The table name
+  /// @param key The key associated with this gauge
+  /// @param gauge The gauge to use
+  /// @param value The value to set the gauge to
+  public void setValueOfTableGauge(final String tableName, final String key, final G gauge, final long value) {
+    final String fullGaugeName = composeTableGaugeName(tableName, key, gauge);
+    setValueOfGauge(value, fullGaugeName);
+  }
+
   /// Sets the value of a custom global gauge.
   ///
   /// @param suffix The suffix to attach to the gauge name

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -58,6 +58,8 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   NETTY_POOLED_ARENAS_DIRECT("arenas", true),
   NETTY_POOLED_ARENAS_HEAP("arenas", true),
   STREAM_DATA_LOSS("streamDataLoss", false),
+  CONSUMING_SEGMENT_DECODER("state", false,
+      "Indicator (value 1) tagging a consuming segment with the decoder class currently instantiated on it."),
 
   // Segment operation throttle metrics - threshold is the upper limit of the throttle and is set whenever the
   // throttle configs are modified

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.restlet.resources;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 
 /// Information regarding the consumer of a segment
@@ -31,21 +32,31 @@ public class SegmentConsumerInfo {
   private final long _lastConsumedTimestamp;
   private final Map<String, String> _partitionToOffsetMap;
   private final PartitionOffsetInfo _partitionOffsetInfo;
+  // FQCN of the StreamMessageDecoder instantiated on the consumer, or null if decoder init has not completed.
+  @Nullable
+  private final String _decoderClassName;
 
   public SegmentConsumerInfo(@JsonProperty("segmentName") String segmentName,
       @JsonProperty("consumerState") String consumerState,
       @JsonProperty("lastConsumedTimestamp") long lastConsumedTimestamp,
       @JsonProperty("partitionToOffsetMap") Map<String, String> partitionToOffsetMap,
-      @JsonProperty("partitionOffsetInfo") PartitionOffsetInfo partitionOffsetInfo) {
+      @JsonProperty("partitionOffsetInfo") PartitionOffsetInfo partitionOffsetInfo,
+      @JsonProperty("decoderClassName") @Nullable String decoderClassName) {
     _segmentName = segmentName;
     _consumerState = consumerState;
     _lastConsumedTimestamp = lastConsumedTimestamp;
     _partitionToOffsetMap = partitionToOffsetMap;
     _partitionOffsetInfo = partitionOffsetInfo;
+    _decoderClassName = decoderClassName;
   }
 
   public String getSegmentName() {
     return _segmentName;
+  }
+
+  @Nullable
+  public String getDecoderClassName() {
+    return _decoderClassName;
   }
 
   public String getConsumerState() {

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/AbstractMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/AbstractMetricsTest.java
@@ -129,6 +129,24 @@ public abstract class AbstractMetricsTest {
   }
 
   @Test
+  public void testSetValueOfTableGaugeWithKey() {
+    ControllerMetrics controllerMetrics = buildTestMetrics();
+    // Composed as gauge.<table>.<key>, mirroring composeTableGaugeName(tableName, key, gauge).
+    String composedName = ControllerGauge.VERSION.getGaugeName() + ".test_table.myKey";
+
+    controllerMetrics.setValueOfTableGauge("test_table", "myKey", ControllerGauge.VERSION, 1L);
+    Assert.assertEquals(getGaugeValue(controllerMetrics, composedName), 1);
+
+    // Re-setting through the cached path updates the same registry entry in place rather than registering a new gauge.
+    controllerMetrics.setValueOfTableGauge("test_table", "myKey", ControllerGauge.VERSION, 5L);
+    Assert.assertEquals(getGaugeValue(controllerMetrics, composedName), 5);
+    Assert.assertEquals(controllerMetrics.getMetricsRegistry().allMetrics().size(), 1);
+
+    controllerMetrics.removeTableGauge("test_table", "myKey", ControllerGauge.VERSION);
+    Assert.assertTrue(controllerMetrics.getMetricsRegistry().allMetrics().isEmpty());
+  }
+
+  @Test
   public void testQueryPhases() {
     ControllerMetrics testMetrics = buildTestMetrics();
     MetricsInspector inspector = createInspector(testMetrics.getMetricsRegistry());

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PrometheusTemplateRegexpTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PrometheusTemplateRegexpTest.java
@@ -380,6 +380,74 @@ public class PrometheusTemplateRegexpTest {
     Assert.assertEquals(m.group(3), "Value");
   }
 
+  // ---- consumingSegmentDecoder patterns (server.yml and pinot.yml) ----
+
+  @DataProvider(name = "consumingSegmentDecoderConfigs")
+  public Object[][] consumingSegmentDecoderConfigs() {
+    return new Object[][]{{"server.yml"}, {"pinot.yml"}};
+  }
+
+  /// consumingSegmentDecoder gauge: verifies both the capture groups and that the label templates fold the database
+  /// prefix into the table label (dropping it exports an incomplete table for database-qualified tables).
+  @Test(dataProvider = "consumingSegmentDecoderConfigs")
+  public void testConsumingSegmentDecoderGaugePattern(String configFile)
+      throws Exception {
+    String ruleName = "pinot_server_consumingSegmentDecoder_$8";
+    Matcher m = Pattern.compile(loadPatternByName(configFile, ruleName)).matcher(
+        "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", "
+            + "name=\"pinot.server.consumingSegmentDecoder.myDb.myTable_REALTIME.rt-control-tower.0."
+            + "CLPLogMessageDecoder\"><>Value");
+    Assert.assertTrue(m.matches(), "Pattern should match db-qualified consumingSegmentDecoder gauge in " + configFile);
+    Assert.assertEquals(m.group(2), "myDb");
+    Assert.assertEquals(m.group(3), "myTable");
+    Assert.assertEquals(m.group(4), "REALTIME");
+    Assert.assertEquals(m.group(5), "rt-control-tower");
+    Assert.assertEquals(m.group(6), "0");
+    Assert.assertEquals(m.group(7), "CLPLogMessageDecoder");
+    Assert.assertEquals(m.group(8), "Value");
+
+    Map<String, String> labels = loadLabelsByName(configFile, ruleName);
+    Assert.assertEquals(labels.get("database"), "$2");
+    Assert.assertEquals(labels.get("table"), "$1$3", "table label must fold the database prefix ($1) with the "
+        + "raw table name ($3) in " + configFile);
+    Assert.assertEquals(labels.get("tableType"), "$4");
+    Assert.assertEquals(labels.get("topic"), "$5");
+    Assert.assertEquals(labels.get("partition"), "$6");
+    Assert.assertEquals(labels.get("decoderClass"), "$7");
+  }
+
+  /// The non-database form leaves the database group empty and the whole name still round-trips.
+  @Test(dataProvider = "consumingSegmentDecoderConfigs")
+  public void testConsumingSegmentDecoderGaugePatternNoDatabase(String configFile)
+      throws Exception {
+    Matcher m = Pattern.compile(loadPatternByName(configFile, "pinot_server_consumingSegmentDecoder_$8")).matcher(
+        "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", "
+            + "name=\"pinot.server.consumingSegmentDecoder.myTable_REALTIME.topic1.5.JSONMessageDecoder\"><>Value");
+    Assert.assertTrue(m.matches(), "Pattern should match non-database consumingSegmentDecoder gauge in " + configFile);
+    Assert.assertEquals(m.group(3), "myTable");
+    Assert.assertEquals(m.group(5), "topic1");
+    Assert.assertEquals(m.group(6), "5");
+    Assert.assertEquals(m.group(7), "JSONMessageDecoder");
+  }
+
+  /// Returns the labels map for the rule whose `name` field equals `ruleName`, failing unless exactly one matches.
+  @SuppressWarnings("unchecked")
+  private Map<String, String> loadLabelsByName(String configFile, String ruleName)
+      throws Exception {
+    Yaml yaml = new Yaml();
+    try (FileReader reader = new FileReader(CONFIG_BASE_PATH + "/" + configFile)) {
+      Map<String, Object> config = yaml.load(reader);
+      List<Map<String, Object>> rules = (List<Map<String, Object>>) config.get("rules");
+      List<Map<String, String>> matches = rules.stream()
+          .filter(rule -> ruleName.equals(rule.get("name")))
+          .map(rule -> (Map<String, String>) rule.get("labels"))
+          .filter(labels -> labels != null)
+          .collect(Collectors.toList());
+      Assert.assertEquals(matches.size(), 1, "Expected exactly one rule named '" + ruleName + "' in " + configFile);
+      return matches.get(0);
+    }
+  }
+
   /// Returns the pattern string for the rule whose `name` field equals `ruleName`. Fails when more
   /// than one rule shares that name — use [#loadPatternByName(String,String,String)] instead.
   ///

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ServerPrometheusMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ServerPrometheusMetricsTest.java
@@ -86,6 +86,13 @@ public abstract class ServerPrometheusMetricsTest extends PinotPrometheusMetrics
   private static final String OPEN_STRUCT_KEY_EXPORTED = "clicks.v2$promo%22code";
   private static final String LABEL_KEY_COLUMN = "column";
   private static final String LABEL_KEY_KEY = "key";
+  private static final String LABEL_KEY_DECODER_CLASS = "decoderClass";
+
+  // CONSUMING_SEGMENT_DECODER uses a compound key "<topic>.<partitionGroupId>.<simpleDecoderClassName>" + a
+  // tableNameWithType, so it is dispatched separately (like OPEN_STRUCT) to assert against its real 5-segment name.
+  private static final String DECODER_TOPIC = "rt-control-tower";
+  private static final int DECODER_PARTITION_GROUP_ID = 0;
+  private static final String DECODER_SIMPLE_CLASS_NAME = "CLPLogMessageDecoder";
 
   private static final List<ServerGauge> GAUGES_ACCEPTING_OPEN_STRUCT_COLUMN =
       List.of(ServerGauge.OPEN_STRUCT_LAST_SEGMENT_DENSE_KEY_COUNT,
@@ -192,6 +199,17 @@ public abstract class ServerPrometheusMetricsTest extends PinotPrometheusMetrics
       } else if (GAUGES_ACCEPTING_OPEN_STRUCT_COLUMN.contains(serverGauge)) {
         _serverMetrics.setOrUpdateTableGauge(TABLE_NAME_WITH_TYPE, OPEN_STRUCT_COLUMN, serverGauge, 100L);
         assertGaugeExportedCorrectly(serverGauge.getGaugeName(), TABLENAME_TABLETYPE_COLUMN, EXPORTED_METRIC_PREFIX);
+      } else if (serverGauge == ServerGauge.CONSUMING_SEGMENT_DECODER) {
+        // Mirror the emit-site composition: setValueOfTableGauge(tableWithType, "<topic>.<pgId>.<simpleName>", ...).
+        String compoundKey = DECODER_TOPIC + "." + DECODER_PARTITION_GROUP_ID + "." + DECODER_SIMPLE_CLASS_NAME;
+        _serverMetrics.setValueOfTableGauge(TABLE_NAME_WITH_TYPE, compoundKey, serverGauge, 1L);
+        assertGaugeExportedCorrectly(serverGauge.getGaugeName(),
+            List.of(ExportedLabelKeys.TABLE, ExportedLabelValues.TABLENAME,
+                ExportedLabelKeys.TABLETYPE, ExportedLabelValues.TABLETYPE_REALTIME,
+                ExportedLabelKeys.TOPIC, DECODER_TOPIC,
+                ExportedLabelKeys.PARTITION, String.valueOf(DECODER_PARTITION_GROUP_ID),
+                LABEL_KEY_DECODER_CLASS, DECODER_SIMPLE_CLASS_NAME),
+            EXPORTED_METRIC_PREFIX);
       } else {
         addGaugeWithLabels(serverGauge, TABLE_NAME_WITH_TYPE);
         assertGaugeExportedCorrectly(serverGauge.getGaugeName(), ExportedLabels.TABLENAME_TABLETYPE,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.restlet.resources.SegmentConsumerInfo;
@@ -83,7 +84,7 @@ public class ConsumingSegmentInfoReader {
             partitionOffsetInfo.getAvailabilityLagMs());
         consumingSegmentInfoMap.computeIfAbsent(info.getSegmentName(), k -> new ArrayList<>()).add(
             new ConsumingSegmentInfo(serverName, info.getConsumerState(), info.getLastConsumedTimestamp(),
-                partitionOffsetInfo.getCurrentOffsets(), offsetInfo));
+                partitionOffsetInfo.getCurrentOffsets(), offsetInfo, info.getDecoderClassName()));
       }
     }
     // Segments which are in CONSUMING state but found no consumer on the server
@@ -210,18 +211,23 @@ public class ConsumingSegmentInfoReader {
     public Map<String, String> _partitionToOffsetMap;
     @JsonProperty("partitionOffsetInfo")
     public PartitionOffsetInfo _partitionOffsetInfo;
+    @JsonProperty("decoderClassName")
+    @Nullable
+    public String _decoderClassName;
 
 
     public ConsumingSegmentInfo(@JsonProperty("serverName") String serverName,
         @JsonProperty("consumerState") String consumerState,
         @JsonProperty("lastConsumedTimestamp") long lastConsumedTimestamp,
         @JsonProperty("partitionToOffsetMap") Map<String, String> partitionToOffsetMap,
-        @JsonProperty("partitionOffsetInfo") PartitionOffsetInfo partitionOffsetInfo) {
+        @JsonProperty("partitionOffsetInfo") PartitionOffsetInfo partitionOffsetInfo,
+        @JsonProperty("decoderClassName") @Nullable String decoderClassName) {
       _serverName = serverName;
       _consumerState = consumerState;
       _lastConsumedTimestamp = lastConsumedTimestamp;
       _partitionToOffsetMap = partitionToOffsetMap;
       _partitionOffsetInfo = partitionOffsetInfo;
+      _decoderClassName = decoderClassName;
     }
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderStatelessTest.java
@@ -67,6 +67,9 @@ public class ConsumingSegmentInfoReaderStatelessTest {
   private static final String TABLE_NAME = "myTable_REALTIME";
   private static final String SEGMENT_NAME_PARTITION_0 = "table__0__29__12345";
   private static final String SEGMENT_NAME_PARTITION_1 = "table__1__32__12345";
+  private static final String DECODER_CLASS = "org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder";
+  // A distinct decoder for partition 1 fixtures so the passthrough assertion catches a cross-wired/hardcoded value.
+  private static final String DECODER_CLASS_ALT = "org.apache.pinot.plugin.inputformat.avro.KafkaAvroMessageDecoder";
   private static final int TIMEOUT_MSEC = 10000;
   private static final int EXTENDED_TIMEOUT_FACTOR = 100;
 
@@ -89,10 +92,10 @@ public class ConsumingSegmentInfoReaderStatelessTest {
     FakeConsumingInfoServer s0 = new FakeConsumingInfoServer(Lists.newArrayList(
         new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0, partitionToOffset0,
             new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset0, Map.of(),
-                Map.of(), Map.of())),
+                Map.of(), Map.of()), DECODER_CLASS),
         new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0, partitionToOffset1,
             new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset1, Map.of(),
-                Map.of(), Map.of()))));
+                Map.of(), Map.of()), DECODER_CLASS_ALT)));
     s0.start(uriPath, createHandler(200, s0._consumerInfos, 0));
     _serverMap.put("server0", s0);
 
@@ -100,10 +103,10 @@ public class ConsumingSegmentInfoReaderStatelessTest {
     FakeConsumingInfoServer s1 = new FakeConsumingInfoServer(Lists.newArrayList(
         new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0, partitionToOffset0,
             new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset0, Map.of(),
-                Map.of(), Map.of())),
+                Map.of(), Map.of()), DECODER_CLASS),
         new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0, partitionToOffset1,
             new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset1, Map.of(),
-                Map.of(), Map.of()))));
+                Map.of(), Map.of()), DECODER_CLASS_ALT)));
     s1.start(uriPath, createHandler(200, s1._consumerInfos, 0));
     _serverMap.put("server1", s1);
 
@@ -111,10 +114,10 @@ public class ConsumingSegmentInfoReaderStatelessTest {
     FakeConsumingInfoServer s2 = new FakeConsumingInfoServer(Lists.newArrayList(
         new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "NOT_CONSUMING", 0, partitionToOffset0,
             new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset0, Map.of(),
-                Map.of(), Map.of())),
+                Map.of(), Map.of()), DECODER_CLASS),
         new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0, partitionToOffset1,
             new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset1, Map.of(),
-                Map.of(), Map.of()))));
+                Map.of(), Map.of()), DECODER_CLASS_ALT)));
     s2.start(uriPath, createHandler(200, s2._consumerInfos, 0));
     _serverMap.put("server2", s2);
 
@@ -122,7 +125,7 @@ public class ConsumingSegmentInfoReaderStatelessTest {
     FakeConsumingInfoServer s3 = new FakeConsumingInfoServer(Lists.newArrayList(
         new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0, partitionToOffset1,
             new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset1, Map.of(),
-                Map.of(), Map.of()))));
+                Map.of(), Map.of()), DECODER_CLASS_ALT)));
     s3.start(uriPath, createHandler(200, s3._consumerInfos, 0));
     _serverMap.put("server3", s3);
 
@@ -130,10 +133,10 @@ public class ConsumingSegmentInfoReaderStatelessTest {
     FakeConsumingInfoServer s4 = new FakeConsumingInfoServer(Lists.newArrayList(
         new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0, partitionToOffset0,
             new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset0, Map.of(),
-                Map.of(), Map.of())),
+                Map.of(), Map.of()), DECODER_CLASS),
         new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0, partitionToOffset1,
             new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset1, Map.of(),
-                Map.of(), Map.of()))));
+                Map.of(), Map.of()), DECODER_CLASS_ALT)));
     s4.start(uriPath, createHandler(200, s4._consumerInfos, TIMEOUT_MSEC * EXTENDED_TIMEOUT_FACTOR));
     _serverMap.put("server4", s4);
   }
@@ -352,5 +355,19 @@ public class ConsumingSegmentInfoReaderStatelessTest {
     assertTrue(serverNames.contains(info._serverName));
     assertEquals(info._consumerState, consumerState);
     assertEquals(info._partitionOffsetInfo._currentOffsetsMap.get(partition), offset);
+    // decoderClassName from the server-side DTO must survive the controller-aggregate reader passthrough. Partition 0
+    // and 1 fixtures use different decoders, so this also catches a cross-wired or hardcoded value.
+    assertEquals(info._decoderClassName, partition.equals("0") ? DECODER_CLASS : DECODER_CLASS_ALT);
+  }
+
+  /// An older server may return a payload without the decoderClassName field; it must deserialize to null rather
+  /// than failing, preserving rolling-upgrade compatibility.
+  @Test
+  public void testDecoderClassNameMissingDeserializesToNull()
+      throws IOException {
+    SegmentConsumerInfo info = JsonUtils.stringToObject(
+        "{\"segmentName\":\"seg\",\"consumerState\":\"CONSUMING\",\"lastConsumedTimestamp\":0,"
+            + "\"partitionToOffsetMap\":{}}", SegmentConsumerInfo.class);
+    assertNull(info.getDecoderClassName());
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/RealtimeConsumerMonitorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/RealtimeConsumerMonitorTest.java
@@ -156,7 +156,7 @@ public class RealtimeConsumerMonitorTest {
         new ConsumingSegmentInfoReader.PartitionOffsetInfo(currentOffsetMap, latestUpstreamOffsetMap, recordsLagMap,
             availabilityLagMsMap);
     return new ConsumingSegmentInfoReader.ConsumingSegmentInfo(serverName, "CONSUMING", -1, currentOffsetMap,
-        partitionOffsetInfo);
+        partitionOffsetInfo, null);
   }
 
   Map<String, String> getStreamConfigMap() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -249,6 +249,10 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private final TableConfig _tableConfig;
   private final RealtimeTableDataManager _realtimeTableDataManager;
   private final StreamDataDecoder _streamDataDecoder;
+  // Pre-computed key "<topic>.<partitionGroupId>.<simpleDecoderClassName>" for the CONSUMING_SEGMENT_DECODER gauge,
+  // or null when the decoder class is unavailable (emit + cleanup are skipped). Computed once at construction.
+  @Nullable
+  private final String _consumingSegmentDecoderKey;
   private final int _segmentMaxRowCount;
   private final String _resourceDataDir;
   private final Schema _schema;
@@ -508,6 +512,12 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         }
       }
       _serverMetrics.setValueOfTableGauge(_clientId, ServerGauge.LLC_PARTITION_CONSUMING, 1);
+      if (_consumingSegmentDecoderKey != null) {
+        // Re-emitted every tick (like LLC_PARTITION_CONSUMING above) so it self-heals if a prior consumer's offload
+        // races this emit at a segment-commit boundary. See #cleanupMetrics for the offload/emit race rationale.
+        _serverMetrics.setValueOfTableGauge(_tableNameWithType, _consumingSegmentDecoderKey,
+            ServerGauge.CONSUMING_SEGMENT_DECODER, 1L);
+      }
       // Consume for the next readTime ms, or we get to final offset, whichever happens earlier,
       // Update _currentOffset upon return from this method
       MessageBatch messageBatch;
@@ -1240,7 +1250,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(_realtimeSegment, segmentZKPropsConfig, tempSegmentFolder.getAbsolutePath(),
               _schema, _tableNameWithType, _tableConfig, _segmentZKMetadata.getSegmentName(),
-              _defaultNullHandlingEnabled);
+              _defaultNullHandlingEnabled, getDecoderClassName());
       _segmentLogger.info("Trying to build segment");
       try {
         converter.build(_segmentVersion);
@@ -1489,6 +1499,34 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     }
   }
 
+  /// @return the FQCN of the {@link StreamMessageDecoder} actually instantiated on this consumer (the source of truth
+  ///         for what is decoding this segment), or {@code null} if decoder init has not completed.
+  @Nullable
+  public String getDecoderClassName() {
+    StreamDataDecoder decoder = _streamDataDecoder;
+    StreamMessageDecoder valueDecoder = decoder == null ? null : decoder.getValueDecoder();
+    return valueDecoder == null ? null : valueDecoder.getClass().getName();
+  }
+
+  /// Computes the CONSUMING_SEGMENT_DECODER gauge key `<topic>.<partitionGroupId>.<simpleDecoderClassName>`, or null if
+  /// the decoder class is unavailable. The simple (not fully-qualified) name is used because the composed metric name
+  /// is split on '.' downstream; a dotted topic is likewise sanitized to '_' (warned once, so no per-tick flood).
+  @Nullable
+  private String computeConsumingSegmentDecoderKey() {
+    String decoderClassName = getDecoderClassName();
+    if (decoderClassName == null) {
+      return null;
+    }
+    String decoderSimpleName = decoderClassName.substring(decoderClassName.lastIndexOf('.') + 1);
+    String topic = _streamConfig.getTopicName();
+    if (topic.indexOf('.') >= 0) {
+      _segmentLogger.warn("CONSUMING_SEGMENT_DECODER tagging will degrade for dotted topic '{}' on {} — replacing "
+          + "'.' with '_' in the emitted topic segment for stability", topic, _clientId);
+      topic = topic.replace('.', '_');
+    }
+    return topic + "." + _partitionGroupId + "." + decoderSimpleName;
+  }
+
   /// Cleans up the metrics that reflects the state of the realtime segment.
   /// This step is essential as the instance may not be the target location for some of the partitions.
   /// E.g. if the number of partitions increases, or a host swap is needed, the target location for some partitions
@@ -1501,6 +1539,12 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     _serverMetrics.removeTableGauge(_clientId, ServerGauge.STREAM_DATA_LOSS);
     _serverMetrics.removeTableGauge(_clientId, ServerGauge.PAUSELESS_CONSUMPTION_ENABLED);
     _serverMetrics.removeTableMeter(_clientId, ServerMeter.SEGMENT_BUILD_FAILURE);
+    if (_consumingSegmentDecoderKey != null) {
+      // Uses the (_tableNameWithType, key) shape the emit used, not the _clientId shape above. If this remove races
+      // the next consumer's emit, that consumer's in-loop re-emit restores the series (see consumeLoop).
+      _serverMetrics.removeTableGauge(_tableNameWithType, _consumingSegmentDecoderKey,
+          ServerGauge.CONSUMING_SEGMENT_DECODER);
+    }
   }
 
   protected void hold()
@@ -1984,6 +2028,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       throw e;
     }
     _streamDataDecoder = localStreamDataDecoder.get();
+    _consumingSegmentDecoderKey = computeConsumingSegmentDecoderKey();
 
     try {
       _transformPipeline = new TransformPipeline(tableConfig, schema);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -40,6 +40,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.common.utils.LLCSegmentName;
@@ -111,6 +112,8 @@ public class RealtimeSegmentDataManagerTest {
 
   private final Map<Integer, ConsumerCoordinator> _partitionGroupIdToConsumerCoordinatorMap =
       new ConcurrentHashMap<>();
+  // ServerMetrics instance handed to the most recently created fake manager, for reading emitted gauges in tests.
+  private ServerMetrics _capturedServerMetrics;
 
   private static TableConfig createTableConfig()
       throws Exception {
@@ -215,9 +218,57 @@ public class RealtimeSegmentDataManagerTest {
         new ConsumerCoordinator(false, tableDataManager));
     Schema schema = Fixtures.createSchema();
     ServerMetrics serverMetrics = new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    _capturedServerMetrics = serverMetrics;
     return new FakeRealtimeSegmentDataManager(segmentZKMetadata, tableConfig, tableDataManager,
         new File(TEMP_DIR, REALTIME_TABLE_NAME).getAbsolutePath(), schema, llcSegmentName,
         _partitionGroupIdToConsumerCoordinatorMap, serverMetrics, timeSupplier);
+  }
+
+  @Test
+  public void testGetDecoderClassName()
+      throws Exception {
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
+      // Reports the actual instantiated decoder wrapped by StreamDataDecoderImpl, resolved via the SPI accessor.
+      Assert.assertEquals(segmentDataManager.getDecoderClassName(), FakeStreamMessageDecoder.class.getName());
+    }
+  }
+
+  @Test
+  public void testConsumingSegmentDecoderGaugeUsesSanitizedKey()
+      throws Exception {
+    TableConfig tableConfig = createTableConfig();
+    // Override the stream topic with a dotted name to exercise the '.'->'_' sanitization in the gauge key.
+    tableConfig.getIndexingConfig().getStreamConfigs().entrySet().stream()
+        .filter(e -> e.getKey().endsWith(".topic.name"))
+        .forEach(e -> e.setValue("dotted.topic"));
+    // Composed as <gauge>.<tableNameWithType>.<sanitizedTopic>.<partitionGroupId>.<simpleDecoderClassName>. The manager
+    // derives tableNameWithType from the table config, so key off that rather than the segment's raw table.
+    String composedName = ServerGauge.CONSUMING_SEGMENT_DECODER.getGaugeName() + "." + tableConfig.getTableName()
+        + ".dotted_topic." + PARTITION_GROUP_ID + ".FakeStreamMessageDecoder";
+    // Drive the real consume loop (not the stub) so the in-loop gauge emit runs; a row-count-triggered COMMIT ends the
+    // loop deterministically, and commit never tears down the decoder gauge (only offload on close does).
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager(true, new TimeSupplier(),
+        String.valueOf(FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS), "10m", tableConfig)) {
+      segmentDataManager._stubConsumeLoop = false;
+      segmentDataManager._state.set(segmentDataManager, RealtimeSegmentDataManager.State.INITIAL_CONSUMING);
+      RealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
+      LongMsgOffset endOffset =
+          new LongMsgOffset(START_OFFSET_VALUE + FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS);
+      segmentDataManager._consumeOffsets.add(endOffset);
+      segmentDataManager._responses.add(new SegmentCompletionProtocol.Response(
+          new SegmentCompletionProtocol.Response.Params()
+              .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT)
+              .withStreamPartitionMsgOffset(endOffset.toString())));
+
+      consumer.run();
+
+      Long gaugeValue = _capturedServerMetrics.getGaugeValue(composedName);
+      Assert.assertNotNull(gaugeValue, "decoder gauge should be emitted under the sanitized key");
+      Assert.assertEquals((long) gaugeValue, 1L);
+    }
+    // Closing the manager offloads it, which cleanupMetrics() uses to remove the decoder gauge.
+    Assert.assertNull(_capturedServerMetrics.getGaugeValue(composedName),
+        "decoder gauge should be removed after the segment is offloaded on close");
   }
 
   @BeforeClass

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
@@ -32,6 +32,7 @@ import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationD
 import org.apache.pinot.segment.local.segment.readers.CompactedPinotSegmentRecordReader;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
 import org.apache.pinot.segment.local.utils.TableConfigUtils;
+import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
@@ -60,10 +61,20 @@ public class RealtimeSegmentConverter {
   private final boolean _nullHandlingEnabled;
   private final boolean _enableColumnMajor;
   private final ServerMetrics _serverMetrics;
+  // Fully-qualified decoder class name to persist in segment metadata under custom.decoder.class, or null to skip.
+  @Nullable
+  private final String _decoderClassName;
 
   public RealtimeSegmentConverter(MutableSegmentImpl realtimeSegment, SegmentZKPropsConfig segmentZKPropsConfig,
       String outputPath, Schema schema, String tableName, TableConfig tableConfig, String segmentName,
       boolean nullHandlingEnabled) {
+    this(realtimeSegment, segmentZKPropsConfig, outputPath, schema, tableName, tableConfig, segmentName,
+        nullHandlingEnabled, null);
+  }
+
+  public RealtimeSegmentConverter(MutableSegmentImpl realtimeSegment, SegmentZKPropsConfig segmentZKPropsConfig,
+      String outputPath, Schema schema, String tableName, TableConfig tableConfig, String segmentName,
+      boolean nullHandlingEnabled, @Nullable String decoderClassName) {
     _realtimeSegmentImpl = realtimeSegment;
     _segmentZKPropsConfig = segmentZKPropsConfig;
     _outputPath = outputPath;
@@ -72,6 +83,7 @@ public class RealtimeSegmentConverter {
     _tableConfig = tableConfig;
     _segmentName = segmentName;
     _nullHandlingEnabled = nullHandlingEnabled;
+    _decoderClassName = decoderClassName;
     if (_tableConfig.getIngestionConfig() != null
         && _tableConfig.getIngestionConfig().getStreamIngestionConfig() != null) {
       _enableColumnMajor =
@@ -85,6 +97,13 @@ public class RealtimeSegmentConverter {
   public void build(@Nullable SegmentVersion segmentVersion)
       throws Exception {
     SegmentGeneratorConfig genConfig = new SegmentGeneratorConfig(_tableConfig, _dataSchema);
+    if (_decoderClassName != null) {
+      // Durably record the decoder in segment metadata; merges (putAll) so other custom properties are preserved.
+      // Harvested back by SegmentMetadataImpl.subset("custom"), surfacing as custom.decoder.class.
+      genConfig.setCustomProperties(Map.of(
+          V1Constants.MetadataKeys.Segment.CUSTOM_SUBSET + "." + V1Constants.MetadataKeys.Segment.DECODER_CLASS,
+          _decoderClassName));
+    }
     genConfig.setInstanceType(InstanceType.SERVER);
     genConfig.setRealtimeConversion(true);
     genConfig.setConsumerDir(_realtimeSegmentImpl.getConsumerDir());

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverterTest.java
@@ -48,6 +48,7 @@ import org.apache.pinot.segment.local.segment.index.text.TextIndexConfigBuilder;
 import org.apache.pinot.segment.local.segment.store.SegmentLocalFSDirectory;
 import org.apache.pinot.segment.local.segment.virtualcolumn.VirtualColumnProviderFactory;
 import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.index.DictionaryIndexConfig;
 import org.apache.pinot.segment.spi.index.ForwardIndexConfig;
@@ -199,6 +200,71 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
       assertTrue(segmentMetadata.getAllColumns().containsAll(schema.getColumnNames()));
       assertEquals(segmentMetadata.getStartOffset(), "1");
       assertEquals(segmentMetadata.getEndOffset(), "100");
+    } finally {
+      mutableSegmentImpl.destroy();
+    }
+  }
+
+  /// The decoderClass constructor overload must persist the decoder under custom.decoder.class in segment metadata,
+  /// and the delegating (no-decoder) constructor must leave the key absent.
+  @Test
+  public void testDecoderClassWrittenToSegmentMetadata()
+      throws Exception {
+    File tmpDir = new File(TMP_DIR, "tmp_" + System.currentTimeMillis());
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName("testTable")
+        .setTimeColumnName(DATE_TIME_COLUMN)
+        .setNoDictionaryColumns(List.of(LONG_COLUMN2))
+        .build();
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName("testTable")
+        .addSingleValueDimension(STRING_COLUMN1, DataType.STRING)
+        .addSingleValueDimension(LONG_COLUMN2, DataType.LONG)
+        .addDateTime(DATE_TIME_COLUMN, DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .build();
+    String tableNameWithType = tableConfig.getTableName();
+    String decoderClass = "org.apache.pinot.plugin.inputformat.clplog.CLPLogMessageDecoder";
+
+    SegmentMetadataImpl withDecoder =
+        buildAndReadMetadata(tmpDir, "withDecoder", tableConfig, schema, tableNameWithType, decoderClass);
+    assertEquals(withDecoder.getCustomMap().get(V1Constants.MetadataKeys.Segment.DECODER_CLASS), decoderClass);
+
+    SegmentMetadataImpl withoutDecoder =
+        buildAndReadMetadata(tmpDir, "withoutDecoder", tableConfig, schema, tableNameWithType, null);
+    assertFalse(withoutDecoder.getCustomMap().containsKey(V1Constants.MetadataKeys.Segment.DECODER_CLASS));
+  }
+
+  private SegmentMetadataImpl buildAndReadMetadata(File tmpDir, String suffix, TableConfig tableConfig, Schema schema,
+      String tableNameWithType, String decoderClass)
+      throws Exception {
+    String segmentName = "testTable__0__0__" + suffix;
+    RealtimeSegmentConfig realtimeSegmentConfig = new RealtimeSegmentConfig.Builder()
+        .setTableNameWithType(tableNameWithType)
+        .setSegmentName(segmentName)
+        .setStreamName(tableNameWithType)
+        .setSchema(schema)
+        .setTimeColumnName(DATE_TIME_COLUMN)
+        .setCapacity(1000)
+        .setAvgNumMultiValues(3)
+        .setIndex(Set.of(LONG_COLUMN2), StandardIndexes.forward(),
+            ForwardIndexConfig.getDefault(FieldConfig.EncodingType.RAW))
+        .setSegmentZKMetadata(getSegmentZKMetadata(segmentName))
+        .setOffHeap(true)
+        .setMemoryManager(new DirectMemoryManager(segmentName))
+        .setStatsHistory(RealtimeSegmentStatsHistory.deserializeFrom(new File(tmpDir, "stats_" + suffix)))
+        .setConsumerDir(new File(tmpDir, "consumerDir_" + suffix).getAbsolutePath())
+        .build();
+    MutableSegmentImpl mutableSegmentImpl = new MutableSegmentImpl(realtimeSegmentConfig, null);
+    try {
+      File outputDir = new File(tmpDir, "outputDir_" + suffix);
+      SegmentZKPropsConfig segmentZKPropsConfig = new SegmentZKPropsConfig();
+      segmentZKPropsConfig.setStartOffset("1");
+      segmentZKPropsConfig.setEndOffset("100");
+      RealtimeSegmentConverter converter =
+          new RealtimeSegmentConverter(mutableSegmentImpl, segmentZKPropsConfig, outputDir.getAbsolutePath(), schema,
+              tableNameWithType, tableConfig, segmentName, false, decoderClass);
+      converter.build(SegmentVersion.v3);
+      return new SegmentMetadataImpl(new File(outputDir, segmentName));
     } finally {
       mutableSegmentImpl.destroy();
     }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
@@ -111,6 +111,8 @@ public class V1Constants {
       public static final String COMPLEX_COLUMNS = "segment.complex.column.names";
 
       public static final String CUSTOM_SUBSET = "custom";
+      // Custom property (under CUSTOM_SUBSET) recording the decoder class that produced a realtime segment.
+      public static final String DECODER_CLASS = "decoder.class";
 
       // TODO: Remove it after 1.6 release
       @Deprecated

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
@@ -240,7 +240,8 @@ public class DebugResource {
               realtimeSegmentDataManager.getLastConsumedTimestamp(),
               currentOffsets,
               new SegmentConsumerInfo.PartitionOffsetInfo(currentOffsets,
-                  upstreamLatest, recordsLagMap, availabilityLagMsMap));
+                  upstreamLatest, recordsLagMap, availabilityLagMsMap),
+              realtimeSegmentDataManager.getDecoderClassName());
     }
     return segmentConsumerInfo;
   }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -1138,7 +1138,8 @@ public class TablesResource {
               new SegmentConsumerInfo.PartitionOffsetInfo(partitiionToOffsetMap, partitionIdToStateMap.entrySet()
                   .stream()
                   .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getUpstreamLatestOffset().toString())),
-                  recordsLagMap, availabilityLagMsMap)));
+                  recordsLagMap, availabilityLagMsMap),
+              realtimeSegmentDataManager.getDecoderClassName()));
         }
       }
     } catch (Exception e) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoder.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.spi.stream;
 
+import javax.annotation.Nullable;
+
+
 /// A decoder for [StreamMessage]
 public interface StreamDataDecoder {
   /// Decodes a [StreamMessage]
@@ -28,4 +31,11 @@ public interface StreamDataDecoder {
   /// @param message [StreamMessage] that contains the data payload and optionally, a key and row metadata
   /// @return [StreamDataDecoderResult] that either contains the decoded row or the exception
   StreamDataDecoderResult decode(StreamMessage message);
+
+  /// @return the wrapped value {@link StreamMessageDecoder}, or null if unavailable. Lets callers report the concrete
+  ///         decoder class without every implementation needing to support it.
+  @Nullable
+  default StreamMessageDecoder getValueDecoder() {
+    return null;
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoderImpl.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoderImpl.java
@@ -61,6 +61,11 @@ public class StreamDataDecoderImpl implements StreamDataDecoder {
   }
 
   @Override
+  public StreamMessageDecoder getValueDecoder() {
+    return _valueDecoder;
+  }
+
+  @Override
   public StreamDataDecoderResult decode(StreamMessage message) {
     try {
       _reuse.clear();

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/stream/StreamDataDecoderImplTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/stream/StreamDataDecoderImplTest.java
@@ -133,6 +133,21 @@ public class StreamDataDecoderImplTest {
     Assert.assertNull(result.getResult());
   }
 
+  @Test
+  public void testGetValueDecoderReturnsWrappedDecoder() {
+    TestDecoder messageDecoder = new TestDecoder();
+    // The impl exposes exactly the wrapped decoder, which is what callers reflect on to report the decoder class.
+    Assert.assertSame(new StreamDataDecoderImpl(messageDecoder).getValueDecoder(), messageDecoder);
+  }
+
+  @Test
+  public void testGetValueDecoderDefaultsToNull() {
+    // A StreamDataDecoder that does not override getValueDecoder() falls back to the default, which returns null so
+    // callers degrade gracefully (no decoder-class reporting) rather than requiring every implementation to support it.
+    StreamDataDecoder decoderWithoutValueAccessor = message -> new StreamDataDecoderResult(new GenericRow(), null);
+    Assert.assertNull(decoderWithoutValueAccessor.getValueDecoder());
+  }
+
   private static class ThrowingDecoder implements StreamMessageDecoder<byte[]> {
 
     @Override


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Decoder class name derives gauge key for emitting and removing the consuming segment decoder gauge\.

```mermaid
flowchart TD
  N0["Get decoder class name #40;F6#41;"]:::stModified
  N1["Compute gauge key #40;F6#41;"]:::stModified
  N2["Emit CONSUMING#95;SEGMENT#95;DECODER gauge #40;F6#41;"]:::stModified
  N3["Remove CONSUMING#95;SEGMENT#95;DECODER gauge #40;F6#41;"]:::stModified
  N0 --> N1
  N1 --> N2
  N1 --> N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F6: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager\.java — [before](https://github.com/apache/pinot/blob/63b3b1f1b3c8e46d38b46dfbe0d3fb8e29f6da43/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java) · [after](https://github.com/apache/pinot/blob/deba87205e8fd7a2ff40bd5586d2bb0ea021ba6a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjYzYjNiMWYxYjNjOGU0NmQzOGI0NmRmYmUwZDNmYjhlMjlmNmRhNDMiLCJjb250ZXh0X2hhc2giOiJlOWM5OTc2YzY0YTcyNmVhOWIxZGJiZGI0MDkyMzllNzFmNDZmYWFhNjk4NWRjNjkzM2Y2NDk0MTNmMmQ3ZTkxIiwiZ2VuZXJhdGVkX2F0IjoxNzg5Nzc5ODY1LCJoZWFkX3NoYSI6ImRlYmE4NzIwNWU4ZmQ3YTJmZjQwYmQ1NTg2ZDJiYjBlYTAyMWJhNmEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIzMGY1ZDIwOGExZTU4YTFlMWNlZTRhZmM1ZmM3N2EzMmI5ZTYxZjY2IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature b2224afdce6262482502fdd1781380fc5e005081b90ac8cf86bf148df9b7a8fc -->
<!-- pinot-pr-flow:end -->

Expose the concrete `StreamMessageDecoder` class of a consuming realtime segment for debugging decode issues:

- New `CONSUMING_SEGMENT_DECODER` server gauge, tagged by table/topic/ partition/decoder class, emitted alongside `LLC_PARTITION_CONSUMING` and removed on segment offload.

- Persist the decoder class in segment metadata (custom.decoder.class) and surface decoderClassName via the consuming-segment debug APIs.

- Add a JMX->Prometheus scrape rule for the new gauge.

**Backward compatible:** SPI addition is a nullable default method, the DTO field is nullable with ignore-unknown, segment metadata is additive, and the scrape rule is anchored to avoid shadowing existing rules.

 
