### PR TITLE
[18808] Add schema-diff helper and column deletion ledger

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -81,6 +81,12 @@ public class ZKMetadataProvider {
   private static final String PROPERTYSTORE_USER_CONFIGS_PREFIX = "/CONFIGS/USER";
   private static final String PROPERTYSTORE_CLUSTER_CONFIGS_PREFIX = "/CONFIGS/CLUSTER";
   private static final String PROPERTYSTORE_SEGMENT_LINEAGE = "/SEGMENT_LINEAGE";
+  /// Table-scoped column-deletion ledger. One znode per table name with type.
+  /// Path: /COLUMN_DELETION_METADATA/<tableNameWithType>
+  ///
+  /// Completion is controller-owned, so this prefix is a sibling of /SEGMENT_LINEAGE and is not
+  /// under /MINION_TASK_METADATA.
+  private static final String PROPERTYSTORE_COLUMN_DELETION_METADATA = "/COLUMN_DELETION_METADATA";
   private static final String PROPERTYSTORE_MINION_TASK_METADATA_PREFIX = "/MINION_TASK_METADATA";
   private static final String PROPERTYSTORE_MATERIALIZED_VIEW_DEFINITION_PREFIX =
       "/CONFIGS/MATERIALIZED_VIEW/DEFINITION";
@@ -246,6 +252,18 @@ public class ZKMetadataProvider {
 
   public static String constructPropertyStorePathForSegmentLineage(String tableNameWithType) {
     return StringUtil.join("/", PROPERTYSTORE_SEGMENT_LINEAGE, tableNameWithType);
+  }
+
+  /// PropertyStore prefix for per-table column-deletion ledger znodes.
+  public static String getPropertyStorePathForColumnDeletionMetadataPrefix() {
+    return PROPERTYSTORE_COLUMN_DELETION_METADATA;
+  }
+
+  /// PropertyStore path for the column-deletion ledger of one table.
+  ///
+  /// @param tableNameWithType table name including type suffix, e.g. {@code foo_OFFLINE}
+  public static String constructPropertyStorePathForColumnDeletionMetadata(String tableNameWithType) {
+    return StringUtil.join("/", PROPERTYSTORE_COLUMN_DELETION_METADATA, tableNameWithType);
   }
 
   public static String getPropertyStorePathForMinionTaskMetadataPrefix() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionDirtySegmentPredicate.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionDirtySegmentPredicate.java
@@ -25,25 +25,27 @@ import java.util.Set;
 import java.util.TreeSet;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
-import org.apache.pinot.spi.data.SchemaDiff;
 
 
 /// Dirty-segment predicate for an explicit column deletion.
 ///
-/// A live segment is dirty for deletion D when:
+/// A live segment is dirty for deletion D when any of these hold:
 /// <ol>
-///   <li>it predates D's immutable epoch (segment creation time, or a recorded eligibility time), and</li>
-///   <li>it has no successful deletion refresh marker whose CRC matches the current segment CRC, and</li>
-///   <li>cheap physical-absence metadata, if supplied, does not prove the logical column is gone.</li>
+///   <li>a {@link ColumnDeletionPhysicalOverride} says the logical column, or an OPEN_STRUCT child
+///       of it, is still physically present (this overrides {@code ctime} and CRC markers), or</li>
+///   <li>the segment predates D's immutable epoch (creation time, or a recorded eligibility time)
+///       and has no successful deletion CRC marker, and the caller did not positively prove the
+///       logical column absent.</li>
 /// </ol>
 ///
-/// Missing metadata is never treated as proof of cleanliness. {@code RefreshSegmentTask.time} alone
-/// is not a successful marker because today's refresh executor can write that key on a no-op skip
-/// without changing CRC.
+/// Missing metadata is never treated as proof of cleanliness. {@code RefreshSegmentTask.time} is
+/// not a successful marker: today's refresh executor can write that key on a no-op skip without
+/// changing CRC.
 ///
-/// Callers pass only live segments (IdealState / ZK metadata still present, not replaced). This
-/// helper does not consult IdealState itself. In-flight tasks that could still install an older CRC
-/// are also the caller's responsibility.
+/// This helper does not read segment files. Callers that can see physical names pass a
+/// {@link ColumnDeletionPhysicalOverride}. It also does not mark
+/// {@link ColumnDeletionState#COMPLETE}. An empty {@code liveSegments} list yields an empty dirty
+/// set and is not cleanup: deep-store objects and later uploads can still hold the column.
 ///
 /// Thread-safe: the helper is stateless.
 public final class ColumnDeletionDirtySegmentPredicate {
@@ -65,8 +67,11 @@ public final class ColumnDeletionDirtySegmentPredicate {
 
   /// True when {@code segment} still needs reclamation for {@code entry}.
   public static boolean isDirty(SegmentZKMetadata segment, ColumnDeletionEntry entry, boolean ignoreCase,
-      @Nullable Set<String> columnsProvenAbsent) {
-    if (isColumnProvenAbsent(entry.getColumnName(), ignoreCase, columnsProvenAbsent)) {
+      @Nullable ColumnDeletionPhysicalOverride physicalOverride) {
+    if (physicalOverride != null && physicalOverride.indicatesPresent(entry.getColumnName(), ignoreCase)) {
+      return true;
+    }
+    if (physicalOverride != null && physicalOverride.provesLogicalColumnAbsent(entry.getColumnName(), ignoreCase)) {
       return false;
     }
     if (!predatesDeletion(segment, entry.getDeletionEpochMs())) {
@@ -76,13 +81,17 @@ public final class ColumnDeletionDirtySegmentPredicate {
   }
 
   /// Segment names from {@code liveSegments} that are dirty for {@code entry}, sorted.
+  ///
+  /// An empty result is not {@link ColumnDeletionState#COMPLETE}, including when
+  /// {@code liveSegments} itself is empty.
   public static List<String> findDirtySegmentNames(Collection<SegmentZKMetadata> liveSegments,
-      ColumnDeletionEntry entry, boolean ignoreCase, @Nullable Map<String, Set<String>> provenAbsentColumnsBySegment) {
+      ColumnDeletionEntry entry, boolean ignoreCase,
+      @Nullable Map<String, ColumnDeletionPhysicalOverride> physicalOverrideBySegment) {
     Set<String> dirty = new TreeSet<>();
     for (SegmentZKMetadata segment : liveSegments) {
-      Set<String> provenAbsent =
-          provenAbsentColumnsBySegment == null ? null : provenAbsentColumnsBySegment.get(segment.getSegmentName());
-      if (isDirty(segment, entry, ignoreCase, provenAbsent)) {
+      ColumnDeletionPhysicalOverride override =
+          physicalOverrideBySegment == null ? null : physicalOverrideBySegment.get(segment.getSegmentName());
+      if (isDirty(segment, entry, ignoreCase, override)) {
         dirty.add(segment.getSegmentName());
       }
     }
@@ -90,15 +99,18 @@ public final class ColumnDeletionDirtySegmentPredicate {
   }
 
   /// Union of dirty segment names across every active (non-complete) deletion on the table.
+  ///
+  /// An empty result is not {@link ColumnDeletionState#COMPLETE}, including when
+  /// {@code liveSegments} itself is empty.
   public static List<String> findDirtySegmentNames(Collection<SegmentZKMetadata> liveSegments,
       ColumnDeletionMetadata metadata, boolean ignoreCase,
-      @Nullable Map<String, Set<String>> provenAbsentColumnsBySegment) {
+      @Nullable Map<String, ColumnDeletionPhysicalOverride> physicalOverrideBySegment) {
     Set<String> dirty = new TreeSet<>();
     for (ColumnDeletionEntry entry : metadata.getEntries().values()) {
       if (!entry.blocksReAdd()) {
         continue;
       }
-      dirty.addAll(findDirtySegmentNames(liveSegments, entry, ignoreCase, provenAbsentColumnsBySegment));
+      dirty.addAll(findDirtySegmentNames(liveSegments, entry, ignoreCase, physicalOverrideBySegment));
     }
     return List.copyOf(dirty);
   }
@@ -126,24 +138,12 @@ public final class ColumnDeletionDirtySegmentPredicate {
     if (customMap == null) {
       return false;
     }
+    // RefreshSegmentTask.time is intentionally ignored. A matching CRC for this deletionId is required.
     String markedCrc = customMap.get(processedCrcKey(deletionId));
     if (markedCrc == null) {
       return false;
     }
     long currentCrc = segment.getCrc();
     return currentCrc >= 0 && markedCrc.equals(Long.toString(currentCrc));
-  }
-
-  private static boolean isColumnProvenAbsent(String columnName, boolean ignoreCase,
-      @Nullable Set<String> columnsProvenAbsent) {
-    if (columnsProvenAbsent == null || columnsProvenAbsent.isEmpty()) {
-      return false;
-    }
-    for (String provenAbsent : columnsProvenAbsent) {
-      if (SchemaDiff.columnNamesEqual(columnName, provenAbsent, ignoreCase)) {
-        return true;
-      }
-    }
-    return false;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionDirtySegmentPredicate.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionDirtySegmentPredicate.java
@@ -1,0 +1,149 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metadata.columndeletion;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.spi.data.SchemaDiff;
+
+
+/// Dirty-segment predicate for an explicit column deletion.
+///
+/// A live segment is dirty for deletion D when:
+/// <ol>
+///   <li>it predates D's immutable epoch (segment creation time, or a recorded eligibility time), and</li>
+///   <li>it has no successful deletion refresh marker whose CRC matches the current segment CRC, and</li>
+///   <li>cheap physical-absence metadata, if supplied, does not prove the logical column is gone.</li>
+/// </ol>
+///
+/// Missing metadata is never treated as proof of cleanliness. {@code RefreshSegmentTask.time} alone
+/// is not a successful marker because today's refresh executor can write that key on a no-op skip
+/// without changing CRC.
+///
+/// Callers pass only live segments (IdealState / ZK metadata still present, not replaced). This
+/// helper does not consult IdealState itself. In-flight tasks that could still install an older CRC
+/// are also the caller's responsibility.
+///
+/// Thread-safe: the helper is stateless.
+public final class ColumnDeletionDirtySegmentPredicate {
+  /// Existing refresh-task processed-time key. Not sufficient by itself to mark a segment clean.
+  public static final String REFRESH_SEGMENT_TASK_TIME_KEY = "RefreshSegmentTask.time";
+  /// Optional custom-map key used when {@link SegmentZKMetadata#getCreationTime()} is missing.
+  public static final String ELIGIBILITY_TIME_KEY = "ColumnDeletion.eligibilityTime";
+
+  private static final String DELETION_CRC_KEY_PREFIX = "ColumnDeletion.";
+  private static final String DELETION_CRC_KEY_SUFFIX = ".crc";
+
+  private ColumnDeletionDirtySegmentPredicate() {
+  }
+
+  /// Custom-map key that records the CRC installed for a successful deletion refresh.
+  public static String processedCrcKey(String deletionId) {
+    return DELETION_CRC_KEY_PREFIX + deletionId + DELETION_CRC_KEY_SUFFIX;
+  }
+
+  /// True when {@code segment} still needs reclamation for {@code entry}.
+  public static boolean isDirty(SegmentZKMetadata segment, ColumnDeletionEntry entry, boolean ignoreCase,
+      @Nullable Set<String> columnsProvenAbsent) {
+    if (isColumnProvenAbsent(entry.getColumnName(), ignoreCase, columnsProvenAbsent)) {
+      return false;
+    }
+    if (!predatesDeletion(segment, entry.getDeletionEpochMs())) {
+      return false;
+    }
+    return !hasSuccessfulRefreshMarker(segment, entry.getDeletionId());
+  }
+
+  /// Segment names from {@code liveSegments} that are dirty for {@code entry}, sorted.
+  public static List<String> findDirtySegmentNames(Collection<SegmentZKMetadata> liveSegments,
+      ColumnDeletionEntry entry, boolean ignoreCase, @Nullable Map<String, Set<String>> provenAbsentColumnsBySegment) {
+    Set<String> dirty = new TreeSet<>();
+    for (SegmentZKMetadata segment : liveSegments) {
+      Set<String> provenAbsent =
+          provenAbsentColumnsBySegment == null ? null : provenAbsentColumnsBySegment.get(segment.getSegmentName());
+      if (isDirty(segment, entry, ignoreCase, provenAbsent)) {
+        dirty.add(segment.getSegmentName());
+      }
+    }
+    return List.copyOf(dirty);
+  }
+
+  /// Union of dirty segment names across every active (non-complete) deletion on the table.
+  public static List<String> findDirtySegmentNames(Collection<SegmentZKMetadata> liveSegments,
+      ColumnDeletionMetadata metadata, boolean ignoreCase,
+      @Nullable Map<String, Set<String>> provenAbsentColumnsBySegment) {
+    Set<String> dirty = new TreeSet<>();
+    for (ColumnDeletionEntry entry : metadata.getEntries().values()) {
+      if (!entry.blocksReAdd()) {
+        continue;
+      }
+      dirty.addAll(findDirtySegmentNames(liveSegments, entry, ignoreCase, provenAbsentColumnsBySegment));
+    }
+    return List.copyOf(dirty);
+  }
+
+  static boolean predatesDeletion(SegmentZKMetadata segment, long deletionEpochMs) {
+    long eligibilityTimeMs = segment.getCreationTime();
+    if (eligibilityTimeMs < 0) {
+      Map<String, String> customMap = segment.getCustomMap();
+      if (customMap != null) {
+        String recorded = customMap.get(ELIGIBILITY_TIME_KEY);
+        if (recorded != null) {
+          eligibilityTimeMs = Long.parseLong(recorded);
+        }
+      }
+    }
+    if (eligibilityTimeMs < 0) {
+      // Missing ctime and eligibility time cannot prove the segment postdates the deletion.
+      return true;
+    }
+    return eligibilityTimeMs < deletionEpochMs;
+  }
+
+  static boolean hasSuccessfulRefreshMarker(SegmentZKMetadata segment, String deletionId) {
+    Map<String, String> customMap = segment.getCustomMap();
+    if (customMap == null) {
+      return false;
+    }
+    String markedCrc = customMap.get(processedCrcKey(deletionId));
+    if (markedCrc == null) {
+      return false;
+    }
+    long currentCrc = segment.getCrc();
+    return currentCrc >= 0 && markedCrc.equals(Long.toString(currentCrc));
+  }
+
+  private static boolean isColumnProvenAbsent(String columnName, boolean ignoreCase,
+      @Nullable Set<String> columnsProvenAbsent) {
+    if (columnsProvenAbsent == null || columnsProvenAbsent.isEmpty()) {
+      return false;
+    }
+    for (String provenAbsent : columnsProvenAbsent) {
+      if (SchemaDiff.columnNamesEqual(columnName, provenAbsent, ignoreCase)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionDirtySegmentPredicate.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionDirtySegmentPredicate.java
@@ -122,7 +122,12 @@ public final class ColumnDeletionDirtySegmentPredicate {
       if (customMap != null) {
         String recorded = customMap.get(ELIGIBILITY_TIME_KEY);
         if (recorded != null) {
-          eligibilityTimeMs = Long.parseLong(recorded);
+          try {
+            eligibilityTimeMs = Long.parseLong(recorded);
+          } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                "Segment '" + segment.getSegmentName() + "' has invalid " + ELIGIBILITY_TIME_KEY + ": " + recorded, e);
+          }
         }
       }
     }
@@ -130,7 +135,8 @@ public final class ColumnDeletionDirtySegmentPredicate {
       // Missing ctime and eligibility time cannot prove the segment postdates the deletion.
       return true;
     }
-    return eligibilityTimeMs < deletionEpochMs;
+    // Equal timestamps cannot prove the segment was built after the delete.
+    return eligibilityTimeMs <= deletionEpochMs;
   }
 
   static boolean hasSuccessfulRefreshMarker(SegmentZKMetadata segment, String deletionId) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionEntry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionEntry.java
@@ -124,6 +124,11 @@ public final class ColumnDeletionEntry {
         _state, _lastError, outstandingSegmentCount);
   }
 
+  public ColumnDeletionEntry withSchemaZkMtimeMs(long schemaZkMtimeMs) {
+    return new ColumnDeletionEntry(_columnName, _deletionId, _deletionEpochMs, _schemaZkVersion, schemaZkMtimeMs,
+        _state, _lastError, _outstandingSegmentCount);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionEntry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionEntry.java
@@ -1,0 +1,153 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metadata.columndeletion;
+
+import com.google.common.base.Preconditions;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+
+
+/// Immutable record for one explicit column deletion on a table.
+///
+/// {@code deletionEpochMs} and {@code schemaZkVersion} are captured when the deletion is accepted
+/// and must not be rewritten after later unrelated schema edits. Progress fields
+/// ({@code lastError}, {@code outstandingSegmentCount}) may change. Thread-safe because instances
+/// are immutable; updates return a new object.
+public final class ColumnDeletionEntry {
+  private final String _columnName;
+  private final String _deletionId;
+  private final long _deletionEpochMs;
+  private final int _schemaZkVersion;
+  private final long _schemaZkMtimeMs;
+  private final ColumnDeletionState _state;
+  @Nullable
+  private final String _lastError;
+  private final int _outstandingSegmentCount;
+
+  public ColumnDeletionEntry(String columnName, String deletionId, long deletionEpochMs, int schemaZkVersion,
+      ColumnDeletionState state) {
+    this(columnName, deletionId, deletionEpochMs, schemaZkVersion, -1L, state, null, 0);
+  }
+
+  public ColumnDeletionEntry(String columnName, String deletionId, long deletionEpochMs, int schemaZkVersion,
+      long schemaZkMtimeMs, ColumnDeletionState state, @Nullable String lastError, int outstandingSegmentCount) {
+    Preconditions.checkArgument(StringUtils.isNotBlank(columnName), "columnName is required");
+    Preconditions.checkArgument(StringUtils.isNotBlank(deletionId), "deletionId is required");
+    Preconditions.checkArgument(deletionEpochMs >= 0, "deletionEpochMs must be >= 0");
+    Preconditions.checkNotNull(state, "state");
+    Preconditions.checkArgument(outstandingSegmentCount >= 0, "outstandingSegmentCount must be >= 0");
+    _columnName = columnName;
+    _deletionId = deletionId;
+    _deletionEpochMs = deletionEpochMs;
+    _schemaZkVersion = schemaZkVersion;
+    _schemaZkMtimeMs = schemaZkMtimeMs;
+    _state = state;
+    _lastError = lastError;
+    _outstandingSegmentCount = outstandingSegmentCount;
+  }
+
+  public String getColumnName() {
+    return _columnName;
+  }
+
+  public String getDeletionId() {
+    return _deletionId;
+  }
+
+  /// Immutable deletion epoch. Later schema znode mtimes must not replace this value.
+  public long getDeletionEpochMs() {
+    return _deletionEpochMs;
+  }
+
+  /// Schema znode version associated with this deletion event. May be the pre-write version
+  /// while {@link ColumnDeletionState#PREPARED}, then the post-write version after advance.
+  public int getSchemaZkVersion() {
+    return _schemaZkVersion;
+  }
+
+  /// Schema znode mtime of the deletion event, or {@code -1} when unknown.
+  public long getSchemaZkMtimeMs() {
+    return _schemaZkMtimeMs;
+  }
+
+  public ColumnDeletionState getState() {
+    return _state;
+  }
+
+  @Nullable
+  public String getLastError() {
+    return _lastError;
+  }
+
+  public int getOutstandingSegmentCount() {
+    return _outstandingSegmentCount;
+  }
+
+  public boolean blocksReAdd() {
+    return _state.blocksReAdd();
+  }
+
+  public ColumnDeletionEntry withState(ColumnDeletionState state) {
+    return new ColumnDeletionEntry(_columnName, _deletionId, _deletionEpochMs, _schemaZkVersion, _schemaZkMtimeMs,
+        state, _lastError, _outstandingSegmentCount);
+  }
+
+  public ColumnDeletionEntry withSchemaZkVersion(int schemaZkVersion) {
+    return new ColumnDeletionEntry(_columnName, _deletionId, _deletionEpochMs, schemaZkVersion, _schemaZkMtimeMs,
+        _state, _lastError, _outstandingSegmentCount);
+  }
+
+  public ColumnDeletionEntry withLastError(@Nullable String lastError) {
+    return new ColumnDeletionEntry(_columnName, _deletionId, _deletionEpochMs, _schemaZkVersion, _schemaZkMtimeMs,
+        _state, lastError, _outstandingSegmentCount);
+  }
+
+  public ColumnDeletionEntry withOutstandingSegmentCount(int outstandingSegmentCount) {
+    return new ColumnDeletionEntry(_columnName, _deletionId, _deletionEpochMs, _schemaZkVersion, _schemaZkMtimeMs,
+        _state, _lastError, outstandingSegmentCount);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ColumnDeletionEntry that = (ColumnDeletionEntry) o;
+    return _deletionEpochMs == that._deletionEpochMs && _schemaZkVersion == that._schemaZkVersion
+        && _schemaZkMtimeMs == that._schemaZkMtimeMs && _outstandingSegmentCount == that._outstandingSegmentCount
+        && _columnName.equals(that._columnName) && _deletionId.equals(that._deletionId) && _state == that._state
+        && Objects.equals(_lastError, that._lastError);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_columnName, _deletionId, _deletionEpochMs, _schemaZkVersion, _schemaZkMtimeMs, _state,
+        _lastError, _outstandingSegmentCount);
+  }
+
+  @Override
+  public String toString() {
+    return "ColumnDeletionEntry{columnName='" + _columnName + "', deletionId='" + _deletionId + "', state=" + _state
+        + ", deletionEpochMs=" + _deletionEpochMs + '}';
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadata.java
@@ -20,6 +20,7 @@ package org.apache.pinot.common.metadata.columndeletion;
 
 import com.google.common.base.Preconditions;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -69,6 +70,7 @@ public final class ColumnDeletionMetadata {
     _tableNameWithType = tableNameWithType;
     _formatVersion = formatVersion;
     _entries = new LinkedHashMap<>(entries);
+    checkNoDuplicateActiveColumns(_entries.values(), false);
   }
 
   public static String newDeletionId() {
@@ -94,16 +96,37 @@ public final class ColumnDeletionMetadata {
   }
 
   public void addEntry(ColumnDeletionEntry entry) {
+    addEntry(entry, false);
+  }
+
+  /// Adds an entry. Rejects a second {@link ColumnDeletionEntry#blocksReAdd()} row for the same
+  /// column. A {@link ColumnDeletionState#COMPLETE} tombstone plus a new active row is allowed.
+  public void addEntry(ColumnDeletionEntry entry, boolean ignoreCase) {
     Preconditions.checkNotNull(entry, "entry");
     Preconditions.checkArgument(!_entries.containsKey(entry.getDeletionId()),
         "Deletion id '%s' already exists", entry.getDeletionId());
+    if (entry.blocksReAdd() && findActiveEntryForColumn(entry.getColumnName(), ignoreCase) != null) {
+      throw new IllegalArgumentException(
+          "Active column deletion already exists for column '" + entry.getColumnName() + "'");
+    }
     _entries.put(entry.getDeletionId(), entry);
   }
 
   public void updateEntry(ColumnDeletionEntry entry) {
+    updateEntry(entry, false);
+  }
+
+  public void updateEntry(ColumnDeletionEntry entry, boolean ignoreCase) {
     Preconditions.checkNotNull(entry, "entry");
     Preconditions.checkArgument(_entries.containsKey(entry.getDeletionId()),
         "Deletion id '%s' does not exist", entry.getDeletionId());
+    if (entry.blocksReAdd()) {
+      ColumnDeletionEntry existingActive = findActiveEntryForColumn(entry.getColumnName(), ignoreCase);
+      if (existingActive != null && !existingActive.getDeletionId().equals(entry.getDeletionId())) {
+        throw new IllegalArgumentException(
+            "Active column deletion already exists for column '" + entry.getColumnName() + "'");
+      }
+    }
     _entries.put(entry.getDeletionId(), entry);
   }
 
@@ -224,6 +247,37 @@ public final class ColumnDeletionMetadata {
       entries.put(entry.getDeletionId(), entry);
     }
     return new ColumnDeletionMetadata(record.getId(), formatVersion, entries);
+  }
+
+  /// Stored format version without refusing newer values. Used by writers that must not clobber
+  /// a znode they cannot parse.
+  static int peekFormatVersion(ZNRecord record) {
+    Preconditions.checkNotNull(record, "record");
+    String formatVersionString = record.getSimpleField(FORMAT_VERSION_KEY);
+    if (StringUtils.isBlank(formatVersionString)) {
+      throw new IllegalArgumentException(
+          "Column deletion metadata for '" + record.getId() + "' is missing formatVersion");
+    }
+    try {
+      return Integer.parseInt(formatVersionString);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "Column deletion metadata for '" + record.getId() + "' has invalid formatVersion: " + formatVersionString, e);
+    }
+  }
+
+  private static void checkNoDuplicateActiveColumns(Iterable<ColumnDeletionEntry> entries, boolean ignoreCase) {
+    Set<String> activeNames = new HashSet<>();
+    for (ColumnDeletionEntry entry : entries) {
+      if (!entry.blocksReAdd()) {
+        continue;
+      }
+      String key = SchemaDiff.normalizeColumnName(entry.getColumnName(), ignoreCase);
+      if (!activeNames.add(key)) {
+        throw new IllegalArgumentException(
+            "Active column deletion already exists for column '" + entry.getColumnName() + "'");
+      }
+    }
   }
 
   private static ColumnDeletionEntry parseEntry(String tableNameWithType, String deletionIdKey,

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadata.java
@@ -1,0 +1,319 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metadata.columndeletion;
+
+import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.spi.data.SchemaDiff;
+
+
+/// Table-scoped column-deletion ledger stored at
+/// {@code /COLUMN_DELETION_METADATA/<tableNameWithType>}.
+///
+/// One znode holds every explicit deletion for that table, including {@link ColumnDeletionState#COMPLETE}
+/// tombstones. The record is format-versioned. Readers refuse versions newer than
+/// {@link #CURRENT_FORMAT_VERSION} so a mixed-version controller cannot clobber a znode it cannot
+/// parse.
+///
+/// This object is not thread-safe. Concurrent writers must read-modify-write through
+/// {@link ColumnDeletionMetadataAccessHelper} using the PropertyStore expected version.
+public final class ColumnDeletionMetadata {
+  public static final int CURRENT_FORMAT_VERSION = 1;
+
+  private static final String FORMAT_VERSION_KEY = "formatVersion";
+  private static final String COLUMN_NAME_KEY = "columnName";
+  private static final String DELETION_ID_KEY = "deletionId";
+  private static final String DELETION_EPOCH_MS_KEY = "deletionEpochMs";
+  private static final String SCHEMA_ZK_VERSION_KEY = "schemaZkVersion";
+  private static final String SCHEMA_ZK_MTIME_MS_KEY = "schemaZkMtimeMs";
+  private static final String STATE_KEY = "state";
+  private static final String LAST_ERROR_KEY = "lastError";
+  private static final String OUTSTANDING_SEGMENT_COUNT_KEY = "outstandingSegmentCount";
+
+  private final String _tableNameWithType;
+  private final int _formatVersion;
+  private final Map<String, ColumnDeletionEntry> _entries;
+
+  public ColumnDeletionMetadata(String tableNameWithType) {
+    this(tableNameWithType, CURRENT_FORMAT_VERSION, new LinkedHashMap<>());
+  }
+
+  public ColumnDeletionMetadata(String tableNameWithType, int formatVersion, Map<String, ColumnDeletionEntry> entries) {
+    Preconditions.checkArgument(StringUtils.isNotBlank(tableNameWithType), "tableNameWithType is required");
+    Preconditions.checkArgument(formatVersion >= 1, "formatVersion must be >= 1");
+    _tableNameWithType = tableNameWithType;
+    _formatVersion = formatVersion;
+    _entries = new LinkedHashMap<>(entries);
+  }
+
+  public static String newDeletionId() {
+    return UUID.randomUUID().toString();
+  }
+
+  public String getTableNameWithType() {
+    return _tableNameWithType;
+  }
+
+  public int getFormatVersion() {
+    return _formatVersion;
+  }
+
+  /// Unmodifiable view of entries keyed by deletion id, in insertion order.
+  public Map<String, ColumnDeletionEntry> getEntries() {
+    return Collections.unmodifiableMap(_entries);
+  }
+
+  @Nullable
+  public ColumnDeletionEntry getEntry(String deletionId) {
+    return _entries.get(deletionId);
+  }
+
+  public void addEntry(ColumnDeletionEntry entry) {
+    Preconditions.checkNotNull(entry, "entry");
+    Preconditions.checkArgument(!_entries.containsKey(entry.getDeletionId()),
+        "Deletion id '%s' already exists", entry.getDeletionId());
+    _entries.put(entry.getDeletionId(), entry);
+  }
+
+  public void updateEntry(ColumnDeletionEntry entry) {
+    Preconditions.checkNotNull(entry, "entry");
+    Preconditions.checkArgument(_entries.containsKey(entry.getDeletionId()),
+        "Deletion id '%s' does not exist", entry.getDeletionId());
+    _entries.put(entry.getDeletionId(), entry);
+  }
+
+  public void removeEntry(String deletionId) {
+    _entries.remove(deletionId);
+  }
+
+  /// Names from every non-{@link ColumnDeletionState#COMPLETE} entry.
+  ///
+  /// When {@code ignoreCase} is true the returned names are {@link Locale#ROOT} lowercased so callers
+  /// can compare with the same rule used by schema validation.
+  public Set<String> getActiveDeletedColumnNames(boolean ignoreCase) {
+    Set<String> names = new TreeSet<>();
+    for (ColumnDeletionEntry entry : _entries.values()) {
+      if (entry.blocksReAdd()) {
+        names.add(SchemaDiff.normalizeColumnName(entry.getColumnName(), ignoreCase));
+      }
+    }
+    return names;
+  }
+
+  /// True when {@code columnName} matches an active (non-complete) deletion.
+  public boolean blocksReAdd(String columnName, boolean ignoreCase) {
+    Preconditions.checkArgument(StringUtils.isNotBlank(columnName), "columnName is required");
+    for (ColumnDeletionEntry entry : _entries.values()) {
+      if (entry.blocksReAdd() && SchemaDiff.columnNamesEqual(entry.getColumnName(), columnName, ignoreCase)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Nullable
+  public ColumnDeletionEntry findActiveEntryForColumn(String columnName, boolean ignoreCase) {
+    for (ColumnDeletionEntry entry : _entries.values()) {
+      if (entry.blocksReAdd() && SchemaDiff.columnNamesEqual(entry.getColumnName(), columnName, ignoreCase)) {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  /// Recover a {@link ColumnDeletionState#PREPARED} entry after controller restart.
+  ///
+  /// If the column is still in the schema, the schema write never landed and the entry is removed.
+  /// If the column is already absent, the schema write landed and the entry becomes
+  /// {@link ColumnDeletionState#RECLAIMING}.
+  ///
+  /// @return the post-reconciliation entry, or {@code null} when the prepared entry was aborted
+  @Nullable
+  public ColumnDeletionEntry reconcilePreparedEntry(String deletionId, boolean columnStillInSchema) {
+    ColumnDeletionEntry entry = _entries.get(deletionId);
+    Preconditions.checkArgument(entry != null, "Deletion id '%s' does not exist", deletionId);
+    if (entry.getState() != ColumnDeletionState.PREPARED) {
+      return entry;
+    }
+    if (columnStillInSchema) {
+      _entries.remove(deletionId);
+      return null;
+    }
+    ColumnDeletionEntry advanced = entry.withState(ColumnDeletionState.RECLAIMING);
+    _entries.put(deletionId, advanced);
+    return advanced;
+  }
+
+  public ZNRecord toZNRecord() {
+    if (_formatVersion > CURRENT_FORMAT_VERSION) {
+      throw new ColumnDeletionUnsupportedFormatException(_formatVersion, CURRENT_FORMAT_VERSION);
+    }
+    ZNRecord znRecord = new ZNRecord(_tableNameWithType);
+    znRecord.setSimpleField(FORMAT_VERSION_KEY, Integer.toString(CURRENT_FORMAT_VERSION));
+    for (ColumnDeletionEntry entry : _entries.values()) {
+      Map<String, String> fields = new LinkedHashMap<>();
+      fields.put(COLUMN_NAME_KEY, entry.getColumnName());
+      fields.put(DELETION_ID_KEY, entry.getDeletionId());
+      fields.put(DELETION_EPOCH_MS_KEY, Long.toString(entry.getDeletionEpochMs()));
+      fields.put(SCHEMA_ZK_VERSION_KEY, Integer.toString(entry.getSchemaZkVersion()));
+      if (entry.getSchemaZkMtimeMs() >= 0) {
+        fields.put(SCHEMA_ZK_MTIME_MS_KEY, Long.toString(entry.getSchemaZkMtimeMs()));
+      }
+      fields.put(STATE_KEY, entry.getState().name());
+      if (entry.getLastError() != null) {
+        fields.put(LAST_ERROR_KEY, entry.getLastError());
+      }
+      if (entry.getOutstandingSegmentCount() > 0) {
+        fields.put(OUTSTANDING_SEGMENT_COUNT_KEY, Integer.toString(entry.getOutstandingSegmentCount()));
+      }
+      znRecord.setMapField(entry.getDeletionId(), fields);
+    }
+    return znRecord;
+  }
+
+  public static ColumnDeletionMetadata fromZNRecord(ZNRecord record) {
+    Preconditions.checkNotNull(record, "record");
+    String formatVersionString = record.getSimpleField(FORMAT_VERSION_KEY);
+    if (StringUtils.isBlank(formatVersionString)) {
+      throw new IllegalArgumentException(
+          "Column deletion metadata for '" + record.getId() + "' is missing formatVersion");
+    }
+    int formatVersion;
+    try {
+      formatVersion = Integer.parseInt(formatVersionString);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "Column deletion metadata for '" + record.getId() + "' has invalid formatVersion: " + formatVersionString, e);
+    }
+    if (formatVersion > CURRENT_FORMAT_VERSION) {
+      throw new ColumnDeletionUnsupportedFormatException(formatVersion, CURRENT_FORMAT_VERSION);
+    }
+    if (formatVersion < 1) {
+      throw new IllegalArgumentException(
+          "Column deletion metadata for '" + record.getId() + "' has invalid formatVersion: " + formatVersion);
+    }
+
+    Map<String, ColumnDeletionEntry> entries = new LinkedHashMap<>();
+    for (Map.Entry<String, Map<String, String>> mapField : record.getMapFields().entrySet()) {
+      ColumnDeletionEntry entry = parseEntry(record.getId(), mapField.getKey(), mapField.getValue());
+      entries.put(entry.getDeletionId(), entry);
+    }
+    return new ColumnDeletionMetadata(record.getId(), formatVersion, entries);
+  }
+
+  private static ColumnDeletionEntry parseEntry(String tableNameWithType, String deletionIdKey,
+      Map<String, String> fields) {
+    if (fields == null) {
+      throw new IllegalArgumentException(
+          "Column deletion entry '" + deletionIdKey + "' on '" + tableNameWithType + "' has no fields");
+    }
+    String storedDeletionId = fields.get(DELETION_ID_KEY);
+    if (StringUtils.isNotBlank(storedDeletionId) && !storedDeletionId.equals(deletionIdKey)) {
+      throw new IllegalArgumentException(
+          "Column deletion entry key '" + deletionIdKey + "' does not match stored deletionId '" + storedDeletionId
+              + "' on '" + tableNameWithType + "'");
+    }
+    String columnName = requiredField(fields, COLUMN_NAME_KEY, deletionIdKey, tableNameWithType);
+    long deletionEpochMs = parseLongField(fields, DELETION_EPOCH_MS_KEY, deletionIdKey, tableNameWithType);
+    int schemaZkVersion = parseIntField(fields, SCHEMA_ZK_VERSION_KEY, deletionIdKey, tableNameWithType);
+    long schemaZkMtimeMs = -1L;
+    if (fields.containsKey(SCHEMA_ZK_MTIME_MS_KEY)) {
+      schemaZkMtimeMs = parseLongField(fields, SCHEMA_ZK_MTIME_MS_KEY, deletionIdKey, tableNameWithType);
+    }
+    String stateName = requiredField(fields, STATE_KEY, deletionIdKey, tableNameWithType);
+    ColumnDeletionState state;
+    try {
+      state = ColumnDeletionState.valueOf(stateName);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Column deletion entry '" + deletionIdKey + "' on '" + tableNameWithType + "' has unknown state: "
+              + stateName, e);
+    }
+    String lastError = fields.get(LAST_ERROR_KEY);
+    int outstandingSegmentCount = 0;
+    if (fields.containsKey(OUTSTANDING_SEGMENT_COUNT_KEY)) {
+      outstandingSegmentCount =
+          parseIntField(fields, OUTSTANDING_SEGMENT_COUNT_KEY, deletionIdKey, tableNameWithType);
+    }
+    return new ColumnDeletionEntry(columnName, deletionIdKey, deletionEpochMs, schemaZkVersion, schemaZkMtimeMs, state,
+        lastError, outstandingSegmentCount);
+  }
+
+  private static String requiredField(Map<String, String> fields, String key, String deletionId,
+      String tableNameWithType) {
+    String value = fields.get(key);
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalArgumentException(
+          "Column deletion entry '" + deletionId + "' on '" + tableNameWithType + "' is missing " + key);
+    }
+    return value;
+  }
+
+  private static long parseLongField(Map<String, String> fields, String key, String deletionId,
+      String tableNameWithType) {
+    String value = requiredField(fields, key, deletionId, tableNameWithType);
+    try {
+      return Long.parseLong(value);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "Column deletion entry '" + deletionId + "' on '" + tableNameWithType + "' has invalid " + key + ": " + value,
+          e);
+    }
+  }
+
+  private static int parseIntField(Map<String, String> fields, String key, String deletionId,
+      String tableNameWithType) {
+    String value = requiredField(fields, key, deletionId, tableNameWithType);
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "Column deletion entry '" + deletionId + "' on '" + tableNameWithType + "' has invalid " + key + ": " + value,
+          e);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ColumnDeletionMetadata that = (ColumnDeletionMetadata) o;
+    return _formatVersion == that._formatVersion && _tableNameWithType.equals(that._tableNameWithType)
+        && _entries.equals(that._entries);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_tableNameWithType, _formatVersion, _entries);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadata.java
@@ -21,7 +21,6 @@ package org.apache.pinot.common.metadata.columndeletion;
 import com.google.common.base.Preconditions;
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelper.java
@@ -72,8 +72,8 @@ public final class ColumnDeletionMetadataAccessHelper {
   /// Write the ledger with an expected znode version.
   ///
   /// First write uses {@code create}. {@code expectedVersion} of {@code -1} against an existing
-  /// current-format znode still matches any version. A stored format newer than this process can
-  /// parse is never overwritten, including when {@code expectedVersion} is {@code -1}.
+  /// current-format znode CASes against the version observed by this call; it is not Helix
+  /// match-any. A stored format newer than this process can parse is never overwritten.
   ///
   /// @return true if the write succeeded
   public static boolean writeColumnDeletionMetadata(ZkHelixPropertyStore<ZNRecord> propertyStore,
@@ -84,7 +84,8 @@ public final class ColumnDeletionMetadataAccessHelper {
     }
     String tableNameWithType = metadata.getTableNameWithType();
     String path = ZKMetadataProvider.constructPropertyStorePathForColumnDeletionMetadata(tableNameWithType);
-    ZNRecord existing = propertyStore.get(path, null, AccessOption.PERSISTENT);
+    Stat stat = new Stat();
+    ZNRecord existing = propertyStore.get(path, stat, AccessOption.PERSISTENT);
     if (existing == null) {
       if (expectedVersion != -1) {
         LOGGER.warn("Failed to write column deletion metadata for table: {} at expected version: {} (znode missing)",
@@ -104,19 +105,20 @@ public final class ColumnDeletionMetadataAccessHelper {
       throw new ColumnDeletionUnsupportedFormatException(storedFormatVersion,
           ColumnDeletionMetadata.CURRENT_FORMAT_VERSION);
     }
+    // -1 is create-or-CAS-against-the-version-just-read, not Helix match-any.
+    int casVersion = expectedVersion == -1 ? stat.getVersion() : expectedVersion;
     try {
-      boolean result = propertyStore.set(path, metadata.toZNRecord(), expectedVersion, AccessOption.PERSISTENT);
+      boolean result = propertyStore.set(path, metadata.toZNRecord(), casVersion, AccessOption.PERSISTENT);
       if (result) {
-        LOGGER.info("Wrote column deletion metadata for table: {} at expected version: {}", tableNameWithType,
-            expectedVersion);
+        LOGGER.info("Wrote column deletion metadata for table: {} at CAS version: {}", tableNameWithType, casVersion);
       } else {
-        LOGGER.warn("Failed to write column deletion metadata for table: {} at expected version: {}",
-            tableNameWithType, expectedVersion);
+        LOGGER.warn("Failed to write column deletion metadata for table: {} at CAS version: {}", tableNameWithType,
+            casVersion);
       }
       return result;
     } catch (ZkBadVersionException e) {
-      LOGGER.warn("CAS conflict writing column deletion metadata for table: {} at expected version: {}",
-          tableNameWithType, expectedVersion);
+      LOGGER.warn("CAS conflict writing column deletion metadata for table: {} at CAS version: {}", tableNameWithType,
+          casVersion);
       return false;
     }
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelper.java
@@ -69,8 +69,11 @@ public final class ColumnDeletionMetadataAccessHelper {
     return ColumnDeletionMetadata.fromZNRecord(znRecord);
   }
 
-  /// Write the ledger with an expected znode version. {@code expectedVersion} of {@code -1} matches any
-  /// version, including create.
+  /// Write the ledger with an expected znode version.
+  ///
+  /// First write uses {@code create}. {@code expectedVersion} of {@code -1} against an existing
+  /// current-format znode still matches any version. A stored format newer than this process can
+  /// parse is never overwritten, including when {@code expectedVersion} is {@code -1}.
   ///
   /// @return true if the write succeeded
   public static boolean writeColumnDeletionMetadata(ZkHelixPropertyStore<ZNRecord> propertyStore,
@@ -81,6 +84,26 @@ public final class ColumnDeletionMetadataAccessHelper {
     }
     String tableNameWithType = metadata.getTableNameWithType();
     String path = ZKMetadataProvider.constructPropertyStorePathForColumnDeletionMetadata(tableNameWithType);
+    ZNRecord existing = propertyStore.get(path, null, AccessOption.PERSISTENT);
+    if (existing == null) {
+      if (expectedVersion != -1) {
+        LOGGER.warn("Failed to write column deletion metadata for table: {} at expected version: {} (znode missing)",
+            tableNameWithType, expectedVersion);
+        return false;
+      }
+      boolean created = propertyStore.create(path, metadata.toZNRecord(), AccessOption.PERSISTENT);
+      if (created) {
+        LOGGER.info("Created column deletion metadata for table: {}", tableNameWithType);
+      } else {
+        LOGGER.warn("Failed to create column deletion metadata for table: {}", tableNameWithType);
+      }
+      return created;
+    }
+    int storedFormatVersion = ColumnDeletionMetadata.peekFormatVersion(existing);
+    if (storedFormatVersion > ColumnDeletionMetadata.CURRENT_FORMAT_VERSION) {
+      throw new ColumnDeletionUnsupportedFormatException(storedFormatVersion,
+          ColumnDeletionMetadata.CURRENT_FORMAT_VERSION);
+    }
     try {
       boolean result = propertyStore.set(path, metadata.toZNRecord(), expectedVersion, AccessOption.PERSISTENT);
       if (result) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelper.java
@@ -71,9 +71,10 @@ public final class ColumnDeletionMetadataAccessHelper {
 
   /// Write the ledger with an expected znode version.
   ///
-  /// First write uses {@code create}. {@code expectedVersion} of {@code -1} against an existing
-  /// current-format znode CASes against the version observed by this call; it is not Helix
-  /// match-any. A stored format newer than this process can parse is never overwritten.
+  /// First write uses {@code create}. {@code expectedVersion} of {@code -1} is create-only: if the
+  /// znode already exists the write returns {@code false} and does not overwrite. Updates must pass
+  /// the version from {@link #getColumnDeletionMetadataZNRecord}. A stored format newer than this
+  /// process can parse is never overwritten.
   ///
   /// @return true if the write succeeded
   public static boolean writeColumnDeletionMetadata(ZkHelixPropertyStore<ZNRecord> propertyStore,
@@ -105,20 +106,24 @@ public final class ColumnDeletionMetadataAccessHelper {
       throw new ColumnDeletionUnsupportedFormatException(storedFormatVersion,
           ColumnDeletionMetadata.CURRENT_FORMAT_VERSION);
     }
-    // -1 is create-or-CAS-against-the-version-just-read, not Helix match-any.
-    int casVersion = expectedVersion == -1 ? stat.getVersion() : expectedVersion;
+    if (expectedVersion == -1) {
+      LOGGER.warn("Refusing create-only write of column deletion metadata for table: {} (znode exists at version: {})",
+          tableNameWithType, stat.getVersion());
+      return false;
+    }
     try {
-      boolean result = propertyStore.set(path, metadata.toZNRecord(), casVersion, AccessOption.PERSISTENT);
+      boolean result = propertyStore.set(path, metadata.toZNRecord(), expectedVersion, AccessOption.PERSISTENT);
       if (result) {
-        LOGGER.info("Wrote column deletion metadata for table: {} at CAS version: {}", tableNameWithType, casVersion);
+        LOGGER.info("Wrote column deletion metadata for table: {} at expected version: {}", tableNameWithType,
+            expectedVersion);
       } else {
-        LOGGER.warn("Failed to write column deletion metadata for table: {} at CAS version: {}", tableNameWithType,
-            casVersion);
+        LOGGER.warn("Failed to write column deletion metadata for table: {} at expected version: {}",
+            tableNameWithType, expectedVersion);
       }
       return result;
     } catch (ZkBadVersionException e) {
-      LOGGER.warn("CAS conflict writing column deletion metadata for table: {} at CAS version: {}", tableNameWithType,
-          casVersion);
+      LOGGER.warn("CAS conflict writing column deletion metadata for table: {} at expected version: {}",
+          tableNameWithType, expectedVersion);
       return false;
     }
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelper.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metadata.columndeletion;
+
+import javax.annotation.Nullable;
+import org.apache.helix.AccessOption;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.zkclient.exception.ZkBadVersionException;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/// CAS read/write helper for {@link ColumnDeletionMetadata}.
+///
+/// Thread-safe: the helper is stateless. Concurrent writers must pass the expected znode version
+/// from the last read. A version conflict returns {@code false} and does not clobber the znode.
+/// A record whose format version is newer than this process can parse is never overwritten.
+public final class ColumnDeletionMetadataAccessHelper {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ColumnDeletionMetadataAccessHelper.class);
+
+  private ColumnDeletionMetadataAccessHelper() {
+  }
+
+  /// Read the ledger znode, or {@code null} when it does not exist.
+  ///
+  /// The returned {@link ZNRecord} has {@link ZNRecord#getVersion()} set from the Stat so callers
+  /// can CAS the next write.
+  @Nullable
+  public static ZNRecord getColumnDeletionMetadataZNRecord(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String tableNameWithType) {
+    String path = ZKMetadataProvider.constructPropertyStorePathForColumnDeletionMetadata(tableNameWithType);
+    Stat stat = new Stat();
+    ZNRecord znRecord = propertyStore.get(path, stat, AccessOption.PERSISTENT);
+    if (znRecord != null) {
+      znRecord.setVersion(stat.getVersion());
+    }
+    return znRecord;
+  }
+
+  /// Decode the ledger, or {@code null} when the znode does not exist.
+  ///
+  /// @throws ColumnDeletionUnsupportedFormatException if the stored format is newer than this process
+  @Nullable
+  public static ColumnDeletionMetadata getColumnDeletionMetadata(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String tableNameWithType) {
+    ZNRecord znRecord = getColumnDeletionMetadataZNRecord(propertyStore, tableNameWithType);
+    if (znRecord == null) {
+      return null;
+    }
+    return ColumnDeletionMetadata.fromZNRecord(znRecord);
+  }
+
+  /// Write the ledger with an expected znode version. {@code expectedVersion} of {@code -1} matches any
+  /// version, including create.
+  ///
+  /// @return true if the write succeeded
+  public static boolean writeColumnDeletionMetadata(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      ColumnDeletionMetadata metadata, int expectedVersion) {
+    if (metadata.getFormatVersion() > ColumnDeletionMetadata.CURRENT_FORMAT_VERSION) {
+      throw new ColumnDeletionUnsupportedFormatException(metadata.getFormatVersion(),
+          ColumnDeletionMetadata.CURRENT_FORMAT_VERSION);
+    }
+    String tableNameWithType = metadata.getTableNameWithType();
+    String path = ZKMetadataProvider.constructPropertyStorePathForColumnDeletionMetadata(tableNameWithType);
+    try {
+      boolean result = propertyStore.set(path, metadata.toZNRecord(), expectedVersion, AccessOption.PERSISTENT);
+      if (result) {
+        LOGGER.info("Wrote column deletion metadata for table: {} at expected version: {}", tableNameWithType,
+            expectedVersion);
+      } else {
+        LOGGER.warn("Failed to write column deletion metadata for table: {} at expected version: {}",
+            tableNameWithType, expectedVersion);
+      }
+      return result;
+    } catch (ZkBadVersionException e) {
+      LOGGER.warn("CAS conflict writing column deletion metadata for table: {} at expected version: {}",
+          tableNameWithType, expectedVersion);
+      return false;
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionPhysicalOverride.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionPhysicalOverride.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metadata.columndeletion;
+
+import java.util.Collection;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.OpenStructNaming;
+import org.apache.pinot.spi.data.SchemaDiff;
+
+
+/// Caller-supplied physical column observations for one segment.
+///
+/// 3A never opens segment files. A later stage that can cheaply see physical names
+/// (column metadata, not "missing therefore gone") passes them here. Presence of a
+/// ledger-named column, or of an OPEN_STRUCT child of that column, forces dirty and
+/// overrides {@code ctime}. Missing names prove nothing.
+///
+/// Instances are immutable and thread-safe.
+public final class ColumnDeletionPhysicalOverride {
+  private final Set<String> _presentPhysicalColumns;
+  private final Set<String> _absentPhysicalColumns;
+
+  private ColumnDeletionPhysicalOverride(Set<String> presentPhysicalColumns, Set<String> absentPhysicalColumns) {
+    _presentPhysicalColumns = presentPhysicalColumns;
+    _absentPhysicalColumns = absentPhysicalColumns;
+  }
+
+  /// Presence-only override. Any listed name, or an OPEN_STRUCT child of the deleted column, is dirty.
+  public static ColumnDeletionPhysicalOverride ofPresent(Collection<String> presentPhysicalColumns) {
+    return new ColumnDeletionPhysicalOverride(copyNames(presentPhysicalColumns), Set.of());
+  }
+
+  /// Positive absence proof only. Do not pass "every name we happened to see" and infer the rest.
+  public static ColumnDeletionPhysicalOverride ofAbsent(Collection<String> absentPhysicalColumns) {
+    return new ColumnDeletionPhysicalOverride(Set.of(), copyNames(absentPhysicalColumns));
+  }
+
+  public static ColumnDeletionPhysicalOverride of(Collection<String> presentPhysicalColumns,
+      Collection<String> absentPhysicalColumns) {
+    return new ColumnDeletionPhysicalOverride(copyNames(presentPhysicalColumns), copyNames(absentPhysicalColumns));
+  }
+
+  public Set<String> getPresentPhysicalColumns() {
+    return _presentPhysicalColumns;
+  }
+
+  public Set<String> getAbsentPhysicalColumns() {
+    return _absentPhysicalColumns;
+  }
+
+  /// True when the deleted logical column, or one of its materialized OPEN_STRUCT children, is present.
+  public boolean indicatesPresent(String logicalColumnName, boolean ignoreCase) {
+    for (String present : _presentPhysicalColumns) {
+      if (matchesLogicalColumn(logicalColumnName, present, ignoreCase)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// True only when the caller positively listed the logical column as absent and listed no child of it
+  /// as present.
+  public boolean provesLogicalColumnAbsent(String logicalColumnName, boolean ignoreCase) {
+    if (indicatesPresent(logicalColumnName, ignoreCase)) {
+      return false;
+    }
+    for (String absent : _absentPhysicalColumns) {
+      if (SchemaDiff.columnNamesEqual(logicalColumnName, absent, ignoreCase)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static boolean matchesLogicalColumn(String logicalColumnName, String physicalColumnName, boolean ignoreCase) {
+    if (SchemaDiff.columnNamesEqual(logicalColumnName, physicalColumnName, ignoreCase)) {
+      return true;
+    }
+    if (!OpenStructNaming.isMaterializedOpenStructColumn(physicalColumnName)) {
+      return false;
+    }
+    return SchemaDiff.columnNamesEqual(logicalColumnName, OpenStructNaming.parseParentColumn(physicalColumnName),
+        ignoreCase);
+  }
+
+  private static Set<String> copyNames(@Nullable Collection<String> names) {
+    if (names == null || names.isEmpty()) {
+      return Set.of();
+    }
+    return Set.copyOf(names);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionState.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionState.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metadata.columndeletion;
+
+
+/// Lifecycle of one explicit column deletion on a table.
+///
+/// {@link #PREPARED} exists so the ledger can be written before the schema znode. If the controller
+/// dies in that window, the next scan either aborts the entry (column still present) or advances it
+/// to {@link #RECLAIMING} (schema write already landed). {@link #COMPLETE} is a bounded tombstone
+/// and must not block a legal same-name re-add.
+public enum ColumnDeletionState {
+  PREPARED,
+  PENDING,
+  RECLAIMING,
+  COMPLETE,
+  FAILED;
+
+  /// True when a same-name add must be rejected.
+  public boolean blocksReAdd() {
+    return this != COMPLETE;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionState.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionState.java
@@ -23,8 +23,11 @@ package org.apache.pinot.common.metadata.columndeletion;
 ///
 /// {@link #PREPARED} exists so the ledger can be written before the schema znode. If the controller
 /// dies in that window, the next scan either aborts the entry (column still present) or advances it
-/// to {@link #RECLAIMING} (schema write already landed). {@link #COMPLETE} is a bounded tombstone
-/// and must not block a legal same-name re-add.
+/// to {@link #RECLAIMING} (schema write already landed). {@link #PENDING} means the schema write
+/// landed and reclamation has not started. {@link #FAILED} means a reclaim attempt failed; the
+/// entry still blocks a same-name re-add until an operator or later reconciler moves it to
+/// {@link #COMPLETE}. {@link #COMPLETE} is a bounded tombstone and must not block a legal
+/// same-name re-add.
 public enum ColumnDeletionState {
   PREPARED,
   PENDING,

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionUnsupportedFormatException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionUnsupportedFormatException.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metadata.columndeletion;
+
+
+/// Thrown when a deletion-ledger znode uses a format version this process cannot read or write.
+///
+/// Mixed-version controllers must fail closed rather than clobber a newer record.
+public final class ColumnDeletionUnsupportedFormatException extends IllegalArgumentException {
+  private final int _formatVersion;
+  private final int _supportedFormatVersion;
+
+  public ColumnDeletionUnsupportedFormatException(int formatVersion, int supportedFormatVersion) {
+    super("Column deletion metadata format version " + formatVersion + " is newer than supported version "
+        + supportedFormatVersion);
+    _formatVersion = formatVersion;
+    _supportedFormatVersion = supportedFormatVersion;
+  }
+
+  public int getFormatVersion() {
+    return _formatVersion;
+  }
+
+  public int getSupportedFormatVersion() {
+    return _supportedFormatVersion;
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionDirtySegmentPredicateTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionDirtySegmentPredicateTest.java
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metadata.columndeletion;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class ColumnDeletionDirtySegmentPredicateTest {
+  private static final ColumnDeletionEntry DELETION =
+      new ColumnDeletionEntry("city", "del-1", 1_000L, 3, ColumnDeletionState.RECLAIMING);
+
+  @Test
+  public void testCreationTimeBeforeEpochIsDirty() {
+    SegmentZKMetadata segment = segment("s1", 500L, 99L, Map.of());
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(segment, DELETION, false, null)).isTrue();
+  }
+
+  @Test
+  public void testCreationTimeAtOrAfterEpochIsClean() {
+    SegmentZKMetadata atEpoch = segment("s1", 1_000L, 99L, Map.of());
+    SegmentZKMetadata afterEpoch = segment("s2", 1_001L, 99L, Map.of());
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(atEpoch, DELETION, false, null)).isFalse();
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(afterEpoch, DELETION, false, null)).isFalse();
+  }
+
+  @Test
+  public void testMissingCreationTimeUsesEligibilityTime() {
+    SegmentZKMetadata dirty = segment("s1", -1L, 99L,
+        Map.of(ColumnDeletionDirtySegmentPredicate.ELIGIBILITY_TIME_KEY, "400"));
+    SegmentZKMetadata clean = segment("s2", -1L, 99L,
+        Map.of(ColumnDeletionDirtySegmentPredicate.ELIGIBILITY_TIME_KEY, "1500"));
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(dirty, DELETION, false, null)).isTrue();
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(clean, DELETION, false, null)).isFalse();
+  }
+
+  @Test
+  public void testMissingCreationAndEligibilityIsDirty() {
+    SegmentZKMetadata segment = segment("s1", -1L, 99L, Map.of());
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(segment, DELETION, false, null)).isTrue();
+  }
+
+  @Test
+  public void testRefreshTaskTimeAloneIsNotSuccess() {
+    SegmentZKMetadata segment = segment("s1", 500L, 99L,
+        Map.of(ColumnDeletionDirtySegmentPredicate.REFRESH_SEGMENT_TASK_TIME_KEY, "2000"));
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(segment, DELETION, false, null)).isTrue();
+  }
+
+  @Test
+  public void testMatchingDeletionCrcMarkerIsClean() {
+    SegmentZKMetadata segment = segment("s1", 500L, 42L,
+        Map.of(ColumnDeletionDirtySegmentPredicate.processedCrcKey("del-1"), "42"));
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(segment, DELETION, false, null)).isFalse();
+  }
+
+  @Test
+  public void testMismatchedDeletionCrcMarkerIsDirty() {
+    SegmentZKMetadata segment = segment("s1", 500L, 42L,
+        Map.of(ColumnDeletionDirtySegmentPredicate.processedCrcKey("del-1"), "7"));
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(segment, DELETION, false, null)).isTrue();
+  }
+
+  @Test
+  public void testCrcMarkerWithUnknownCurrentCrcIsDirty() {
+    SegmentZKMetadata segment = segment("s1", 500L, -1L,
+        Map.of(ColumnDeletionDirtySegmentPredicate.processedCrcKey("del-1"), "-1"));
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(segment, DELETION, false, null)).isTrue();
+  }
+
+  @Test
+  public void testPhysicalAbsenceProofIsClean() {
+    SegmentZKMetadata segment = segment("s1", 500L, 99L, Map.of());
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(segment, DELETION, false, Set.of("city"))).isFalse();
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(segment, DELETION, false, Set.of("other"))).isTrue();
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(segment, DELETION, true, Set.of("CITY"))).isFalse();
+  }
+
+  @Test
+  public void testFindDirtySegmentNamesSkipsReplacedAndComplete() {
+    SegmentZKMetadata dirty = segment("dirty", 100L, 1L, Map.of());
+    SegmentZKMetadata cleanNew = segment("newSeg", 5_000L, 1L, Map.of());
+    SegmentZKMetadata cleaned = segment("cleaned", 100L, 9L,
+        Map.of(ColumnDeletionDirtySegmentPredicate.processedCrcKey("del-1"), "9"));
+
+    ColumnDeletionMetadata metadata = new ColumnDeletionMetadata("foo_OFFLINE");
+    metadata.addEntry(DELETION);
+    metadata.addEntry(new ColumnDeletionEntry("zip", "del-2", 1_000L, 3, ColumnDeletionState.COMPLETE));
+
+    List<String> dirtyNames =
+        ColumnDeletionDirtySegmentPredicate.findDirtySegmentNames(List.of(dirty, cleanNew, cleaned), metadata, false,
+            null);
+    assertThat(dirtyNames).containsExactly("dirty");
+  }
+
+  @Test
+  public void testUnionAcrossActiveDeletions() {
+    SegmentZKMetadata cityDirty = segment("s1", 100L, 1L, Map.of());
+    SegmentZKMetadata zipDirty = segment("s2", 100L, 1L,
+        Map.of(ColumnDeletionDirtySegmentPredicate.processedCrcKey("del-1"), "1"));
+
+    ColumnDeletionMetadata metadata = new ColumnDeletionMetadata("foo_OFFLINE");
+    metadata.addEntry(DELETION);
+    metadata.addEntry(new ColumnDeletionEntry("zip", "del-2", 1_000L, 3, ColumnDeletionState.FAILED));
+
+    List<String> dirtyNames =
+        ColumnDeletionDirtySegmentPredicate.findDirtySegmentNames(List.of(cityDirty, zipDirty), metadata, false, null);
+    assertThat(dirtyNames).containsExactly("s1", "s2");
+  }
+
+  @Test
+  public void testProvenAbsenceBySegment() {
+    SegmentZKMetadata s1 = segment("s1", 100L, 1L, Map.of());
+    SegmentZKMetadata s2 = segment("s2", 100L, 1L, Map.of());
+    Map<String, Set<String>> proven = Map.of("s1", Set.of("city"));
+
+    List<String> dirtyNames =
+        ColumnDeletionDirtySegmentPredicate.findDirtySegmentNames(List.of(s1, s2), DELETION, false, proven);
+    assertThat(dirtyNames).containsExactly("s2");
+  }
+
+  private static SegmentZKMetadata segment(String name, long creationTime, long crc, Map<String, String> customMap) {
+    SegmentZKMetadata metadata = new SegmentZKMetadata(name);
+    if (creationTime >= 0) {
+      metadata.setCreationTime(creationTime);
+    }
+    if (crc >= 0) {
+      metadata.setCrc(crc);
+    }
+    if (!customMap.isEmpty()) {
+      metadata.setCustomMap(new HashMap<>(customMap));
+    }
+    return metadata;
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionDirtySegmentPredicateTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionDirtySegmentPredicateTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.spi.data.OpenStructNaming;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,11 +40,44 @@ public class ColumnDeletionDirtySegmentPredicateTest {
   }
 
   @Test
-  public void testCreationTimeAtOrAfterEpochIsClean() {
+  public void testCreationTimeAtOrAfterEpochIsCleanWithoutPresence() {
     SegmentZKMetadata atEpoch = segment("s1", 1_000L, 99L, Map.of());
     SegmentZKMetadata afterEpoch = segment("s2", 1_001L, 99L, Map.of());
     assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(atEpoch, DELETION, false, null)).isFalse();
     assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(afterEpoch, DELETION, false, null)).isFalse();
+  }
+
+  @Test
+  public void testPhysicalPresenceOverridesCtime() {
+    SegmentZKMetadata afterEpoch = segment("s2", 1_001L, 99L, Map.of());
+    ColumnDeletionPhysicalOverride present = ColumnDeletionPhysicalOverride.ofPresent(Set.of("city"));
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(afterEpoch, DELETION, false, present)).isTrue();
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(afterEpoch, DELETION, true,
+        ColumnDeletionPhysicalOverride.ofPresent(Set.of("CITY")))).isTrue();
+  }
+
+  @Test
+  public void testPhysicalPresenceOfOpenStructChildOverridesCtime() {
+    ColumnDeletionEntry structDeletion =
+        new ColumnDeletionEntry("payload", "del-struct", 1_000L, 3, ColumnDeletionState.RECLAIMING);
+    SegmentZKMetadata afterEpoch = segment("s2", 5_000L, 99L, Map.of());
+    ColumnDeletionPhysicalOverride childPresent = ColumnDeletionPhysicalOverride.ofPresent(
+        Set.of(OpenStructNaming.materializedColumnName("payload", "userId")));
+    ColumnDeletionPhysicalOverride sparsePresent = ColumnDeletionPhysicalOverride.ofPresent(
+        Set.of(OpenStructNaming.sparseColumnName("payload")));
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(afterEpoch, structDeletion, false, childPresent)).isTrue();
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(afterEpoch, structDeletion, false, sparsePresent)).isTrue();
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(afterEpoch, structDeletion, false,
+        ColumnDeletionPhysicalOverride.ofPresent(Set.of("other$col")))).isFalse();
+  }
+
+  @Test
+  public void testPhysicalPresenceOverridesCrcMarker() {
+    SegmentZKMetadata marked = segment("s1", 500L, 42L,
+        Map.of(ColumnDeletionDirtySegmentPredicate.processedCrcKey("del-1"), "42"));
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(marked, DELETION, false, null)).isFalse();
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(marked, DELETION, false,
+        ColumnDeletionPhysicalOverride.ofPresent(Set.of("city")))).isTrue();
   }
 
   @Test
@@ -91,11 +125,34 @@ public class ColumnDeletionDirtySegmentPredicateTest {
   }
 
   @Test
-  public void testPhysicalAbsenceProofIsClean() {
+  public void testPositiveAbsenceProofIsClean() {
     SegmentZKMetadata segment = segment("s1", 500L, 99L, Map.of());
-    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(segment, DELETION, false, Set.of("city"))).isFalse();
-    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(segment, DELETION, false, Set.of("other"))).isTrue();
-    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(segment, DELETION, true, Set.of("CITY"))).isFalse();
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(segment, DELETION, false,
+        ColumnDeletionPhysicalOverride.ofAbsent(Set.of("city")))).isFalse();
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(segment, DELETION, false,
+        ColumnDeletionPhysicalOverride.ofAbsent(Set.of("other")))).isTrue();
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(segment, DELETION, true,
+        ColumnDeletionPhysicalOverride.ofAbsent(Set.of("CITY")))).isFalse();
+  }
+
+  @Test
+  public void testPresenceWinsOverAbsence() {
+    SegmentZKMetadata segment = segment("s1", 5_000L, 99L, Map.of());
+    ColumnDeletionPhysicalOverride both =
+        ColumnDeletionPhysicalOverride.of(Set.of("city"), Set.of("city"));
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(segment, DELETION, false, both)).isTrue();
+  }
+
+  @Test
+  public void testEmptyLiveSetIsNotComplete() {
+    ColumnDeletionMetadata metadata = new ColumnDeletionMetadata("foo_OFFLINE");
+    metadata.addEntry(DELETION);
+
+    List<String> dirtyNames =
+        ColumnDeletionDirtySegmentPredicate.findDirtySegmentNames(List.of(), metadata, false, null);
+    assertThat(dirtyNames).isEmpty();
+    assertThat(metadata.getEntry("del-1").getState()).isEqualTo(ColumnDeletionState.RECLAIMING);
+    assertThat(metadata.blocksReAdd("city", false)).isTrue();
   }
 
   @Test
@@ -131,14 +188,16 @@ public class ColumnDeletionDirtySegmentPredicateTest {
   }
 
   @Test
-  public void testProvenAbsenceBySegment() {
-    SegmentZKMetadata s1 = segment("s1", 100L, 1L, Map.of());
-    SegmentZKMetadata s2 = segment("s2", 100L, 1L, Map.of());
-    Map<String, Set<String>> proven = Map.of("s1", Set.of("city"));
+  public void testPresenceOverrideBySegment() {
+    SegmentZKMetadata postEpoch = segment("s1", 5_000L, 1L, Map.of());
+    SegmentZKMetadata alsoPostEpoch = segment("s2", 5_000L, 1L, Map.of());
+    Map<String, ColumnDeletionPhysicalOverride> overrides =
+        Map.of("s1", ColumnDeletionPhysicalOverride.ofPresent(Set.of("city")));
 
     List<String> dirtyNames =
-        ColumnDeletionDirtySegmentPredicate.findDirtySegmentNames(List.of(s1, s2), DELETION, false, proven);
-    assertThat(dirtyNames).containsExactly("s2");
+        ColumnDeletionDirtySegmentPredicate.findDirtySegmentNames(List.of(postEpoch, alsoPostEpoch), DELETION, false,
+            overrides);
+    assertThat(dirtyNames).containsExactly("s1");
   }
 
   private static SegmentZKMetadata segment(String name, long creationTime, long crc, Map<String, String> customMap) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionDirtySegmentPredicateTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionDirtySegmentPredicateTest.java
@@ -27,6 +27,7 @@ import org.apache.pinot.spi.data.OpenStructNaming;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 public class ColumnDeletionDirtySegmentPredicateTest {
@@ -40,10 +41,14 @@ public class ColumnDeletionDirtySegmentPredicateTest {
   }
 
   @Test
-  public void testCreationTimeAtOrAfterEpochIsCleanWithoutPresence() {
+  public void testCreationTimeAtEpochIsDirtyWithoutPresence() {
     SegmentZKMetadata atEpoch = segment("s1", 1_000L, 99L, Map.of());
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(atEpoch, DELETION, false, null)).isTrue();
+  }
+
+  @Test
+  public void testCreationTimeAfterEpochIsCleanWithoutPresence() {
     SegmentZKMetadata afterEpoch = segment("s2", 1_001L, 99L, Map.of());
-    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(atEpoch, DELETION, false, null)).isFalse();
     assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(afterEpoch, DELETION, false, null)).isFalse();
   }
 
@@ -84,10 +89,23 @@ public class ColumnDeletionDirtySegmentPredicateTest {
   public void testMissingCreationTimeUsesEligibilityTime() {
     SegmentZKMetadata dirty = segment("s1", -1L, 99L,
         Map.of(ColumnDeletionDirtySegmentPredicate.ELIGIBILITY_TIME_KEY, "400"));
+    SegmentZKMetadata atEpoch = segment("sAt", -1L, 99L,
+        Map.of(ColumnDeletionDirtySegmentPredicate.ELIGIBILITY_TIME_KEY, "1000"));
     SegmentZKMetadata clean = segment("s2", -1L, 99L,
         Map.of(ColumnDeletionDirtySegmentPredicate.ELIGIBILITY_TIME_KEY, "1500"));
     assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(dirty, DELETION, false, null)).isTrue();
+    assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(atEpoch, DELETION, false, null)).isTrue();
     assertThat(ColumnDeletionDirtySegmentPredicate.isDirty(clean, DELETION, false, null)).isFalse();
+  }
+
+  @Test
+  public void testInvalidEligibilityTimeIncludesSegmentName() {
+    SegmentZKMetadata segment = segment("badSeg", -1L, 99L,
+        Map.of(ColumnDeletionDirtySegmentPredicate.ELIGIBILITY_TIME_KEY, "not-a-number"));
+    assertThatThrownBy(() -> ColumnDeletionDirtySegmentPredicate.isDirty(segment, DELETION, false, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("badSeg")
+        .hasMessageContaining(ColumnDeletionDirtySegmentPredicate.ELIGIBILITY_TIME_KEY);
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelperTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelperTest.java
@@ -1,0 +1,212 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metadata.columndeletion;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.helix.AccessOption;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.zkclient.exception.ZkBadVersionException;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.zookeeper.data.Stat;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class ColumnDeletionMetadataAccessHelperTest {
+  private static final String TABLE = "foo_OFFLINE";
+  private static final String PATH = ZKMetadataProvider.constructPropertyStorePathForColumnDeletionMetadata(TABLE);
+
+  @Test
+  public void testMissingZnodeReturnsNull() {
+    InMemoryLedgerStore store = new InMemoryLedgerStore();
+    assertThat(ColumnDeletionMetadataAccessHelper.getColumnDeletionMetadata(store.propertyStore(), TABLE)).isNull();
+  }
+
+  @Test
+  public void testCreateThenRead() {
+    InMemoryLedgerStore store = new InMemoryLedgerStore();
+    ColumnDeletionMetadata metadata = new ColumnDeletionMetadata(TABLE);
+    metadata.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 5, ColumnDeletionState.PREPARED));
+
+    assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), metadata, -1))
+        .isTrue();
+    assertThat(store.version()).isEqualTo(0);
+
+    ZNRecord znRecord = ColumnDeletionMetadataAccessHelper.getColumnDeletionMetadataZNRecord(store.propertyStore(),
+        TABLE);
+    assertThat(znRecord.getVersion()).isEqualTo(0);
+    ColumnDeletionMetadata decoded =
+        ColumnDeletionMetadataAccessHelper.getColumnDeletionMetadata(store.propertyStore(), TABLE);
+    assertThat(decoded.getEntry("del-1").getState()).isEqualTo(ColumnDeletionState.PREPARED);
+    assertThat(decoded.getEntry("del-1").getDeletionEpochMs()).isEqualTo(1000L);
+  }
+
+  @Test
+  public void testCasSuccessAndConflict() {
+    InMemoryLedgerStore store = new InMemoryLedgerStore();
+    ColumnDeletionMetadata metadata = new ColumnDeletionMetadata(TABLE);
+    metadata.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 5, ColumnDeletionState.PREPARED));
+    assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), metadata, -1))
+        .isTrue();
+
+    ColumnDeletionMetadata firstReader =
+        ColumnDeletionMetadataAccessHelper.getColumnDeletionMetadata(store.propertyStore(), TABLE);
+    firstReader.updateEntry(firstReader.getEntry("del-1").withState(ColumnDeletionState.RECLAIMING));
+    assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), firstReader, 0))
+        .isTrue();
+    assertThat(store.version()).isEqualTo(1);
+
+    ColumnDeletionMetadata staleWriter = new ColumnDeletionMetadata(TABLE);
+    staleWriter.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 5, ColumnDeletionState.FAILED));
+    assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), staleWriter, 0))
+        .isFalse();
+
+    ColumnDeletionMetadata current =
+        ColumnDeletionMetadataAccessHelper.getColumnDeletionMetadata(store.propertyStore(), TABLE);
+    assertThat(current.getEntry("del-1").getState()).isEqualTo(ColumnDeletionState.RECLAIMING);
+    assertThat(current.getEntry("del-1").getDeletionEpochMs()).isEqualTo(1000L);
+  }
+
+  @Test
+  public void testRestartReconcilesPrepared() {
+    InMemoryLedgerStore store = new InMemoryLedgerStore();
+    ColumnDeletionMetadata prepared = new ColumnDeletionMetadata(TABLE);
+    prepared.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 5, ColumnDeletionState.PREPARED));
+    assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), prepared, -1))
+        .isTrue();
+
+    // Crash after PREPARED. Schema write landed, so the column is already absent.
+    ColumnDeletionMetadata afterRestart =
+        ColumnDeletionMetadataAccessHelper.getColumnDeletionMetadata(store.propertyStore(), TABLE);
+    afterRestart.reconcilePreparedEntry("del-1", false);
+    ZNRecord znRecord = ColumnDeletionMetadataAccessHelper.getColumnDeletionMetadataZNRecord(store.propertyStore(),
+        TABLE);
+    assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), afterRestart,
+        znRecord.getVersion())).isTrue();
+
+    ColumnDeletionMetadata recovered =
+        ColumnDeletionMetadataAccessHelper.getColumnDeletionMetadata(store.propertyStore(), TABLE);
+    assertThat(recovered.getEntry("del-1").getState()).isEqualTo(ColumnDeletionState.RECLAIMING);
+    assertThat(recovered.blocksReAdd("city", false)).isTrue();
+  }
+
+  @Test
+  public void testRestartAbortsPreparedWhenSchemaUnchanged() {
+    InMemoryLedgerStore store = new InMemoryLedgerStore();
+    ColumnDeletionMetadata prepared = new ColumnDeletionMetadata(TABLE);
+    prepared.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 5, ColumnDeletionState.PREPARED));
+    assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), prepared, -1))
+        .isTrue();
+
+    ColumnDeletionMetadata afterRestart =
+        ColumnDeletionMetadataAccessHelper.getColumnDeletionMetadata(store.propertyStore(), TABLE);
+    afterRestart.reconcilePreparedEntry("del-1", true);
+    ZNRecord znRecord = ColumnDeletionMetadataAccessHelper.getColumnDeletionMetadataZNRecord(store.propertyStore(),
+        TABLE);
+    assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), afterRestart,
+        znRecord.getVersion())).isTrue();
+
+    ColumnDeletionMetadata recovered =
+        ColumnDeletionMetadataAccessHelper.getColumnDeletionMetadata(store.propertyStore(), TABLE);
+    assertThat(recovered.getEntry("del-1")).isNull();
+    assertThat(recovered.blocksReAdd("city", false)).isFalse();
+  }
+
+  @Test
+  public void testWriteRefusesNewerInMemoryFormat() {
+    InMemoryLedgerStore store = new InMemoryLedgerStore();
+    ColumnDeletionMetadata newer =
+        new ColumnDeletionMetadata(TABLE, ColumnDeletionMetadata.CURRENT_FORMAT_VERSION + 1, Map.of());
+    assertThatThrownBy(
+        () -> ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), newer, -1))
+        .isInstanceOf(ColumnDeletionUnsupportedFormatException.class);
+    assertThat(store.record()).isNull();
+  }
+
+  @Test
+  public void testReadRefusesNewerStoredFormat() {
+    InMemoryLedgerStore store = new InMemoryLedgerStore();
+    ZNRecord newer = new ZNRecord(TABLE);
+    newer.setSimpleField("formatVersion", Integer.toString(ColumnDeletionMetadata.CURRENT_FORMAT_VERSION + 1));
+    store.seed(newer);
+
+    assertThatThrownBy(
+        () -> ColumnDeletionMetadataAccessHelper.getColumnDeletionMetadata(store.propertyStore(), TABLE))
+        .isInstanceOf(ColumnDeletionUnsupportedFormatException.class);
+  }
+
+  /// Minimal PropertyStore stand-in that versions a single ledger znode.
+  private static final class InMemoryLedgerStore {
+    private final AtomicReference<ZNRecord> _record = new AtomicReference<>();
+    private final AtomicInteger _version = new AtomicInteger(-1);
+    private final ZkHelixPropertyStore<ZNRecord> _propertyStore = mockPropertyStore();
+
+    @SuppressWarnings("unchecked")
+    private ZkHelixPropertyStore<ZNRecord> mockPropertyStore() {
+      ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+      when(propertyStore.get(eq(PATH), any(Stat.class), eq(AccessOption.PERSISTENT))).thenAnswer(invocation -> {
+        Stat stat = invocation.getArgument(1);
+        ZNRecord record = _record.get();
+        if (record != null && stat != null) {
+          stat.setVersion(_version.get());
+        }
+        return record;
+      });
+      when(propertyStore.set(eq(PATH), any(ZNRecord.class), anyInt(), eq(AccessOption.PERSISTENT))).thenAnswer(
+          invocation -> {
+            int expectedVersion = invocation.getArgument(2);
+            int currentVersion = _version.get();
+            if (expectedVersion != -1 && expectedVersion != currentVersion) {
+              throw new ZkBadVersionException("expected " + expectedVersion + " but was " + currentVersion);
+            }
+            _record.set(invocation.getArgument(1));
+            _version.set(currentVersion < 0 ? 0 : currentVersion + 1);
+            return true;
+          });
+      return propertyStore;
+    }
+
+    ZkHelixPropertyStore<ZNRecord> propertyStore() {
+      return _propertyStore;
+    }
+
+    int version() {
+      return _version.get();
+    }
+
+    ZNRecord record() {
+      return _record.get();
+    }
+
+    void seed(ZNRecord record) {
+      _record.set(record);
+      _version.set(0);
+    }
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelperTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelperTest.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -161,6 +162,25 @@ public class ColumnDeletionMetadataAccessHelperTest {
         .isInstanceOf(ColumnDeletionUnsupportedFormatException.class);
   }
 
+  @Test
+  public void testWriteWildcardVersionDoesNotClobberNewerStoredFormat() {
+    InMemoryLedgerStore store = new InMemoryLedgerStore();
+    ZNRecord newer = new ZNRecord(TABLE);
+    newer.setSimpleField("formatVersion", Integer.toString(ColumnDeletionMetadata.CURRENT_FORMAT_VERSION + 1));
+    newer.setSimpleField("futureField", "keep-me");
+    store.seed(newer);
+
+    ColumnDeletionMetadata v1 = new ColumnDeletionMetadata(TABLE);
+    v1.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 5, ColumnDeletionState.PREPARED));
+    assertThatThrownBy(
+        () -> ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), v1, -1))
+        .isInstanceOf(ColumnDeletionUnsupportedFormatException.class);
+    assertThat(store.record().getSimpleField("formatVersion")).isEqualTo(
+        Integer.toString(ColumnDeletionMetadata.CURRENT_FORMAT_VERSION + 1));
+    assertThat(store.record().getSimpleField("futureField")).isEqualTo("keep-me");
+    assertThat(store.version()).isEqualTo(0);
+  }
+
   /// Minimal PropertyStore stand-in that versions a single ledger znode.
   private static final class InMemoryLedgerStore {
     private final AtomicReference<ZNRecord> _record = new AtomicReference<>();
@@ -170,13 +190,21 @@ public class ColumnDeletionMetadataAccessHelperTest {
     @SuppressWarnings("unchecked")
     private ZkHelixPropertyStore<ZNRecord> mockPropertyStore() {
       ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
-      when(propertyStore.get(eq(PATH), any(Stat.class), eq(AccessOption.PERSISTENT))).thenAnswer(invocation -> {
+      when(propertyStore.get(eq(PATH), nullable(Stat.class), eq(AccessOption.PERSISTENT))).thenAnswer(invocation -> {
         Stat stat = invocation.getArgument(1);
         ZNRecord record = _record.get();
         if (record != null && stat != null) {
           stat.setVersion(_version.get());
         }
         return record;
+      });
+      when(propertyStore.create(eq(PATH), any(ZNRecord.class), eq(AccessOption.PERSISTENT))).thenAnswer(invocation -> {
+        if (_record.get() != null) {
+          return false;
+        }
+        _record.set(invocation.getArgument(1));
+        _version.set(0);
+        return true;
       });
       when(propertyStore.set(eq(PATH), any(ZNRecord.class), anyInt(), eq(AccessOption.PERSISTENT))).thenAnswer(
           invocation -> {

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelperTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelperTest.java
@@ -163,6 +163,50 @@ public class ColumnDeletionMetadataAccessHelperTest {
   }
 
   @Test
+  public void testWriteSpecificVersionOnMissingZnodeReturnsFalse() {
+    InMemoryLedgerStore store = new InMemoryLedgerStore();
+    ColumnDeletionMetadata metadata = new ColumnDeletionMetadata(TABLE);
+    metadata.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 5, ColumnDeletionState.PREPARED));
+    assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), metadata, 0))
+        .isFalse();
+    assertThat(store.record()).isNull();
+  }
+
+  @Test
+  public void testWriteWildcardVersionOnExistingCurrentFormatUsesObservedVersion() {
+    InMemoryLedgerStore store = new InMemoryLedgerStore();
+    ColumnDeletionMetadata created = new ColumnDeletionMetadata(TABLE);
+    created.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 5, ColumnDeletionState.PREPARED));
+    assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), created, -1))
+        .isTrue();
+
+    ColumnDeletionMetadata updated = new ColumnDeletionMetadata(TABLE);
+    updated.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 5, ColumnDeletionState.RECLAIMING));
+    assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), updated, -1))
+        .isTrue();
+    assertThat(store.version()).isEqualTo(1);
+    assertThat(ColumnDeletionMetadataAccessHelper.getColumnDeletionMetadata(store.propertyStore(), TABLE)
+        .getEntry("del-1").getState()).isEqualTo(ColumnDeletionState.RECLAIMING);
+  }
+
+  @Test
+  public void testWriteWildcardVersionLosesCasWhenVersionMoves() {
+    InMemoryLedgerStore store = new InMemoryLedgerStore();
+    ColumnDeletionMetadata created = new ColumnDeletionMetadata(TABLE);
+    created.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 5, ColumnDeletionState.PREPARED));
+    assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), created, -1))
+        .isTrue();
+
+    store.bumpVersionAfterNextGet();
+    ColumnDeletionMetadata updated = new ColumnDeletionMetadata(TABLE);
+    updated.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 5, ColumnDeletionState.RECLAIMING));
+    assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), updated, -1))
+        .isFalse();
+    assertThat(ColumnDeletionMetadata.fromZNRecord(store.record()).getEntry("del-1").getState()).isEqualTo(
+        ColumnDeletionState.PREPARED);
+  }
+
+  @Test
   public void testWriteWildcardVersionDoesNotClobberNewerStoredFormat() {
     InMemoryLedgerStore store = new InMemoryLedgerStore();
     ZNRecord newer = new ZNRecord(TABLE);
@@ -185,6 +229,7 @@ public class ColumnDeletionMetadataAccessHelperTest {
   private static final class InMemoryLedgerStore {
     private final AtomicReference<ZNRecord> _record = new AtomicReference<>();
     private final AtomicInteger _version = new AtomicInteger(-1);
+    private final AtomicInteger _bumpAfterGet = new AtomicInteger(0);
     private final ZkHelixPropertyStore<ZNRecord> _propertyStore = mockPropertyStore();
 
     @SuppressWarnings("unchecked")
@@ -195,6 +240,9 @@ public class ColumnDeletionMetadataAccessHelperTest {
         ZNRecord record = _record.get();
         if (record != null && stat != null) {
           stat.setVersion(_version.get());
+        }
+        if (record != null && _bumpAfterGet.getAndSet(0) > 0) {
+          _version.incrementAndGet();
         }
         return record;
       });
@@ -235,6 +283,10 @@ public class ColumnDeletionMetadataAccessHelperTest {
     void seed(ZNRecord record) {
       _record.set(record);
       _version.set(0);
+    }
+
+    void bumpVersionAfterNextGet() {
+      _bumpAfterGet.set(1);
     }
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelperTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelperTest.java
@@ -173,24 +173,24 @@ public class ColumnDeletionMetadataAccessHelperTest {
   }
 
   @Test
-  public void testWriteWildcardVersionOnExistingCurrentFormatUsesObservedVersion() {
+  public void testWriteWildcardVersionOnExistingZnodeIsCreateOnly() {
     InMemoryLedgerStore store = new InMemoryLedgerStore();
     ColumnDeletionMetadata created = new ColumnDeletionMetadata(TABLE);
     created.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 5, ColumnDeletionState.PREPARED));
     assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), created, -1))
         .isTrue();
 
-    ColumnDeletionMetadata updated = new ColumnDeletionMetadata(TABLE);
-    updated.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 5, ColumnDeletionState.RECLAIMING));
-    assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), updated, -1))
-        .isTrue();
-    assertThat(store.version()).isEqualTo(1);
+    ColumnDeletionMetadata staleRetry = new ColumnDeletionMetadata(TABLE);
+    staleRetry.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 5, ColumnDeletionState.PREPARED));
+    assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), staleRetry, -1))
+        .isFalse();
+    assertThat(store.version()).isEqualTo(0);
     assertThat(ColumnDeletionMetadataAccessHelper.getColumnDeletionMetadata(store.propertyStore(), TABLE)
-        .getEntry("del-1").getState()).isEqualTo(ColumnDeletionState.RECLAIMING);
+        .getEntry("del-1").getState()).isEqualTo(ColumnDeletionState.PREPARED);
   }
 
   @Test
-  public void testWriteWildcardVersionLosesCasWhenVersionMoves() {
+  public void testWriteLosesCasWhenVersionMoves() {
     InMemoryLedgerStore store = new InMemoryLedgerStore();
     ColumnDeletionMetadata created = new ColumnDeletionMetadata(TABLE);
     created.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 5, ColumnDeletionState.PREPARED));
@@ -200,7 +200,7 @@ public class ColumnDeletionMetadataAccessHelperTest {
     store.bumpVersionAfterNextGet();
     ColumnDeletionMetadata updated = new ColumnDeletionMetadata(TABLE);
     updated.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 5, ColumnDeletionState.RECLAIMING));
-    assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), updated, -1))
+    assertThat(ColumnDeletionMetadataAccessHelper.writeColumnDeletionMetadata(store.propertyStore(), updated, 0))
         .isFalse();
     assertThat(ColumnDeletionMetadata.fromZNRecord(store.record()).getEntry("del-1").getState()).isEqualTo(
         ColumnDeletionState.PREPARED);

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataTest.java
@@ -237,6 +237,78 @@ public class ColumnDeletionMetadataTest {
   }
 
   @Test
+  public void testSecondActiveEntryForSameColumnRejected() {
+    ColumnDeletionMetadata metadata = new ColumnDeletionMetadata("foo_OFFLINE");
+    metadata.addEntry(new ColumnDeletionEntry("city", "del-1", 1L, 0, ColumnDeletionState.RECLAIMING));
+    assertThatThrownBy(
+        () -> metadata.addEntry(new ColumnDeletionEntry("city", "del-2", 2L, 1, ColumnDeletionState.PREPARED)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("city");
+  }
+
+  @Test
+  public void testCompleteTombstoneAllowsNewActiveEntryForSameColumn() {
+    ColumnDeletionMetadata metadata = new ColumnDeletionMetadata("foo_OFFLINE");
+    metadata.addEntry(new ColumnDeletionEntry("city", "del-1", 1L, 0, ColumnDeletionState.COMPLETE));
+    metadata.addEntry(new ColumnDeletionEntry("city", "del-2", 2L, 1, ColumnDeletionState.PREPARED));
+    assertThat(metadata.findActiveEntryForColumn("city", false).getDeletionId()).isEqualTo("del-2");
+    assertThat(metadata.getEntry("del-1").getState()).isEqualTo(ColumnDeletionState.COMPLETE);
+  }
+
+  @Test
+  public void testAddEntryIgnoreCaseRejectsCaseVariantActiveName() {
+    ColumnDeletionMetadata metadata = new ColumnDeletionMetadata("foo_OFFLINE");
+    metadata.addEntry(new ColumnDeletionEntry("City", "del-1", 1L, 0, ColumnDeletionState.PENDING));
+    assertThatThrownBy(
+        () -> metadata.addEntry(new ColumnDeletionEntry("city", "del-2", 2L, 1, ColumnDeletionState.PREPARED), true))
+        .isInstanceOf(IllegalArgumentException.class);
+    metadata.addEntry(new ColumnDeletionEntry("city", "del-2", 2L, 1, ColumnDeletionState.PREPARED), false);
+    assertThat(metadata.getEntry("del-2").getColumnName()).isEqualTo("city");
+  }
+
+  @Test
+  public void testFromZNRecordRejectsDuplicateExactActiveNames() {
+    ZNRecord record = new ZNRecord("foo_OFFLINE");
+    record.setSimpleField("formatVersion", "1");
+    record.setMapField("del-1", activeFields("city", "del-1", "RECLAIMING"));
+    record.setMapField("del-2", activeFields("city", "del-2", "FAILED"));
+
+    assertThatThrownBy(() -> ColumnDeletionMetadata.fromZNRecord(record)).isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("city");
+  }
+
+  @Test
+  public void testFromZNRecordAllowsCompletePlusActiveSameName() {
+    ZNRecord record = new ZNRecord("foo_OFFLINE");
+    record.setSimpleField("formatVersion", "1");
+    record.setMapField("del-1", activeFields("city", "del-1", "COMPLETE"));
+    record.setMapField("del-2", activeFields("city", "del-2", "PREPARED"));
+
+    ColumnDeletionMetadata metadata = ColumnDeletionMetadata.fromZNRecord(record);
+    assertThat(metadata.getEntry("del-1").getState()).isEqualTo(ColumnDeletionState.COMPLETE);
+    assertThat(metadata.getEntry("del-2").getState()).isEqualTo(ColumnDeletionState.PREPARED);
+  }
+
+  @Test
+  public void testWithSchemaZkMtimeMsPreservesEpoch() {
+    ColumnDeletionEntry original = new ColumnDeletionEntry("city", "del-1", 1000L, 3, ColumnDeletionState.PREPARED);
+    ColumnDeletionEntry updated = original.withSchemaZkMtimeMs(2_000L);
+    assertThat(updated.getSchemaZkMtimeMs()).isEqualTo(2_000L);
+    assertThat(updated.getDeletionEpochMs()).isEqualTo(1000L);
+    assertThat(updated.getSchemaZkVersion()).isEqualTo(3);
+  }
+
+  private static Map<String, String> activeFields(String columnName, String deletionId, String state) {
+    Map<String, String> fields = new HashMap<>();
+    fields.put("columnName", columnName);
+    fields.put("deletionId", deletionId);
+    fields.put("deletionEpochMs", "1");
+    fields.put("schemaZkVersion", "1");
+    fields.put("state", state);
+    return fields;
+  }
+
+  @Test
   public void testNewDeletionIdIsUnique() {
     assertThat(ColumnDeletionMetadata.newDeletionId()).isNotEqualTo(ColumnDeletionMetadata.newDeletionId());
   }

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataTest.java
@@ -1,0 +1,243 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metadata.columndeletion;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+public class ColumnDeletionMetadataTest {
+
+  @Test
+  public void testPropertyStorePath() {
+    assertThat(ZKMetadataProvider.getPropertyStorePathForColumnDeletionMetadataPrefix())
+        .isEqualTo("/COLUMN_DELETION_METADATA");
+    assertThat(ZKMetadataProvider.constructPropertyStorePathForColumnDeletionMetadata("foo_OFFLINE"))
+        .isEqualTo("/COLUMN_DELETION_METADATA/foo_OFFLINE");
+    assertThat(ZKMetadataProvider.constructPropertyStorePathForColumnDeletionMetadata("foo_REALTIME"))
+        .isEqualTo("/COLUMN_DELETION_METADATA/foo_REALTIME");
+  }
+
+  @Test
+  public void testEmptyLedgerRoundTrip() {
+    ColumnDeletionMetadata metadata = new ColumnDeletionMetadata("foo_OFFLINE");
+    ColumnDeletionMetadata decoded = ColumnDeletionMetadata.fromZNRecord(metadata.toZNRecord());
+    assertThat(decoded).isEqualTo(metadata);
+    assertThat(decoded.getFormatVersion()).isEqualTo(ColumnDeletionMetadata.CURRENT_FORMAT_VERSION);
+    assertThat(decoded.getEntries()).isEmpty();
+    assertThat(decoded.getActiveDeletedColumnNames(false)).isEmpty();
+  }
+
+  @Test
+  public void testRoundTripPreservesImmutableEpoch() {
+    ColumnDeletionMetadata metadata = new ColumnDeletionMetadata("foo_OFFLINE");
+    ColumnDeletionEntry entry =
+        new ColumnDeletionEntry("city", "del-1", 1_700_000_000_000L, 7, 1_700_000_000_100L,
+            ColumnDeletionState.RECLAIMING, "refresh timed out", 3);
+    metadata.addEntry(entry);
+
+    ColumnDeletionMetadata decoded = ColumnDeletionMetadata.fromZNRecord(metadata.toZNRecord());
+    ColumnDeletionEntry decodedEntry = decoded.getEntry("del-1");
+    assertThat(decodedEntry).isEqualTo(entry);
+    assertThat(decodedEntry.getDeletionEpochMs()).isEqualTo(1_700_000_000_000L);
+    assertThat(decodedEntry.getSchemaZkVersion()).isEqualTo(7);
+    assertThat(decodedEntry.getSchemaZkMtimeMs()).isEqualTo(1_700_000_000_100L);
+    assertThat(decodedEntry.getLastError()).isEqualTo("refresh timed out");
+    assertThat(decodedEntry.getOutstandingSegmentCount()).isEqualTo(3);
+  }
+
+  @Test
+  public void testProgressUpdateDoesNotChangeEpoch() {
+    ColumnDeletionEntry original =
+        new ColumnDeletionEntry("city", "del-1", 1000L, 3, ColumnDeletionState.RECLAIMING);
+    ColumnDeletionEntry updated = original.withLastError("minion gone").withOutstandingSegmentCount(12);
+
+    assertThat(updated.getDeletionEpochMs()).isEqualTo(1000L);
+    assertThat(updated.getSchemaZkVersion()).isEqualTo(3);
+    assertThat(updated.getColumnName()).isEqualTo("city");
+    assertThat(updated.getLastError()).isEqualTo("minion gone");
+    assertThat(updated.getOutstandingSegmentCount()).isEqualTo(12);
+  }
+
+  @Test
+  public void testMultipleDeletionsAndReAddGate() {
+    ColumnDeletionMetadata metadata = new ColumnDeletionMetadata("foo_OFFLINE");
+    metadata.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 1, ColumnDeletionState.RECLAIMING));
+    metadata.addEntry(new ColumnDeletionEntry("zip", "del-2", 2000L, 2, ColumnDeletionState.COMPLETE));
+    metadata.addEntry(new ColumnDeletionEntry("oldCol", "del-3", 3000L, 3, ColumnDeletionState.FAILED));
+
+    assertThat(metadata.getActiveDeletedColumnNames(false)).containsExactly("city", "oldCol");
+    assertThat(metadata.blocksReAdd("city", false)).isTrue();
+    assertThat(metadata.blocksReAdd("zip", false)).isFalse();
+    assertThat(metadata.blocksReAdd("oldCol", false)).isTrue();
+    assertThat(metadata.blocksReAdd("other", false)).isFalse();
+    assertThat(metadata.findActiveEntryForColumn("zip", false)).isNull();
+    assertThat(metadata.findActiveEntryForColumn("city", false).getDeletionId()).isEqualTo("del-1");
+  }
+
+  @Test
+  public void testIgnoreCaseReAddBlock() {
+    ColumnDeletionMetadata metadata = new ColumnDeletionMetadata("foo_OFFLINE");
+    metadata.addEntry(new ColumnDeletionEntry("City", "del-1", 1000L, 1, ColumnDeletionState.PENDING));
+
+    assertThat(metadata.blocksReAdd("city", true)).isTrue();
+    assertThat(metadata.blocksReAdd("CITY", true)).isTrue();
+    assertThat(metadata.blocksReAdd("city", false)).isFalse();
+    assertThat(metadata.getActiveDeletedColumnNames(true)).containsExactly("city");
+  }
+
+  @Test
+  public void testEveryNonCompleteStateBlocksReAdd() {
+    for (ColumnDeletionState state : ColumnDeletionState.values()) {
+      ColumnDeletionEntry entry = new ColumnDeletionEntry("col", "del-" + state, 1L, 0, state);
+      assertThat(entry.blocksReAdd()).isEqualTo(state != ColumnDeletionState.COMPLETE);
+    }
+  }
+
+  @Test
+  public void testReconcilePreparedAbortsWhenColumnStillPresent() {
+    ColumnDeletionMetadata metadata = new ColumnDeletionMetadata("foo_OFFLINE");
+    metadata.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 4, ColumnDeletionState.PREPARED));
+
+    assertThat(metadata.reconcilePreparedEntry("del-1", true)).isNull();
+    assertThat(metadata.getEntry("del-1")).isNull();
+    assertThat(metadata.blocksReAdd("city", false)).isFalse();
+  }
+
+  @Test
+  public void testReconcilePreparedAdvancesWhenColumnAlreadyGone() {
+    ColumnDeletionMetadata metadata = new ColumnDeletionMetadata("foo_OFFLINE");
+    metadata.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 4, ColumnDeletionState.PREPARED));
+
+    ColumnDeletionEntry advanced = metadata.reconcilePreparedEntry("del-1", false);
+    assertThat(advanced.getState()).isEqualTo(ColumnDeletionState.RECLAIMING);
+    assertThat(advanced.getDeletionEpochMs()).isEqualTo(1000L);
+    assertThat(metadata.getEntry("del-1").getState()).isEqualTo(ColumnDeletionState.RECLAIMING);
+  }
+
+  @Test
+  public void testReconcilePreparedLeavesOtherStatesAlone() {
+    ColumnDeletionMetadata metadata = new ColumnDeletionMetadata("foo_OFFLINE");
+    metadata.addEntry(new ColumnDeletionEntry("city", "del-1", 1000L, 4, ColumnDeletionState.RECLAIMING));
+
+    ColumnDeletionEntry unchanged = metadata.reconcilePreparedEntry("del-1", true);
+    assertThat(unchanged.getState()).isEqualTo(ColumnDeletionState.RECLAIMING);
+    assertThat(metadata.getEntry("del-1").getState()).isEqualTo(ColumnDeletionState.RECLAIMING);
+  }
+
+  @Test
+  public void testMissingFormatVersionRejected() {
+    ZNRecord record = new ZNRecord("foo_OFFLINE");
+    assertThatThrownBy(() -> ColumnDeletionMetadata.fromZNRecord(record)).isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("formatVersion");
+  }
+
+  @Test
+  public void testNewerFormatVersionRejected() {
+    ZNRecord record = new ZNRecord("foo_OFFLINE");
+    record.setSimpleField("formatVersion", Integer.toString(ColumnDeletionMetadata.CURRENT_FORMAT_VERSION + 1));
+    assertThatThrownBy(() -> ColumnDeletionMetadata.fromZNRecord(record)).isInstanceOf(
+        ColumnDeletionUnsupportedFormatException.class);
+  }
+
+  @Test
+  public void testFormatVersionZeroRejected() {
+    ZNRecord record = new ZNRecord("foo_OFFLINE");
+    record.setSimpleField("formatVersion", "0");
+    assertThatThrownBy(() -> ColumnDeletionMetadata.fromZNRecord(record)).isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("invalid formatVersion");
+  }
+
+  @Test
+  public void testToZNRecordRefusesNewerInMemoryFormat() {
+    ColumnDeletionMetadata metadata =
+        new ColumnDeletionMetadata("foo_OFFLINE", ColumnDeletionMetadata.CURRENT_FORMAT_VERSION + 1, Map.of());
+    assertThatThrownBy(metadata::toZNRecord).isInstanceOf(ColumnDeletionUnsupportedFormatException.class);
+  }
+
+  @Test
+  public void testUnknownStateRejected() {
+    ZNRecord record = new ZNRecord("foo_OFFLINE");
+    record.setSimpleField("formatVersion", "1");
+    Map<String, String> fields = new HashMap<>();
+    fields.put("columnName", "city");
+    fields.put("deletionId", "del-1");
+    fields.put("deletionEpochMs", "1");
+    fields.put("schemaZkVersion", "1");
+    fields.put("state", "VANISHED");
+    record.setMapField("del-1", fields);
+
+    assertThatThrownBy(() -> ColumnDeletionMetadata.fromZNRecord(record)).isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("unknown state");
+  }
+
+  @Test
+  public void testDeletionIdMismatchRejected() {
+    ZNRecord record = new ZNRecord("foo_OFFLINE");
+    record.setSimpleField("formatVersion", "1");
+    Map<String, String> fields = new HashMap<>();
+    fields.put("columnName", "city");
+    fields.put("deletionId", "other-id");
+    fields.put("deletionEpochMs", "1");
+    fields.put("schemaZkVersion", "1");
+    fields.put("state", "RECLAIMING");
+    record.setMapField("del-1", fields);
+
+    assertThatThrownBy(() -> ColumnDeletionMetadata.fromZNRecord(record)).isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("does not match");
+  }
+
+  @Test
+  public void testUnknownMapKeysAreIgnored() {
+    ZNRecord record = new ZNRecord("foo_OFFLINE");
+    record.setSimpleField("formatVersion", "1");
+    Map<String, String> fields = new HashMap<>();
+    fields.put("columnName", "city");
+    fields.put("deletionId", "del-1");
+    fields.put("deletionEpochMs", "9");
+    fields.put("schemaZkVersion", "2");
+    fields.put("state", "PENDING");
+    fields.put("futureField", "ok");
+    record.setMapField("del-1", fields);
+
+    ColumnDeletionEntry entry = ColumnDeletionMetadata.fromZNRecord(record).getEntry("del-1");
+    assertThat(entry.getColumnName()).isEqualTo("city");
+    assertThat(entry.getState()).isEqualTo(ColumnDeletionState.PENDING);
+    assertThat(entry.getDeletionEpochMs()).isEqualTo(9L);
+  }
+
+  @Test
+  public void testDuplicateDeletionIdRejected() {
+    ColumnDeletionMetadata metadata = new ColumnDeletionMetadata("foo_OFFLINE");
+    ColumnDeletionEntry entry = new ColumnDeletionEntry("city", "del-1", 1L, 0, ColumnDeletionState.PREPARED);
+    metadata.addEntry(entry);
+    assertThatThrownBy(() -> metadata.addEntry(entry)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void testNewDeletionIdIsUnique() {
+    assertThat(ColumnDeletionMetadata.newDeletionId()).isNotEqualTo(ColumnDeletionMetadata.newDeletionId());
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/SchemaDiff.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/SchemaDiff.java
@@ -106,7 +106,8 @@ public final class SchemaDiff {
 
     List<String> oldPrimaryKeyColumns = copyPrimaryKeyColumns(oldSchema);
     List<String> newPrimaryKeyColumns = copyPrimaryKeyColumns(newSchema);
-    boolean primaryKeyColumnsChanged = !primaryKeyColumnsEqual(oldPrimaryKeyColumns, newPrimaryKeyColumns, ignoreCase);
+    // Primary-key equality stays exact-name, matching Schema.isBackwardCompatibleWith.
+    boolean primaryKeyColumnsChanged = !oldPrimaryKeyColumns.equals(newPrimaryKeyColumns);
     boolean existingPrimaryKeyColumnsChanged = !oldPrimaryKeyColumns.isEmpty() && primaryKeyColumnsChanged;
 
     return new SchemaDiff(List.copyOf(deletedColumnNames), List.copyOf(addedColumnNames),
@@ -156,12 +157,16 @@ public final class SchemaDiff {
   }
 
   /// True when there are no deletes, no adds, no retained incompatibilities, and no primary-key change.
-  public boolean isNoOp() {
+  ///
+  /// Default-null, max-length, transform, and description edits are not structural and do not
+  /// affect this result. Do not skip a schema write based on this method alone.
+  public boolean isStructurallyUnchanged() {
     return _deletedColumnNames.isEmpty() && _addedColumnNames.isEmpty() && _retainedIncompatibleColumns.isEmpty()
         && !_primaryKeyColumnsChanged;
   }
 
-  /// True when the only incompatibility versus {@link Schema#isBackwardCompatibleWith(Schema)} is missing columns.
+  /// True when column deletion would be the only extra permission needed versus today's update rules,
+  /// plus field-kind changes which {@link Schema#isBackwardCompatibleWith(Schema)} does not check.
   ///
   /// Type, field-kind, and existing primary-key changes still fail this check. An empty deleted set
   /// is a normal compatible update from the deletion-flag point of view.
@@ -170,6 +175,7 @@ public final class SchemaDiff {
   }
 
   public static String normalizeColumnName(String columnName, boolean ignoreCase) {
+    Preconditions.checkNotNull(columnName, "columnName");
     return ignoreCase ? columnName.toLowerCase(Locale.ROOT) : columnName;
   }
 
@@ -205,19 +211,6 @@ public final class SchemaDiff {
       return List.of();
     }
     return List.copyOf(primaryKeyColumns);
-  }
-
-  private static boolean primaryKeyColumnsEqual(List<String> oldPrimaryKeyColumns, List<String> newPrimaryKeyColumns,
-      boolean ignoreCase) {
-    if (oldPrimaryKeyColumns.size() != newPrimaryKeyColumns.size()) {
-      return false;
-    }
-    for (int i = 0; i < oldPrimaryKeyColumns.size(); i++) {
-      if (!columnNamesEqual(oldPrimaryKeyColumns.get(i), newPrimaryKeyColumns.get(i), ignoreCase)) {
-        return false;
-      }
-    }
-    return true;
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/SchemaDiff.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/SchemaDiff.java
@@ -1,0 +1,310 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.data;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+
+/// Structured difference between two {@link Schema}s.
+///
+/// Computes the sets used by first-class column deletion (apache/pinot#18808):
+/// {@code deleted = old - new}, {@code added = new - old}, and retained columns whose
+/// {@link FieldSpec} is not backward compatible or whose field kind changed. A rename is
+/// reported as one delete plus one add. This class does not decide whether a delete is
+/// allowed and does not write any metadata.
+///
+/// Instances are immutable and therefore thread-safe.
+public final class SchemaDiff {
+  private final List<String> _deletedColumnNames;
+  private final List<String> _addedColumnNames;
+  private final List<RetainedColumnChange> _retainedIncompatibleColumns;
+  private final List<String> _oldPrimaryKeyColumns;
+  private final List<String> _newPrimaryKeyColumns;
+  private final boolean _primaryKeyColumnsChanged;
+  private final boolean _existingPrimaryKeyColumnsChanged;
+  private final boolean _ignoreCase;
+
+  private SchemaDiff(List<String> deletedColumnNames, List<String> addedColumnNames,
+      List<RetainedColumnChange> retainedIncompatibleColumns, List<String> oldPrimaryKeyColumns,
+      List<String> newPrimaryKeyColumns, boolean primaryKeyColumnsChanged, boolean existingPrimaryKeyColumnsChanged,
+      boolean ignoreCase) {
+    _deletedColumnNames = deletedColumnNames;
+    _addedColumnNames = addedColumnNames;
+    _retainedIncompatibleColumns = retainedIncompatibleColumns;
+    _oldPrimaryKeyColumns = oldPrimaryKeyColumns;
+    _newPrimaryKeyColumns = newPrimaryKeyColumns;
+    _primaryKeyColumnsChanged = primaryKeyColumnsChanged;
+    _existingPrimaryKeyColumnsChanged = existingPrimaryKeyColumnsChanged;
+    _ignoreCase = ignoreCase;
+  }
+
+  /// Case-sensitive diff. Column names must match exactly to be treated as the same column.
+  public static SchemaDiff compute(Schema oldSchema, Schema newSchema) {
+    return compute(oldSchema, newSchema, false);
+  }
+
+  /// Diff two schemas.
+  ///
+  /// When {@code ignoreCase} is true, names are matched with {@link Locale#ROOT} lowercasing, the
+  /// same rule {@code SchemaUtils.validate} uses for case-insensitive tables. A schema that already
+  /// contains a case collision is rejected rather than silently merging those columns.
+  ///
+  /// @param oldSchema previously stored schema
+  /// @param newSchema proposed schema
+  /// @param ignoreCase whether to treat names that differ only by case as the same column
+  public static SchemaDiff compute(Schema oldSchema, Schema newSchema, boolean ignoreCase) {
+    Preconditions.checkNotNull(oldSchema, "oldSchema");
+    Preconditions.checkNotNull(newSchema, "newSchema");
+
+    Map<String, String> oldIndex = indexColumnNames(oldSchema, ignoreCase);
+    Map<String, String> newIndex = indexColumnNames(newSchema, ignoreCase);
+
+    List<String> deletedColumnNames = new ArrayList<>();
+    List<String> addedColumnNames = new ArrayList<>();
+    List<RetainedColumnChange> retainedIncompatibleColumns = new ArrayList<>();
+
+    for (Map.Entry<String, String> oldEntry : oldIndex.entrySet()) {
+      String newColumnName = newIndex.get(oldEntry.getKey());
+      if (newColumnName == null) {
+        deletedColumnNames.add(oldEntry.getValue());
+        continue;
+      }
+      FieldSpec oldFieldSpec = oldSchema.getFieldSpecFor(oldEntry.getValue());
+      FieldSpec newFieldSpec = newSchema.getFieldSpecFor(newColumnName);
+      if (isRetainedIncompatible(oldFieldSpec, newFieldSpec)) {
+        retainedIncompatibleColumns.add(
+            new RetainedColumnChange(oldEntry.getValue(), newColumnName, oldFieldSpec, newFieldSpec));
+      }
+    }
+    for (Map.Entry<String, String> newEntry : newIndex.entrySet()) {
+      if (!oldIndex.containsKey(newEntry.getKey())) {
+        addedColumnNames.add(newEntry.getValue());
+      }
+    }
+
+    List<String> oldPrimaryKeyColumns = copyPrimaryKeyColumns(oldSchema);
+    List<String> newPrimaryKeyColumns = copyPrimaryKeyColumns(newSchema);
+    boolean primaryKeyColumnsChanged = !primaryKeyColumnsEqual(oldPrimaryKeyColumns, newPrimaryKeyColumns, ignoreCase);
+    boolean existingPrimaryKeyColumnsChanged = !oldPrimaryKeyColumns.isEmpty() && primaryKeyColumnsChanged;
+
+    return new SchemaDiff(List.copyOf(deletedColumnNames), List.copyOf(addedColumnNames),
+        List.copyOf(retainedIncompatibleColumns), oldPrimaryKeyColumns, newPrimaryKeyColumns, primaryKeyColumnsChanged,
+        existingPrimaryKeyColumnsChanged, ignoreCase);
+  }
+
+  /// Names present in {@code oldSchema} and absent from {@code newSchema}, in schema iteration order.
+  public List<String> getDeletedColumnNames() {
+    return _deletedColumnNames;
+  }
+
+  /// Names present in {@code newSchema} and absent from {@code oldSchema}, in schema iteration order.
+  public List<String> getAddedColumnNames() {
+    return _addedColumnNames;
+  }
+
+  /// Same-name columns that fail {@link FieldSpec#isBackwardCompatibleWith(FieldSpec)} or changed field kind.
+  ///
+  /// Default-null and max-length edits are compatible today and are not listed.
+  public List<RetainedColumnChange> getRetainedIncompatibleColumns() {
+    return _retainedIncompatibleColumns;
+  }
+
+  public List<String> getOldPrimaryKeyColumns() {
+    return _oldPrimaryKeyColumns;
+  }
+
+  public List<String> getNewPrimaryKeyColumns() {
+    return _newPrimaryKeyColumns;
+  }
+
+  /// True when the primary-key lists differ, including adding keys to a schema that had none.
+  public boolean isPrimaryKeyColumnsChanged() {
+    return _primaryKeyColumnsChanged;
+  }
+
+  /// True when the old schema already had primary keys and the new list is not equal.
+  ///
+  /// This is the existing {@link Schema#isBackwardCompatibleWith(Schema)} primary-key rule.
+  public boolean isExistingPrimaryKeyColumnsChanged() {
+    return _existingPrimaryKeyColumnsChanged;
+  }
+
+  public boolean isIgnoreCase() {
+    return _ignoreCase;
+  }
+
+  /// True when there are no deletes, no adds, no retained incompatibilities, and no primary-key change.
+  public boolean isNoOp() {
+    return _deletedColumnNames.isEmpty() && _addedColumnNames.isEmpty() && _retainedIncompatibleColumns.isEmpty()
+        && !_primaryKeyColumnsChanged;
+  }
+
+  /// True when the only incompatibility versus {@link Schema#isBackwardCompatibleWith(Schema)} is missing columns.
+  ///
+  /// Type, field-kind, and existing primary-key changes still fail this check. An empty deleted set
+  /// is a normal compatible update from the deletion-flag point of view.
+  public boolean isCompatibleWhenColumnDeletionAllowed() {
+    return _retainedIncompatibleColumns.isEmpty() && !_existingPrimaryKeyColumnsChanged;
+  }
+
+  public static String normalizeColumnName(String columnName, boolean ignoreCase) {
+    return ignoreCase ? columnName.toLowerCase(Locale.ROOT) : columnName;
+  }
+
+  public static boolean columnNamesEqual(String left, String right, boolean ignoreCase) {
+    if (left == null || right == null) {
+      return false;
+    }
+    return normalizeColumnName(left, ignoreCase).equals(normalizeColumnName(right, ignoreCase));
+  }
+
+  private static boolean isRetainedIncompatible(FieldSpec oldFieldSpec, FieldSpec newFieldSpec) {
+    return !newFieldSpec.isBackwardCompatibleWith(oldFieldSpec)
+        || oldFieldSpec.getFieldType() != newFieldSpec.getFieldType();
+  }
+
+  private static Map<String, String> indexColumnNames(Schema schema, boolean ignoreCase) {
+    Map<String, String> normalizedToOriginal = new LinkedHashMap<>();
+    for (String columnName : schema.getColumnNames()) {
+      String normalized = normalizeColumnName(columnName, ignoreCase);
+      String previous = normalizedToOriginal.put(normalized, columnName);
+      if (previous != null) {
+        throw new IllegalArgumentException(
+            "Schema '" + schema.getSchemaName() + "' has case-colliding columns '" + previous + "' and '" + columnName
+                + "'");
+      }
+    }
+    return normalizedToOriginal;
+  }
+
+  private static List<String> copyPrimaryKeyColumns(Schema schema) {
+    List<String> primaryKeyColumns = schema.getPrimaryKeyColumns();
+    if (primaryKeyColumns == null || primaryKeyColumns.isEmpty()) {
+      return List.of();
+    }
+    return List.copyOf(primaryKeyColumns);
+  }
+
+  private static boolean primaryKeyColumnsEqual(List<String> oldPrimaryKeyColumns, List<String> newPrimaryKeyColumns,
+      boolean ignoreCase) {
+    if (oldPrimaryKeyColumns.size() != newPrimaryKeyColumns.size()) {
+      return false;
+    }
+    for (int i = 0; i < oldPrimaryKeyColumns.size(); i++) {
+      if (!columnNamesEqual(oldPrimaryKeyColumns.get(i), newPrimaryKeyColumns.get(i), ignoreCase)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SchemaDiff that = (SchemaDiff) o;
+    return _primaryKeyColumnsChanged == that._primaryKeyColumnsChanged
+        && _existingPrimaryKeyColumnsChanged == that._existingPrimaryKeyColumnsChanged
+        && _ignoreCase == that._ignoreCase && _deletedColumnNames.equals(that._deletedColumnNames)
+        && _addedColumnNames.equals(that._addedColumnNames)
+        && _retainedIncompatibleColumns.equals(that._retainedIncompatibleColumns)
+        && _oldPrimaryKeyColumns.equals(that._oldPrimaryKeyColumns)
+        && _newPrimaryKeyColumns.equals(that._newPrimaryKeyColumns);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_deletedColumnNames, _addedColumnNames, _retainedIncompatibleColumns, _oldPrimaryKeyColumns,
+        _newPrimaryKeyColumns, _primaryKeyColumnsChanged, _existingPrimaryKeyColumnsChanged, _ignoreCase);
+  }
+
+  @Override
+  public String toString() {
+    return "SchemaDiff{deleted=" + _deletedColumnNames + ", added=" + _addedColumnNames + ", retainedIncompatible="
+        + _retainedIncompatibleColumns + ", oldPrimaryKeys=" + _oldPrimaryKeyColumns + ", newPrimaryKeys="
+        + _newPrimaryKeyColumns + ", ignoreCase=" + _ignoreCase + '}';
+  }
+
+  /// A retained column whose {@link FieldSpec} is not backward compatible, or whose field kind changed.
+  public static final class RetainedColumnChange {
+    private final String _oldColumnName;
+    private final String _newColumnName;
+    private final FieldSpec _oldFieldSpec;
+    private final FieldSpec _newFieldSpec;
+
+    public RetainedColumnChange(String oldColumnName, String newColumnName, FieldSpec oldFieldSpec,
+        FieldSpec newFieldSpec) {
+      _oldColumnName = oldColumnName;
+      _newColumnName = newColumnName;
+      _oldFieldSpec = oldFieldSpec;
+      _newFieldSpec = newFieldSpec;
+    }
+
+    public String getOldColumnName() {
+      return _oldColumnName;
+    }
+
+    public String getNewColumnName() {
+      return _newColumnName;
+    }
+
+    public FieldSpec getOldFieldSpec() {
+      return _oldFieldSpec;
+    }
+
+    public FieldSpec getNewFieldSpec() {
+      return _newFieldSpec;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      RetainedColumnChange that = (RetainedColumnChange) o;
+      return _oldColumnName.equals(that._oldColumnName) && _newColumnName.equals(that._newColumnName)
+          && _oldFieldSpec.equals(that._oldFieldSpec) && _newFieldSpec.equals(that._newFieldSpec);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_oldColumnName, _newColumnName, _oldFieldSpec, _newFieldSpec);
+    }
+
+    @Override
+    public String toString() {
+      return _oldColumnName + "->" + _newColumnName + " (" + _oldFieldSpec.getDataType() + "/"
+          + _oldFieldSpec.getFieldType() + " -> " + _newFieldSpec.getDataType() + "/" + _newFieldSpec.getFieldType()
+          + ")";
+    }
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/SchemaDiffTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/SchemaDiffTest.java
@@ -40,7 +40,7 @@ public class SchemaDiffTest {
     assertThat(diff.isPrimaryKeyColumnsChanged()).isFalse();
     assertThat(diff.isExistingPrimaryKeyColumnsChanged()).isFalse();
     assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isTrue();
-    assertThat(diff.isNoOp()).isFalse();
+    assertThat(diff.isStructurallyUnchanged()).isFalse();
     assertThat(newSchema.isBackwardCompatibleWith(oldSchema)).isFalse();
   }
 
@@ -130,7 +130,7 @@ public class SchemaDiffTest {
     SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema);
     assertThat(diff.getRetainedIncompatibleColumns()).isEmpty();
     assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isTrue();
-    assertThat(diff.isNoOp()).isTrue();
+    assertThat(diff.isStructurallyUnchanged()).isTrue();
     assertThat(newSchema.isBackwardCompatibleWith(oldSchema)).isTrue();
   }
 
@@ -158,6 +158,23 @@ public class SchemaDiffTest {
     assertThat(diff.isExistingPrimaryKeyColumnsChanged()).isTrue();
     assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isFalse();
     assertThat(newSchema.isBackwardCompatibleWith(oldSchema)).isFalse();
+  }
+
+  @Test
+  public void testPrimaryKeyCaseChangeIsReportedEvenWhenIgnoreCase() {
+    Schema oldSchema = baseSchemaBuilder().setPrimaryKeyColumns(List.of("id")).build();
+    Schema newSchema = baseSchemaBuilder().setPrimaryKeyColumns(List.of("ID")).build();
+
+    SchemaDiff ignoreCase = SchemaDiff.compute(oldSchema, newSchema, true);
+    assertThat(ignoreCase.isExistingPrimaryKeyColumnsChanged()).isTrue();
+    assertThat(ignoreCase.isCompatibleWhenColumnDeletionAllowed()).isFalse();
+    assertThat(ignoreCase.getDeletedColumnNames()).isEmpty();
+    assertThat(ignoreCase.getAddedColumnNames()).isEmpty();
+    assertThat(newSchema.isBackwardCompatibleWith(oldSchema)).isFalse();
+
+    SchemaDiff exact = SchemaDiff.compute(oldSchema, newSchema, false);
+    assertThat(exact.isExistingPrimaryKeyColumnsChanged()).isTrue();
+    assertThat(exact.isCompatibleWhenColumnDeletionAllowed()).isFalse();
   }
 
   @Test
@@ -214,7 +231,7 @@ public class SchemaDiffTest {
     Schema newSchema = baseSchemaBuilder().build();
 
     SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema);
-    assertThat(diff.isNoOp()).isTrue();
+    assertThat(diff.isStructurallyUnchanged()).isTrue();
     assertThat(diff.getDeletedColumnNames()).isEmpty();
     assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isTrue();
     assertThat(newSchema.isBackwardCompatibleWith(oldSchema)).isTrue();

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/SchemaDiffTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/SchemaDiffTest.java
@@ -1,0 +1,272 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.data;
+
+import java.util.List;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+public class SchemaDiffTest {
+
+  @Test
+  public void testDeleteOneColumn() {
+    Schema oldSchema = baseSchemaBuilder().addSingleValueDimension("toDelete", FieldSpec.DataType.INT).build();
+    Schema newSchema = baseSchemaBuilder().build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema);
+    assertThat(diff.getDeletedColumnNames()).containsExactly("toDelete");
+    assertThat(diff.getAddedColumnNames()).isEmpty();
+    assertThat(diff.getRetainedIncompatibleColumns()).isEmpty();
+    assertThat(diff.isPrimaryKeyColumnsChanged()).isFalse();
+    assertThat(diff.isExistingPrimaryKeyColumnsChanged()).isFalse();
+    assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isTrue();
+    assertThat(diff.isNoOp()).isFalse();
+    assertThat(newSchema.isBackwardCompatibleWith(oldSchema)).isFalse();
+  }
+
+  @Test
+  public void testDeleteManyColumns() {
+    Schema oldSchema = baseSchemaBuilder().addSingleValueDimension("a", FieldSpec.DataType.INT)
+        .addSingleValueDimension("b", FieldSpec.DataType.STRING).addMetric("c", FieldSpec.DataType.LONG).build();
+    Schema newSchema = baseSchemaBuilder().build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema);
+    assertThat(diff.getDeletedColumnNames()).containsExactly("a", "b", "c");
+    assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isTrue();
+  }
+
+  @Test
+  public void testAddPlusDelete() {
+    Schema oldSchema = baseSchemaBuilder().addSingleValueDimension("oldCol", FieldSpec.DataType.INT).build();
+    Schema newSchema = baseSchemaBuilder().addSingleValueDimension("newCol", FieldSpec.DataType.INT).build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema);
+    assertThat(diff.getDeletedColumnNames()).containsExactly("oldCol");
+    assertThat(diff.getAddedColumnNames()).containsExactly("newCol");
+    assertThat(diff.getRetainedIncompatibleColumns()).isEmpty();
+    assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isTrue();
+  }
+
+  @Test
+  public void testRenameIsAddPlusDelete() {
+    Schema oldSchema = baseSchemaBuilder().addSingleValueDimension("city", FieldSpec.DataType.STRING).build();
+    Schema newSchema = baseSchemaBuilder().addSingleValueDimension("cityName", FieldSpec.DataType.STRING).build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema);
+    assertThat(diff.getDeletedColumnNames()).containsExactly("city");
+    assertThat(diff.getAddedColumnNames()).containsExactly("cityName");
+    assertThat(diff.getRetainedIncompatibleColumns()).isEmpty();
+  }
+
+  @Test
+  public void testRetainedTypeChange() {
+    Schema oldSchema = baseSchemaBuilder().addSingleValueDimension("sv", FieldSpec.DataType.INT).build();
+    Schema newSchema = baseSchemaBuilder().addSingleValueDimension("sv", FieldSpec.DataType.LONG).build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema);
+    assertThat(diff.getDeletedColumnNames()).isEmpty();
+    assertThat(diff.getAddedColumnNames()).isEmpty();
+    assertThat(diff.getRetainedIncompatibleColumns()).hasSize(1);
+    assertThat(diff.getRetainedIncompatibleColumns().get(0).getOldColumnName()).isEqualTo("sv");
+    assertThat(diff.getRetainedIncompatibleColumns().get(0).getOldFieldSpec().getDataType())
+        .isEqualTo(FieldSpec.DataType.INT);
+    assertThat(diff.getRetainedIncompatibleColumns().get(0).getNewFieldSpec().getDataType())
+        .isEqualTo(FieldSpec.DataType.LONG);
+    assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isFalse();
+    assertThat(newSchema.isBackwardCompatibleWith(oldSchema)).isFalse();
+  }
+
+  @Test
+  public void testRetainedSingleValueToMultiValue() {
+    Schema oldSchema = baseSchemaBuilder().addSingleValueDimension("tags", FieldSpec.DataType.STRING).build();
+    Schema newSchema = baseSchemaBuilder().addMultiValueDimension("tags", FieldSpec.DataType.STRING).build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema);
+    assertThat(diff.getRetainedIncompatibleColumns()).hasSize(1);
+    assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isFalse();
+  }
+
+  @Test
+  public void testRetainedFieldKindChange() {
+    Schema oldSchema = baseSchemaBuilder().addSingleValueDimension("count", FieldSpec.DataType.INT).build();
+    Schema newSchema = baseSchemaBuilder().addMetric("count", FieldSpec.DataType.INT).build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema);
+    assertThat(diff.getRetainedIncompatibleColumns()).hasSize(1);
+    assertThat(diff.getRetainedIncompatibleColumns().get(0).getOldFieldSpec().getFieldType())
+        .isEqualTo(FieldSpec.FieldType.DIMENSION);
+    assertThat(diff.getRetainedIncompatibleColumns().get(0).getNewFieldSpec().getFieldType())
+        .isEqualTo(FieldSpec.FieldType.METRIC);
+    assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isFalse();
+  }
+
+  @Test
+  public void testDefaultValueChangeIsCompatible() {
+    Schema oldSchema =
+        baseSchemaBuilder().addSingleValueDimension("sv", FieldSpec.DataType.INT, 10).build();
+    Schema newSchema =
+        baseSchemaBuilder().addSingleValueDimension("sv", FieldSpec.DataType.INT, 100).build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema);
+    assertThat(diff.getRetainedIncompatibleColumns()).isEmpty();
+    assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isTrue();
+    assertThat(diff.isNoOp()).isTrue();
+    assertThat(newSchema.isBackwardCompatibleWith(oldSchema)).isTrue();
+  }
+
+  @Test
+  public void testAddPrimaryKeysWhenNoneExisted() {
+    Schema oldSchema = baseSchemaBuilder().build();
+    Schema newSchema = baseSchemaBuilder().setPrimaryKeyColumns(List.of("id")).build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema);
+    assertThat(diff.isPrimaryKeyColumnsChanged()).isTrue();
+    assertThat(diff.isExistingPrimaryKeyColumnsChanged()).isFalse();
+    assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isTrue();
+    assertThat(newSchema.isBackwardCompatibleWith(oldSchema)).isTrue();
+  }
+
+  @Test
+  public void testChangeExistingPrimaryKeys() {
+    Schema oldSchema = baseSchemaBuilder().setPrimaryKeyColumns(List.of("id")).build();
+    Schema newSchema = baseSchemaBuilder().setPrimaryKeyColumns(List.of("id", "country")).build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema);
+    assertThat(diff.getOldPrimaryKeyColumns()).containsExactly("id");
+    assertThat(diff.getNewPrimaryKeyColumns()).containsExactly("id", "country");
+    assertThat(diff.isPrimaryKeyColumnsChanged()).isTrue();
+    assertThat(diff.isExistingPrimaryKeyColumnsChanged()).isTrue();
+    assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isFalse();
+    assertThat(newSchema.isBackwardCompatibleWith(oldSchema)).isFalse();
+  }
+
+  @Test
+  public void testCaseSensitiveTreatsRenameAsAddAndDelete() {
+    Schema oldSchema = baseSchemaBuilder().addSingleValueDimension("City", FieldSpec.DataType.STRING).build();
+    Schema newSchema = baseSchemaBuilder().addSingleValueDimension("city", FieldSpec.DataType.STRING).build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema, false);
+    assertThat(diff.getDeletedColumnNames()).containsExactly("City");
+    assertThat(diff.getAddedColumnNames()).containsExactly("city");
+    assertThat(diff.getRetainedIncompatibleColumns()).isEmpty();
+  }
+
+  @Test
+  public void testIgnoreCaseMatchesSameColumn() {
+    Schema oldSchema = baseSchemaBuilder().addSingleValueDimension("City", FieldSpec.DataType.STRING).build();
+    Schema newSchema = baseSchemaBuilder().addSingleValueDimension("city", FieldSpec.DataType.STRING).build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema, true);
+    assertThat(diff.getDeletedColumnNames()).isEmpty();
+    assertThat(diff.getAddedColumnNames()).isEmpty();
+    // FieldSpec compatibility compares the stored name, so a case-only rename is retained-incompatible.
+    assertThat(diff.getRetainedIncompatibleColumns()).hasSize(1);
+    assertThat(diff.getRetainedIncompatibleColumns().get(0).getOldColumnName()).isEqualTo("City");
+    assertThat(diff.getRetainedIncompatibleColumns().get(0).getNewColumnName()).isEqualTo("city");
+    assertThat(diff.isIgnoreCase()).isTrue();
+  }
+
+  @Test
+  public void testIgnoreCaseTypeChange() {
+    Schema oldSchema = baseSchemaBuilder().addSingleValueDimension("City", FieldSpec.DataType.STRING).build();
+    Schema newSchema = baseSchemaBuilder().addSingleValueDimension("city", FieldSpec.DataType.INT).build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema, true);
+    assertThat(diff.getDeletedColumnNames()).isEmpty();
+    assertThat(diff.getRetainedIncompatibleColumns()).hasSize(1);
+    assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isFalse();
+  }
+
+  @Test
+  public void testIgnoreCaseCollisionThrows() {
+    Schema colliding = new Schema.SchemaBuilder().setSchemaName("collide")
+        .addSingleValueDimension("City", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("city", FieldSpec.DataType.INT).build();
+    Schema other = baseSchemaBuilder().build();
+
+    assertThatThrownBy(() -> SchemaDiff.compute(colliding, other, true)).isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("case-colliding");
+  }
+
+  @Test
+  public void testNoOpIdenticalSchemas() {
+    Schema oldSchema = baseSchemaBuilder().build();
+    Schema newSchema = baseSchemaBuilder().build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema);
+    assertThat(diff.isNoOp()).isTrue();
+    assertThat(diff.getDeletedColumnNames()).isEmpty();
+    assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isTrue();
+    assertThat(newSchema.isBackwardCompatibleWith(oldSchema)).isTrue();
+  }
+
+  @Test
+  public void testAddOnlyIsCompatibleWhenDeletionAllowed() {
+    Schema oldSchema = baseSchemaBuilder().build();
+    Schema newSchema = baseSchemaBuilder().addSingleValueDimension("extra", FieldSpec.DataType.INT).build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema);
+    assertThat(diff.getDeletedColumnNames()).isEmpty();
+    assertThat(diff.getAddedColumnNames()).containsExactly("extra");
+    assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isTrue();
+    assertThat(newSchema.isBackwardCompatibleWith(oldSchema)).isTrue();
+  }
+
+  @Test
+  public void testDeletePlusTypeChangeIsNotCompatibleWhenDeletionAllowed() {
+    Schema oldSchema = baseSchemaBuilder().addSingleValueDimension("gone", FieldSpec.DataType.INT)
+        .addSingleValueDimension("sv", FieldSpec.DataType.INT).build();
+    Schema newSchema = baseSchemaBuilder().addSingleValueDimension("sv", FieldSpec.DataType.LONG).build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema);
+    assertThat(diff.getDeletedColumnNames()).containsExactly("gone");
+    assertThat(diff.getRetainedIncompatibleColumns()).hasSize(1);
+    assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isFalse();
+  }
+
+  @Test
+  public void testOpenStructDelete() {
+    Schema oldSchema = baseSchemaBuilder()
+        .addOpenStruct("attrs", Map.of("count", new DimensionFieldSpec("count", FieldSpec.DataType.INT, true)))
+        .build();
+    Schema newSchema = baseSchemaBuilder().build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema);
+    assertThat(diff.getDeletedColumnNames()).containsExactly("attrs");
+    assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isTrue();
+  }
+
+  @Test
+  public void testNullSchemaRejected() {
+    Schema schema = baseSchemaBuilder().build();
+    assertThatThrownBy(() -> SchemaDiff.compute(null, schema)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> SchemaDiff.compute(schema, null)).isInstanceOf(NullPointerException.class);
+  }
+
+  private static Schema.SchemaBuilder baseSchemaBuilder() {
+    return new Schema.SchemaBuilder().setSchemaName("testSchema")
+        .addSingleValueDimension("id", FieldSpec.DataType.INT)
+        .addSingleValueDimension("country", FieldSpec.DataType.STRING)
+        .addDateTime("ts", FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS");
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/SchemaDiffTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/SchemaDiffTest.java
@@ -178,6 +178,21 @@ public class SchemaDiffTest {
   }
 
   @Test
+  public void testDeletedPrimaryKeyColumnWithUnchangedPkList() {
+    Schema oldSchema = baseSchemaBuilder().setPrimaryKeyColumns(List.of("id")).build();
+    Schema newSchema = new Schema.SchemaBuilder().setSchemaName("testSchema")
+        .addSingleValueDimension("country", FieldSpec.DataType.STRING)
+        .addDateTime("ts", FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .setPrimaryKeyColumns(List.of("id")).build();
+
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, newSchema);
+    assertThat(diff.getDeletedColumnNames()).containsExactly("id");
+    assertThat(diff.isExistingPrimaryKeyColumnsChanged()).isFalse();
+    assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isTrue();
+    assertThat(newSchema.isBackwardCompatibleWith(oldSchema)).isFalse();
+  }
+
+  @Test
   public void testCaseSensitiveTreatsRenameAsAddAndDelete() {
     Schema oldSchema = baseSchemaBuilder().addSingleValueDimension("City", FieldSpec.DataType.STRING).build();
     Schema newSchema = baseSchemaBuilder().addSingleValueDimension("city", FieldSpec.DataType.STRING).build();

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/SchemaTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/SchemaTest.java
@@ -841,4 +841,17 @@ public class SchemaTest {
     ComplexFieldSpec cfs = (ComplexFieldSpec) fs;
     Assert.assertEquals(cfs.getChildFieldSpec("count").getDataType(), FieldSpec.DataType.INT);
   }
+
+  @Test
+  public void testSchemaDiffDoesNotRelaxCompatibilityContract() {
+    Schema oldSchema = new Schema.SchemaBuilder().addSingleValueDimension("svDimension", FieldSpec.DataType.INT)
+        .addMetric("metric", FieldSpec.DataType.INT).build();
+    Schema deletedColumn = new Schema.SchemaBuilder().addSingleValueDimension("svDimension", FieldSpec.DataType.INT)
+        .build();
+
+    Assert.assertFalse(deletedColumn.isBackwardCompatibleWith(oldSchema));
+    SchemaDiff diff = SchemaDiff.compute(oldSchema, deletedColumn);
+    assertThat(diff.getDeletedColumnNames()).containsExactly("metric");
+    assertThat(diff.isCompatibleWhenColumnDeletionAllowed()).isTrue();
+  }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Flow of column deletion ledger: create entry, add, persist, reconcile, check dirty segments via CRC\.

```mermaid
flowchart TD
  N0["Create ColumnDeletionEntry #40;PREPARED#41; #40;F3#41;"]:::stAdded
  N1["Add entry to ColumnDeletionMetadata #40;F4#41;"]:::stAdded
  N2["Persist ledger via CAS write #40;F5#41;"]:::stAdded
  N3["Reconcile PREPARED entry after schema write #40;F4#41;"]:::stAdded
  N4["Determine if segment is dirty for deletion #40;F2#41;"]:::stAdded
  N5["Check for successful refresh CRC marker #40;F2#41;"]:::stAdded
  N6["Compute schema diff for deleted#47;added columns #40;F9#41;"]:::stAdded
  N0 -->|"entry passed"| N1
  N1 -->|"metadata passed"| N2
  N2 -->|"calls toZNRecord#47;peekFormatVersion"| N1
  N1 -->|"uses schema diff for duplicate check"| N6
  N3 -->|"calls withState"| N0
  N4 -->|"calls hasSuccessfulRefreshMarker"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionDirtySegmentPredicate\.java — [after](https://github.com/apache/pinot/blob/239f614b8ff6b97181ebc667f45d7673a697e2ac/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionDirtySegmentPredicate.java)
- F3: pinot\-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionEntry\.java — [after](https://github.com/apache/pinot/blob/239f614b8ff6b97181ebc667f45d7673a697e2ac/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionEntry.java)
- F4: pinot\-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadata\.java — [after](https://github.com/apache/pinot/blob/239f614b8ff6b97181ebc667f45d7673a697e2ac/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadata.java)
- F5: pinot\-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelper\.java — [after](https://github.com/apache/pinot/blob/239f614b8ff6b97181ebc667f45d7673a697e2ac/pinot-common/src/main/java/org/apache/pinot/common/metadata/columndeletion/ColumnDeletionMetadataAccessHelper.java)
- F9: pinot\-spi/src/main/java/org/apache/pinot/spi/data/SchemaDiff\.java — [after](https://github.com/apache/pinot/blob/239f614b8ff6b97181ebc667f45d7673a697e2ac/pinot-spi/src/main/java/org/apache/pinot/spi/data/SchemaDiff.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjMwZjVkMjA4YTFlNThhMWUxY2VlNGFmYzVmYzc3YTMyYjllNjFmNjYiLCJjb250ZXh0X2hhc2giOiJkMmI5MjFkNTFlYzQ2NDA3YTA3MzFjMjA0ZGI0NDUyZjVmNDM3N2RjMjU2MzU2YzZlYmRjMTUyNDgxNDUxNzdhIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTczMjM5LCJoZWFkX3NoYSI6IjIzOWY2MTRiOGZmNmI5NzE4MWViYzY2N2Y0NWQ3NjczYTY5N2UyYWMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyNmJmMDc1ZDE2Y2ZjNmQ4MGQ1NjgyNTg5MTA5Zjg3M2E5YzZkZDk2IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 58b52eb3b760fe6c8f2d91d2f60eb67ff71313ff1170ff73e490c5f460435786 -->
<!-- pinot-pr-flow:end -->

Ledger-only foundation for first-class column deletion ([#18808](https://github.com/apache/pinot/issues/18808)). This is **not** a public delete API and does **not** replace [#18831](https://github.com/apache/pinot/pull/18831).

## What this adds

- `SchemaDiff` in `pinot-spi`: dedicated helper for deleted / added / retained-incompatible columns. Not an overload of `Schema.isBackwardCompatibleWith`. Primary-key equality stays exact-name. `ignoreCase` uses `Locale.ROOT` for column-name matching only.
- PropertyStore path `/COLUMN_DELETION_METADATA/<tableNameWithType>`.
- Format-versioned ledger (`PREPARED` → `PENDING` / `RECLAIMING` → `COMPLETE` / `FAILED`). Newer stored formats are refused. `write(..., -1)` is create-only; updates CAS the version from the last read.
- Dirty-set helper: `RefreshSegmentTask.time` is not a success marker. Equal `ctime` is dirty. An empty live set is not `COMPLETE`. Callers may pass a physical-presence override. This PR does not read segment files.

## What this does not add

- No REST or client `allowColumnDeletion`
- No `reclaimDeletedColumnsOnReload`
- No `BaseDefaultColumnHandler` REMOVE expansion
- No schema-update path that actually deletes a column

## Tests

Unit tests in `pinot-spi` (`SchemaDiffTest`, `SchemaTest`) and `pinot-common` (`ColumnDeletionMetadataTest`, `ColumnDeletionMetadataAccessHelperTest`, `ColumnDeletionDirtySegmentPredicateTest`).

## Compatibility

Additive only. New ZK prefix is unused until a later writer exists. Mixed-version controllers that cannot parse a newer ledger format refuse to overwrite it.

Labels: `feature`, `release-notes` (new public `SchemaDiff` type in `pinot-spi`).
