### PR TITLE
Parse V2 LLC segment names without writing them

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
@@ -65,14 +65,25 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
 
   public LLCSegmentName(String segmentName) {
     String[] parts = StringUtils.splitByWholeSeparator(segmentName, SEPARATOR);
-    Preconditions.checkArgument(parts.length == 4, "Invalid LLC segment name: %s", segmentName);
-    _formatVersion = FORMAT_VERSION_V1;
+    if (parts.length == 4) {
+      _formatVersion = FORMAT_VERSION_V1;
+      _tableName = parts[0];
+      _partitionGroupId = Integer.parseInt(parts[1]);
+      _topicId = StreamPartitionIdentity.UNKNOWN_TOPIC_ID;
+      _partitionId = StreamPartitionIdentity.UNKNOWN_PARTITION_ID;
+      _sequenceNumber = Integer.parseInt(parts[2]);
+      _creationTime = parts[3];
+      _segmentName = segmentName;
+      return;
+    }
+    Preconditions.checkArgument(isV2Parts(parts), "Invalid LLC segment name: %s", segmentName);
+    _formatVersion = FORMAT_VERSION_V2;
     _tableName = parts[0];
-    _partitionGroupId = Integer.parseInt(parts[1]);
-    _topicId = StreamPartitionIdentity.UNKNOWN_TOPIC_ID;
-    _partitionId = StreamPartitionIdentity.UNKNOWN_PARTITION_ID;
-    _sequenceNumber = Integer.parseInt(parts[2]);
-    _creationTime = parts[3];
+    _partitionGroupId = 0;
+    _topicId = parseNonNegativeInt(parts[2], "topicId", segmentName);
+    _partitionId = parseNonNegativeInt(parts[3], "partitionId", segmentName);
+    _sequenceNumber = Integer.parseInt(parts[4]);
+    _creationTime = parts[5];
     _segmentName = segmentName;
   }
 
@@ -102,8 +113,8 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
         + SEPARATOR + creationTime;
   }
 
-  /// Returns the [LLCSegmentName] for the given segment name, or `null` if the given segment name does not
-  /// represent an LLC segment.
+  /// Returns the [LLCSegmentName] for the given V1 or V2 segment name, or `null` if the given
+  /// segment name does not represent an LLC segment.
   @Nullable
   public static LLCSegmentName of(String segmentName) {
     try {
@@ -114,6 +125,9 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
   }
 
   /// Returns whether the given segment name represents an LLC segment.
+  ///
+  /// V1 names have 3 `__` separators. V2 names have 5 and token 2 is the literal `v2`.
+  /// Five-token uploaded names and 5-part `table__configId__partition__seq__time` names are not LLC.
   public static boolean isLLCSegment(String segmentName) {
     int numSeparators = 0;
     int index = 0;
@@ -121,12 +135,34 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
       numSeparators++;
       index += 2; // SEPARATOR.length()
     }
-    return numSeparators == 3;
+    if (numSeparators == 3) {
+      return true;
+    }
+    if (numSeparators == 5) {
+      return isV2Parts(StringUtils.splitByWholeSeparator(segmentName, SEPARATOR));
+    }
+    return false;
   }
 
-  /// Returns the sequence number of the given segment name.
+  /// Returns the sequence number of the given V1 or V2 LLC segment name.
   public static int getSequenceNumber(String segmentName) {
-    return Integer.parseInt(StringUtils.splitByWholeSeparator(segmentName, SEPARATOR)[2]);
+    String[] parts = StringUtils.splitByWholeSeparator(segmentName, SEPARATOR);
+    if (parts.length == 4) {
+      return Integer.parseInt(parts[2]);
+    }
+    Preconditions.checkArgument(isV2Parts(parts), "Invalid LLC segment name: %s", segmentName);
+    return Integer.parseInt(parts[4]);
+  }
+
+  private static boolean isV2Parts(String[] parts) {
+    return parts.length == 6 && V2_TOKEN.equals(parts[1]);
+  }
+
+  private static int parseNonNegativeInt(String raw, String fieldName, String segmentName) {
+    int value = Integer.parseInt(raw);
+    Preconditions.checkArgument(value >= 0, "Invalid LLC segment name %s: %s must be non-negative", segmentName,
+        fieldName);
+    return value;
   }
 
   public String getTableName() {
@@ -143,6 +179,7 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
 
   /// V1 packed or raw partition-group int. V2 names have no packed id.
   public int getPartitionGroupId() {
+    Preconditions.checkState(!isV2(), "V2 LLC segment name has no packed partition group id: %s", _segmentName);
     return _partitionGroupId;
   }
 
@@ -184,8 +221,9 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
   public int compareTo(LLCSegmentName other) {
     Preconditions.checkArgument(_tableName.equals(other._tableName),
         "Cannot compare segment names from different table: %s, %s", _segmentName, other.getSegmentName());
-    if (_partitionGroupId != other._partitionGroupId) {
-      return Integer.compare(_partitionGroupId, other._partitionGroupId);
+    int identityCmp = getStreamPartitionIdentity().compareTo(other.getStreamPartitionIdentity());
+    if (identityCmp != 0) {
+      return identityCmp;
     }
     return Integer.compare(_sequenceNumber, other._sequenceNumber);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
@@ -23,18 +23,42 @@ import com.google.common.base.Preconditions;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.spi.stream.StreamPartitionIdentity;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 
+/// Low-level consumer segment name.
+///
+/// V1 (4 tokens): `{rawTable}__{partitionGroupId}__{sequence}__{creationTime}`
+///
+/// V2 (6 tokens): `{rawTable}__v2__{topicId}__{partitionId}__{sequence}__{creationTime}`
+///
+/// The version token is the literal `v2`, so a name is self-describing without ZK. Uploaded
+/// realtime names stay 5 tokens (`prefix__table__partition__time__suffix`) and are not LLC.
+/// Do not accept a 5-token `table__configId__partition__seq__time` name (apache/pinot#18830).
+///
+/// V1 constructors and generated names are unchanged. Production writers must keep using the
+/// 4-arg constructor. [formatV2] exists for parse/format tests and a later writer PR.
+///
+/// `getPartitionGroupId()` stays an `int` and is V1-only. New call sites should use
+/// [getStreamPartitionIdentity] rather than a packed int or a `TopicPartitionId` wrapper
+/// (apache/pinot#18913).
 public class LLCSegmentName implements Comparable<LLCSegmentName> {
+  public static final int FORMAT_VERSION_V1 = StreamPartitionIdentity.FORMAT_VERSION_V1;
+  public static final int FORMAT_VERSION_V2 = StreamPartitionIdentity.FORMAT_VERSION_V2;
+
   private static final String SEPARATOR = "__";
+  private static final String V2_TOKEN = "v2";
   private static final String DATE_FORMAT = "yyyyMMdd'T'HHmm'Z'";
   private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormat.forPattern(DATE_FORMAT).withZoneUTC();
 
+  private final int _formatVersion;
   private final String _tableName;
   private final int _partitionGroupId;
+  private final int _topicId;
+  private final int _partitionId;
   private final int _sequenceNumber;
   private final String _creationTime;
   private final String _segmentName;
@@ -42,8 +66,11 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
   public LLCSegmentName(String segmentName) {
     String[] parts = StringUtils.splitByWholeSeparator(segmentName, SEPARATOR);
     Preconditions.checkArgument(parts.length == 4, "Invalid LLC segment name: %s", segmentName);
+    _formatVersion = FORMAT_VERSION_V1;
     _tableName = parts[0];
     _partitionGroupId = Integer.parseInt(parts[1]);
+    _topicId = StreamPartitionIdentity.UNKNOWN_TOPIC_ID;
+    _partitionId = StreamPartitionIdentity.UNKNOWN_PARTITION_ID;
     _sequenceNumber = Integer.parseInt(parts[2]);
     _creationTime = parts[3];
     _segmentName = segmentName;
@@ -51,12 +78,28 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
 
   public LLCSegmentName(String tableName, int partitionGroupId, int sequenceNumber, long msSinceEpoch) {
     Preconditions.checkArgument(!tableName.contains(SEPARATOR), "Illegal table name: %s", tableName);
+    _formatVersion = FORMAT_VERSION_V1;
     _tableName = tableName;
     _partitionGroupId = partitionGroupId;
+    _topicId = StreamPartitionIdentity.UNKNOWN_TOPIC_ID;
+    _partitionId = StreamPartitionIdentity.UNKNOWN_PARTITION_ID;
     _sequenceNumber = sequenceNumber;
     // ISO8601 date: 20160120T1234Z
     _creationTime = DATE_FORMATTER.print(msSinceEpoch);
     _segmentName = tableName + SEPARATOR + partitionGroupId + SEPARATOR + sequenceNumber + SEPARATOR + _creationTime;
+  }
+
+  /// Formats a V2 LLC name. Do not call this from production writers until the reader-first
+  /// gate is on. Topic and partition must be non-negative; `partitionId` may be
+  /// `0..Integer.MAX_VALUE`.
+  public static String formatV2(String tableName, int topicId, int partitionId, int sequenceNumber,
+      long msSinceEpoch) {
+    Preconditions.checkArgument(!tableName.contains(SEPARATOR), "Illegal table name: %s", tableName);
+    Preconditions.checkArgument(topicId >= 0, "V2 topicId must be non-negative: %s", topicId);
+    Preconditions.checkArgument(partitionId >= 0, "V2 partitionId must be non-negative: %s", partitionId);
+    String creationTime = DATE_FORMATTER.print(msSinceEpoch);
+    return tableName + SEPARATOR + V2_TOKEN + SEPARATOR + topicId + SEPARATOR + partitionId + SEPARATOR + sequenceNumber
+        + SEPARATOR + creationTime;
   }
 
   /// Returns the [LLCSegmentName] for the given segment name, or `null` if the given segment name does not
@@ -90,8 +133,33 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
     return _tableName;
   }
 
+  public int getFormatVersion() {
+    return _formatVersion;
+  }
+
+  public boolean isV2() {
+    return _formatVersion == FORMAT_VERSION_V2;
+  }
+
+  /// V1 packed or raw partition-group int. V2 names have no packed id.
   public int getPartitionGroupId() {
     return _partitionGroupId;
+  }
+
+  /// Registry topic id. V1 names do not store one; do not infer it from `% 10000`.
+  public int getTopicId() {
+    Preconditions.checkState(isV2(), "V1 LLC segment name has no topic id: %s", _segmentName);
+    return _topicId;
+  }
+
+  /// Raw stream partition id from a V2 name.
+  public int getPartitionId() {
+    Preconditions.checkState(isV2(), "V1 LLC segment name has no raw partition id: %s", _segmentName);
+    return _partitionId;
+  }
+
+  public StreamPartitionIdentity getStreamPartitionIdentity() {
+    return isV2() ? StreamPartitionIdentity.v2(_topicId, _partitionId) : StreamPartitionIdentity.v1(_partitionGroupId);
   }
 
   public int getSequenceNumber() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
@@ -79,7 +79,7 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
     Preconditions.checkArgument(isV2Parts(parts), "Invalid LLC segment name: %s", segmentName);
     _formatVersion = FORMAT_VERSION_V2;
     _tableName = parts[0];
-    _partitionGroupId = 0;
+    _partitionGroupId = Integer.MIN_VALUE;
     _topicId = parseNonNegativeInt(parts[2], "topicId", segmentName);
     _partitionId = parseNonNegativeInt(parts[3], "partitionId", segmentName);
     _sequenceNumber = Integer.parseInt(parts[4]);
@@ -100,11 +100,8 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
     _segmentName = tableName + SEPARATOR + partitionGroupId + SEPARATOR + sequenceNumber + SEPARATOR + _creationTime;
   }
 
-  /// Formats a V2 LLC name. Do not call this from production writers until the reader-first
-  /// gate is on. Topic and partition must be non-negative; `partitionId` may be
-  /// `0..Integer.MAX_VALUE`.
-  public static String formatV2(String tableName, int topicId, int partitionId, int sequenceNumber,
-      long msSinceEpoch) {
+  /// Formats a V2 LLC name for tests. Production writers must not emit V2 names.
+  static String formatV2(String tableName, int topicId, int partitionId, int sequenceNumber, long msSinceEpoch) {
     Preconditions.checkArgument(!tableName.contains(SEPARATOR), "Illegal table name: %s", tableName);
     Preconditions.checkArgument(topicId >= 0, "V2 topicId must be non-negative: %s", topicId);
     Preconditions.checkArgument(partitionId >= 0, "V2 partitionId must be non-negative: %s", partitionId);

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/LLCSegmentNameTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/LLCSegmentNameTest.java
@@ -19,11 +19,15 @@
 package org.apache.pinot.common.utils;
 
 import java.util.Arrays;
+import org.apache.pinot.spi.stream.StreamPartitionIdentity;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 
@@ -92,5 +96,98 @@ public class LLCSegmentNameTest {
     LLCSegmentName[] testSorted = new LLCSegmentName[]{segName3, segName1, segName4, segName5, segName6};
     Arrays.sort(testSorted);
     Assert.assertEquals(testSorted, new LLCSegmentName[]{segName5, segName1, segName6, segName3, segName4});
+  }
+
+  @Test
+  public void testV1FormatVersionAndIdentity() {
+    LLCSegmentName llcSegmentName = new LLCSegmentName("myTable", 10000, 1, 1465508537069L);
+    assertEquals(llcSegmentName.getFormatVersion(), LLCSegmentName.FORMAT_VERSION_V1);
+    assertFalse(llcSegmentName.isV2());
+    assertEquals(llcSegmentName.getPartitionGroupId(), 10000);
+    assertEquals(llcSegmentName.getStreamPartitionIdentity(), StreamPartitionIdentity.v1(10000));
+    assertEquals(LLCSegmentName.getSequenceNumber(llcSegmentName.getSegmentName()), 1);
+    assertThrows(IllegalStateException.class, llcSegmentName::getTopicId);
+    assertThrows(IllegalStateException.class, llcSegmentName::getPartitionId);
+  }
+
+  @Test
+  public void testV2ParseFormatRoundTrip() {
+    long msSinceEpoch = 1465508537069L;
+    String segmentName = LLCSegmentName.formatV2("orders", 1, 0, 17, msSinceEpoch);
+    assertEquals(segmentName, "orders__v2__1__0__17__20160609T2142Z");
+    assertTrue(LLCSegmentName.isLLCSegment(segmentName));
+    assertEquals(LLCSegmentName.getSequenceNumber(segmentName), 17);
+
+    LLCSegmentName parsed = new LLCSegmentName(segmentName);
+    assertEquals(parsed.getSegmentName(), segmentName);
+    assertEquals(parsed.getTableName(), "orders");
+    assertEquals(parsed.getFormatVersion(), LLCSegmentName.FORMAT_VERSION_V2);
+    assertTrue(parsed.isV2());
+    assertEquals(parsed.getTopicId(), 1);
+    assertEquals(parsed.getPartitionId(), 0);
+    assertEquals(parsed.getSequenceNumber(), 17);
+    assertEquals(parsed.getCreationTime(), "20160609T2142Z");
+    assertEquals(parsed.getStreamPartitionIdentity(), StreamPartitionIdentity.v2(1, 0));
+    assertEquals(LLCSegmentName.of(segmentName), parsed);
+    assertThrows(IllegalStateException.class, parsed::getPartitionGroupId);
+  }
+
+  @Test
+  public void testV2HistoricalCollisionPair() {
+    long msSinceEpoch = 1465508537069L;
+    LLCSegmentName topic0Large = new LLCSegmentName(LLCSegmentName.formatV2("t", 0, 10000, 0, msSinceEpoch));
+    LLCSegmentName topic1Zero = new LLCSegmentName(LLCSegmentName.formatV2("t", 1, 0, 0, msSinceEpoch));
+    assertNotEquals(topic0Large.getSegmentName(), topic1Zero.getSegmentName());
+    assertNotEquals(topic0Large.getStreamPartitionIdentity(), topic1Zero.getStreamPartitionIdentity());
+    assertNotEquals(topic0Large, topic1Zero);
+    assertTrue(topic0Large.compareTo(topic1Zero) < 0);
+  }
+
+  @Test
+  public void testV2NumericBoundaries() {
+    long msSinceEpoch = 1465508537069L;
+    for (int partitionId : new int[]{0, 9999, 10000, 10001, Integer.MAX_VALUE}) {
+      String name = LLCSegmentName.formatV2("t", 0, partitionId, 3, msSinceEpoch);
+      LLCSegmentName parsed = new LLCSegmentName(name);
+      assertEquals(parsed.getPartitionId(), partitionId);
+      assertEquals(parsed.getTopicId(), 0);
+      assertEquals(parsed.getSequenceNumber(), 3);
+    }
+    LLCSegmentName maxTopic = new LLCSegmentName(LLCSegmentName.formatV2("t", Integer.MAX_VALUE, 0, 0, msSinceEpoch));
+    assertEquals(maxTopic.getTopicId(), Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void testUploadedAndFivePartNamesAreNotLlc() {
+    String uploaded = "uploaded__table__0__20220101T0000Z__suffix";
+    assertTrue(UploadedRealtimeSegmentName.isUploadedRealtimeSegmentName(uploaded));
+    assertFalse(LLCSegmentName.isLLCSegment(uploaded));
+    assertNull(LLCSegmentName.of(uploaded));
+
+    // #18830 5-part grammar: no v2 token, same token count as uploaded names.
+    String fivePart = "table__1__0__17__20160609T2142Z";
+    assertFalse(LLCSegmentName.isLLCSegment(fivePart));
+    assertNull(LLCSegmentName.of(fivePart));
+  }
+
+  @Test
+  public void testV2MalformedNames() {
+    assertFalse(LLCSegmentName.isLLCSegment("orders__v3__1__0__17__20160609T2142Z"));
+    assertNull(LLCSegmentName.of("orders__v3__1__0__17__20160609T2142Z"));
+    assertFalse(LLCSegmentName.isLLCSegment("orders__V2__1__0__17__20160609T2142Z"));
+    assertNull(LLCSegmentName.of("orders__v2__1__0__17"));
+    assertNull(LLCSegmentName.of("orders__v2__1__0__17__20160609T2142Z__extra"));
+    assertNull(LLCSegmentName.of("orders__v2__x__0__17__20160609T2142Z"));
+    assertNull(LLCSegmentName.of("orders__v2__-1__0__17__20160609T2142Z"));
+    assertNull(LLCSegmentName.of("orders__v2__1__-1__17__20160609T2142Z"));
+    assertThrows(IllegalArgumentException.class, () -> new LLCSegmentName("orders__v2__-1__0__17__20160609T2142Z"));
+    assertThrows(IllegalArgumentException.class, () -> LLCSegmentName.formatV2("bad__table", 0, 0, 0, 0L));
+    assertThrows(IllegalArgumentException.class, () -> LLCSegmentName.formatV2("t", -1, 0, 0, 0L));
+    assertThrows(IllegalArgumentException.class, () -> LLCSegmentName.formatV2("t", 0, -1, 0, 0L));
+    assertThrows(IllegalArgumentException.class, () -> LLCSegmentName.getSequenceNumber(uploadedFivePart()));
+  }
+
+  private static String uploadedFivePart() {
+    return "uploaded__table__0__20220101T0000Z__suffix";
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/LLCSegmentNameTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/LLCSegmentNameTest.java
@@ -141,6 +141,10 @@ public class LLCSegmentNameTest {
     assertNotEquals(topic0Large.getStreamPartitionIdentity(), topic1Zero.getStreamPartitionIdentity());
     assertNotEquals(topic0Large, topic1Zero);
     assertTrue(topic0Large.compareTo(topic1Zero) < 0);
+
+    LLCSegmentName v1Packed = new LLCSegmentName("t", 10000, 0, msSinceEpoch);
+    assertTrue(v1Packed.compareTo(topic0Large) < 0);
+    assertTrue(v1Packed.compareTo(topic1Zero) < 0);
   }
 
   @Test
@@ -177,6 +181,7 @@ public class LLCSegmentNameTest {
     assertFalse(LLCSegmentName.isLLCSegment("orders__V2__1__0__17__20160609T2142Z"));
     assertNull(LLCSegmentName.of("orders__v2__1__0__17"));
     assertNull(LLCSegmentName.of("orders__v2__1__0__17__20160609T2142Z__extra"));
+    assertTrue(LLCSegmentName.isLLCSegment("orders__v2__x__0__17__20160609T2142Z"));
     assertNull(LLCSegmentName.of("orders__v2__x__0__17__20160609T2142Z"));
     assertNull(LLCSegmentName.of("orders__v2__-1__0__17__20160609T2142Z"));
     assertNull(LLCSegmentName.of("orders__v2__1__-1__17__20160609T2142Z"));

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionIdentity.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionIdentity.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.stream;
+
+import com.google.common.base.Preconditions;
+import java.util.Objects;
+
+
+/// Composite identity for one logical stream partition.
+///
+/// V1 identities wrap the integer persisted in a 4-part LLC name. That integer may be a raw stream
+/// partition or a packed `streamIndex * 10000 + partitionId`. This class does not pack, unpad, or
+/// guess which case it is.
+///
+/// V2 identities are `(topicId, partitionId)` as stored in a `table__v2__...` name. Topic id is the
+/// stable registry id, not the current `streamConfigMaps` list index.
+///
+/// Equality is injective: V1 packed `10000`, V2 `(0, 10000)`, and V2 `(1, 0)` are three values.
+/// Use this type as a map key instead of a packed int. Do not add a
+/// `topicId * 10000 + partitionId` helper here. `IngestionConfigUtils.PARTITION_PADDING_OFFSET`
+/// stays on the V1 write path only.
+///
+/// `LLCSegmentName.getPartitionGroupId()` remains an `int` and is V1-only. This type is the
+/// wrapper not to return from that getter (see apache/pinot#18913). Prefer this type at new call
+/// sites; do not add a parallel `TopicPartitionId` type.
+///
+/// Immutable and safe to share across threads.
+public final class StreamPartitionIdentity implements Comparable<StreamPartitionIdentity> {
+  public static final int FORMAT_VERSION_V1 = 1;
+  public static final int FORMAT_VERSION_V2 = 2;
+
+  /// Sentinel topic id for V1 names, which do not store a topic id. Never infer a topic from
+  /// `{@code partitionGroupId % 10000}`.
+  public static final int UNKNOWN_TOPIC_ID = -1;
+
+  /// Sentinel raw partition id on V1 names. The persisted value lives in [getPartitionId] as the
+  /// V1 partition-group integer.
+  public static final int UNKNOWN_PARTITION_ID = -1;
+
+  private final int _formatVersion;
+  private final int _topicId;
+  private final int _partitionId;
+
+  private StreamPartitionIdentity(int formatVersion, int topicId, int partitionId) {
+    _formatVersion = formatVersion;
+    _topicId = topicId;
+    _partitionId = partitionId;
+  }
+
+  /// V1 identity for a persisted partition-group int. `partitionGroupId` is stored as-is.
+  public static StreamPartitionIdentity v1(int partitionGroupId) {
+    return new StreamPartitionIdentity(FORMAT_VERSION_V1, UNKNOWN_TOPIC_ID, partitionGroupId);
+  }
+
+  /// V2 identity. Both ids are non-negative decimal ints from the segment name.
+  public static StreamPartitionIdentity v2(int topicId, int partitionId) {
+    Preconditions.checkArgument(topicId >= 0, "V2 topicId must be non-negative: %s", topicId);
+    Preconditions.checkArgument(partitionId >= 0, "V2 partitionId must be non-negative: %s", partitionId);
+    return new StreamPartitionIdentity(FORMAT_VERSION_V2, topicId, partitionId);
+  }
+
+  public int getFormatVersion() {
+    return _formatVersion;
+  }
+
+  public boolean isV2() {
+    return _formatVersion == FORMAT_VERSION_V2;
+  }
+
+  /// Topic id for V2, or [UNKNOWN_TOPIC_ID] for V1.
+  public int getTopicId() {
+    return _topicId;
+  }
+
+  /// Raw stream partition for V2, or the persisted V1 partition-group int.
+  public int getPartitionId() {
+    return _partitionId;
+  }
+
+  @Override
+  public int compareTo(StreamPartitionIdentity other) {
+    int versionCmp = Integer.compare(_formatVersion, other._formatVersion);
+    if (versionCmp != 0) {
+      return versionCmp;
+    }
+    int topicCmp = Integer.compare(_topicId, other._topicId);
+    if (topicCmp != 0) {
+      return topicCmp;
+    }
+    return Integer.compare(_partitionId, other._partitionId);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof StreamPartitionIdentity)) {
+      return false;
+    }
+    StreamPartitionIdentity that = (StreamPartitionIdentity) o;
+    return _formatVersion == that._formatVersion && _topicId == that._topicId && _partitionId == that._partitionId;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_formatVersion, _topicId, _partitionId);
+  }
+
+  @Override
+  public String toString() {
+    if (isV2()) {
+      return "v2:topicId=" + _topicId + ",partitionId=" + _partitionId;
+    }
+    return "v1:partitionGroupId=" + _partitionId;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionIdentity.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionIdentity.java
@@ -49,8 +49,8 @@ public final class StreamPartitionIdentity implements Comparable<StreamPartition
   /// `partitionGroupId % 10000`.
   public static final int UNKNOWN_TOPIC_ID = -1;
 
-  /// Sentinel raw partition id on V1 names. The persisted value lives in [getPartitionId] as the
-  /// V1 partition-group integer.
+  /// Unused field sentinel on V1 LLC names. V1 identities store the partition-group int
+  /// internally and expose it via [getPartitionGroupId].
   public static final int UNKNOWN_PARTITION_ID = -1;
 
   private final int _formatVersion;
@@ -83,13 +83,21 @@ public final class StreamPartitionIdentity implements Comparable<StreamPartition
     return _formatVersion == FORMAT_VERSION_V2;
   }
 
-  /// Topic id for V2, or [UNKNOWN_TOPIC_ID] for V1.
+  /// Registry topic id from a V2 identity.
   public int getTopicId() {
+    Preconditions.checkState(isV2(), "V1 stream partition identity has no topic id: %s", this);
     return _topicId;
   }
 
-  /// Raw stream partition for V2, or the persisted V1 partition-group int.
+  /// Raw stream partition id from a V2 identity.
   public int getPartitionId() {
+    Preconditions.checkState(isV2(), "V1 stream partition identity has no raw partition id: %s", this);
+    return _partitionId;
+  }
+
+  /// Persisted V1 partition-group int. V2 identities have no packed id.
+  public int getPartitionGroupId() {
+    Preconditions.checkState(!isV2(), "V2 stream partition identity has no packed partition group id: %s", this);
     return _partitionId;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionIdentity.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionIdentity.java
@@ -46,7 +46,7 @@ public final class StreamPartitionIdentity implements Comparable<StreamPartition
   public static final int FORMAT_VERSION_V2 = 2;
 
   /// Sentinel topic id for V1 names, which do not store a topic id. Never infer a topic from
-  /// `{@code partitionGroupId % 10000}`.
+  /// `partitionGroupId % 10000`.
   public static final int UNKNOWN_TOPIC_ID = -1;
 
   /// Sentinel raw partition id on V1 names. The persisted value lives in [getPartitionId] as the

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/stream/StreamPartitionIdentityTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/stream/StreamPartitionIdentityTest.java
@@ -35,8 +35,9 @@ public class StreamPartitionIdentityTest {
     StreamPartitionIdentity identity = StreamPartitionIdentity.v1(10000);
     assertEquals(identity.getFormatVersion(), StreamPartitionIdentity.FORMAT_VERSION_V1);
     assertFalse(identity.isV2());
-    assertEquals(identity.getTopicId(), StreamPartitionIdentity.UNKNOWN_TOPIC_ID);
-    assertEquals(identity.getPartitionId(), 10000);
+    assertEquals(identity.getPartitionGroupId(), 10000);
+    assertThrows(IllegalStateException.class, identity::getTopicId);
+    assertThrows(IllegalStateException.class, identity::getPartitionId);
     assertEquals(identity.toString(), "v1:partitionGroupId=10000");
     assertEquals(identity, StreamPartitionIdentity.v1(10000));
     assertEquals(identity.hashCode(), StreamPartitionIdentity.v1(10000).hashCode());
@@ -49,6 +50,7 @@ public class StreamPartitionIdentityTest {
     assertTrue(identity.isV2());
     assertEquals(identity.getTopicId(), 1);
     assertEquals(identity.getPartitionId(), 0);
+    assertThrows(IllegalStateException.class, identity::getPartitionGroupId);
     assertEquals(identity.toString(), "v2:topicId=1,partitionId=0");
     assertEquals(identity, StreamPartitionIdentity.v2(1, 0));
     assertEquals(identity.hashCode(), StreamPartitionIdentity.v2(1, 0).hashCode());

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/stream/StreamPartitionIdentityTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/stream/StreamPartitionIdentityTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.stream;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+/// Equality, ordering, and validation for [StreamPartitionIdentity].
+public class StreamPartitionIdentityTest {
+
+  @Test
+  public void testV1Identity() {
+    StreamPartitionIdentity identity = StreamPartitionIdentity.v1(10000);
+    assertEquals(identity.getFormatVersion(), StreamPartitionIdentity.FORMAT_VERSION_V1);
+    assertFalse(identity.isV2());
+    assertEquals(identity.getTopicId(), StreamPartitionIdentity.UNKNOWN_TOPIC_ID);
+    assertEquals(identity.getPartitionId(), 10000);
+    assertEquals(identity.toString(), "v1:partitionGroupId=10000");
+    assertEquals(identity, StreamPartitionIdentity.v1(10000));
+    assertEquals(identity.hashCode(), StreamPartitionIdentity.v1(10000).hashCode());
+  }
+
+  @Test
+  public void testV2Identity() {
+    StreamPartitionIdentity identity = StreamPartitionIdentity.v2(1, 0);
+    assertEquals(identity.getFormatVersion(), StreamPartitionIdentity.FORMAT_VERSION_V2);
+    assertTrue(identity.isV2());
+    assertEquals(identity.getTopicId(), 1);
+    assertEquals(identity.getPartitionId(), 0);
+    assertEquals(identity.toString(), "v2:topicId=1,partitionId=0");
+    assertEquals(identity, StreamPartitionIdentity.v2(1, 0));
+    assertEquals(identity.hashCode(), StreamPartitionIdentity.v2(1, 0).hashCode());
+  }
+
+  @Test
+  public void testHistoricalCollisionPairIsDistinct() {
+    StreamPartitionIdentity v1Packed = StreamPartitionIdentity.v1(10000);
+    StreamPartitionIdentity v2Topic0Large = StreamPartitionIdentity.v2(0, 10000);
+    StreamPartitionIdentity v2Topic1Zero = StreamPartitionIdentity.v2(1, 0);
+
+    assertNotEquals(v1Packed, v2Topic0Large);
+    assertNotEquals(v1Packed, v2Topic1Zero);
+    assertNotEquals(v2Topic0Large, v2Topic1Zero);
+    assertTrue(v1Packed.compareTo(v2Topic0Large) < 0);
+    assertTrue(v2Topic0Large.compareTo(v2Topic1Zero) < 0);
+  }
+
+  @Test
+  public void testV2RejectsNegatives() {
+    assertThrows(IllegalArgumentException.class, () -> StreamPartitionIdentity.v2(-1, 0));
+    assertThrows(IllegalArgumentException.class, () -> StreamPartitionIdentity.v2(0, -1));
+  }
+
+  @Test
+  public void testV2AcceptsIntegerMaxPartition() {
+    StreamPartitionIdentity identity = StreamPartitionIdentity.v2(0, Integer.MAX_VALUE);
+    assertEquals(identity.getPartitionId(), Integer.MAX_VALUE);
+  }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

LLCSegmentName parses V1/V2 names; getStreamPartitionIdentity\(\) returns V1/V2 StreamPartitionIdentity\.

```mermaid
flowchart TD
  N0["LLCSegmentName#40;String#41; #91;F1#93; #40;F1#41;"]:::stModified
  N1["getStreamPartitionIdentity#40;#41; #91;F1#93; #40;F1#41;"]:::stAdded
  N2["StreamPartitionIdentity#46;v1#40;int#41; #91;F2#93; #40;F2#41;"]:::stAdded
  N3["StreamPartitionIdentity#46;v2#40;int#44; int#41; #91;F2#93; #40;F2#41;"]:::stAdded
  N0 --> N1
  N1 --> N2
  N1 --> N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName\.java — [before](https://github.com/apache/pinot/blob/26bf075d16cfc6d80d5682589109f873a9c6dd96/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java) · [after](https://github.com/apache/pinot/blob/6cb9d040f3de01570d3ebd189f6458adf3b6876d/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java)
- F2: pinot\-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionIdentity\.java — [after](https://github.com/apache/pinot/blob/6cb9d040f3de01570d3ebd189f6458adf3b6876d/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionIdentity.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjI2YmYwNzVkMTZjZmM2ZDgwZDU2ODI1ODkxMDlmODczYTljNmRkOTYiLCJjb250ZXh0X2hhc2giOiJkM2QxNWVmMWYxYTAwOWRhMDJhZGFlNDViMjQ4MjRmMGZhMzZmOGY4ZDIwZDMxYjAyMzRjOTE4NzUzYzVhNDdjIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTc2NzczLCJoZWFkX3NoYSI6IjZjYjlkMDQwZjNkZTAxNTcwZDNlYmQxODlmNjQ1OGFkZjNiNjg3NmQiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyNmJmMDc1ZDE2Y2ZjNmQ4MGQ1NjgyNTg5MTA5Zjg3M2E5YzZkZDk2IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 91bdd02859366007196ee8c5a733a7157f9e4327173c2ab39785ff92b8e2505d -->
<!-- pinot-pr-flow:end -->

This is the parse-only slice of #17260. Readers can recognize `table__v2__topicId__partitionId__sequence__creationTime` names. Generation stays on the existing 4-part V1 constructor. No V2 names are written.

Not stacked on #18830, #18913, or #18949. Those PRs write a 5-part name or keep packed ints. This one only teaches `LLCSegmentName` and a new `StreamPartitionIdentity` type to read the 6-token `v2` grammar.

## What changed

- `LLCSegmentName` accepts V1 (4 tokens) and V2 (6 tokens, literal `v2`).
- `isLLCSegment`, `of`, and `getSequenceNumber(String)` handle both.
- `getPartitionGroupId()` stays an `int` and is V1-only (throws on V2), per Jackie on #18913.
- New accessors: `getFormatVersion()`, `getTopicId()`, `getPartitionId()`, `getStreamPartitionIdentity()`.
- `StreamPartitionIdentity` in `pinot-spi`. No `topicId * 10000` helpers.
- Uploaded 5-part names and the #18830 5-part grammar stay non-LLC.
- `IngestionConfigUtils` packing is unchanged.

`formatV2` is package-private for tests. Production writers still use the 4-arg V1 constructor.

## Validation

```
./mvnw -pl pinot-common,pinot-spi -am \
  -Dtest=LLCSegmentNameTest,StreamPartitionIdentityTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

13 tests passed. Spotless, checkstyle, and license checks passed on `pinot-spi` and `pinot-common`.

Base: apache/master `26bf075d16` after rebase.

Label: `bugfix` (template requirement).
