### PR TITLE
Reuse sort-key storage across rejected GROUP BY candidates

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -238,6 +238,23 @@ public class TableResizer {
       if (comparator.compare(intermediateRecord, heap[0]) > 0) {
         heap[0] = intermediateRecord;
         downHeap(heap, size, 0, comparator);
+      } else {
+        // Reuse the rejected entry's values until a candidate enters the heap. The comparator only reads values,
+        // so the rejected entry's key and record can stay unchanged while its array is outside the heap.
+        Comparable[] orderByValues = intermediateRecord._values;
+        while (mapEntryIterator.hasNext()) {
+          entry = mapEntryIterator.next();
+          Record record = entry.getValue();
+          for (int i = 0; i < _numOrderByExpressions; i++) {
+            orderByValues[i] = _orderByValueExtractors[i].extract(record);
+          }
+          if (comparator.compare(intermediateRecord, heap[0]) > 0) {
+            heap[0] = new IntermediateRecord(entry.getKey(), record, orderByValues);
+            downHeap(heap, size, 0, comparator);
+            // The array now belongs to the heap; start with a fresh candidate on the next outer iteration.
+            break;
+          }
+        }
       }
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/TableResizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/TableResizerTest.java
@@ -21,22 +21,28 @@ package org.apache.pinot.core.data.table;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.query.aggregation.groupby.DoubleGroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.segment.local.customobject.AvgPair;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 
@@ -367,6 +373,142 @@ public class TableResizerTest {
     } else {
       assertEquals(results.get(1)._record, _records.get(4));
       assertEquals(results.get(2)._record, _records.get(3));
+    }
+  }
+
+  @Test
+  public void testTopRecordsAlternatingAcceptedAndRejectedCandidates() {
+    Map<Key, Record> records = recordsWithMetrics(30.0, 10.0, 20.0, 5.0, 40.0, 4.0, 50.0, 3.0, 60.0);
+    TableResizer resizer = sumResizer("SUM(m) DESC, id", false);
+
+    // With three retained entries, rejected and accepted candidates alternate after the initial heap.
+    // The unsorted result pins the existing heap order as well as the retained Record identities.
+    assertRecordOrder(resizer.getTopRecords(records, 3, false), records, 4, 6, 8);
+    assertRecordOrder(resizer.getTopRecords(records, 3, true), records, 8, 6, 4);
+    assertEquals(records.size(), 9);
+    assertEquals(records.get(new Key(new Object[]{4})).getValues(), new Object[]{4, 40.0});
+  }
+
+  @Test
+  public void testTopRecordsPreservesRecordsAcrossRejectionRuns() {
+    Map<Key, Record> records = recordsWithMetrics(10.0, 20.0, 30.0, 1.0, 2.0, 40.0, 50.0, 3.0, 4.0);
+    TableResizer resizer = sumResizer("SUM(m) DESC, id", false);
+
+    // A new maximum follows two rejected entries, then another maximum and a final rejection run.
+    // Check both the retained record identities and the heap order after every admission path.
+    assertRecordOrder(resizer.getTopRecords(records, 2, false), records, 5, 6);
+    assertRecordOrder(resizer.getTopRecords(records, 2, true), records, 6, 5);
+    assertEquals(records.size(), 9);
+  }
+
+  @Test
+  public void testTopRecordsRetainsExistingEntriesOnTies() {
+    Map<Key, Record> records = recordsWithMetrics(1.0, 1.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 2.0);
+    TableResizer resizer = sumResizer("SUM(m) DESC", false);
+
+    // ID 8 ties the root after three replacements and must not displace it. Equal children keep the
+    // existing left-child preference; changing either rule changes unsorted partial-result order.
+    assertRecordOrder(resizer.getTopRecords(records, 3, false), records, 7, 3, 5);
+    assertRecordOrder(resizer.getTopRecords(records, 3, true), records, 3, 5, 7);
+  }
+
+  @Test
+  public void testResizeRetainedAndEvictedHeapsPreserveRecords() {
+    Map<Key, Record> records = recordsWithMetrics(30.0, 10.0, 20.0, 5.0, 40.0, 4.0, 50.0, 3.0, 60.0);
+    TableResizer resizer = sumResizer("SUM(m) DESC, id", false);
+
+    Map<Key, Record> retainedHeap = new LinkedHashMap<>(records);
+    resizer.resizeRecordsMap(retainedHeap, 3);
+    assertRecordOrder(retainedHeap.values(), records, 4, 6, 8);
+
+    Map<Key, Record> evictedHeap = new LinkedHashMap<>(records);
+    resizer.resizeRecordsMap(evictedHeap, 5);
+    assertRecordOrder(evictedHeap.values(), records, 0, 2, 4, 6, 8);
+    assertEquals(records.size(), 9);
+  }
+
+  @DataProvider
+  public Object[][] nullAndFloatingPointOrders() {
+    return new Object[][]{
+        {"SUM(m) ASC NULLS FIRST, id", new int[]{3, 7, 5, 9, 4, 1, 2, 6, 0, 8}},
+        {"SUM(m) ASC NULLS LAST, id", new int[]{5, 9, 4, 1, 2, 6, 0, 8, 3, 7}},
+        {"SUM(m) DESC NULLS FIRST, id", new int[]{3, 7, 0, 8, 6, 2, 1, 4, 9, 5}},
+        {"SUM(m) DESC NULLS LAST, id", new int[]{0, 8, 6, 2, 1, 4, 9, 5, 3, 7}}
+    };
+  }
+
+  @Test(dataProvider = "nullAndFloatingPointOrders")
+  public void testTopRecordsNullsAndFloatingPointOrdering(String orderBy, int[] expectedIds) {
+    double firstNaN = Double.longBitsToDouble(0x7ff8000000000001L);
+    double secondNaN = Double.longBitsToDouble(0x7ff8000000000002L);
+    Map<Key, Record> records = recordsWithMetrics(firstNaN, 0.0, 10.0, null, -0.0,
+        Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, null, secondNaN, -5.0);
+    TableResizer resizer = sumResizer(orderBy, true);
+
+    // Cover a single-entry heap, repeated recycling, and the unchanged full-sort path.
+    for (int size : new int[]{1, 7, 10}) {
+      assertRecordOrder(resizer.getTopRecords(records, size, true), records, Arrays.copyOf(expectedIds, size));
+    }
+    Map<Key, Record> resized = new LinkedHashMap<>(records);
+    resizer.resizeRecordsMap(resized, 7);
+    assertEquals(resized.size(), 7);
+    for (int i = 0; i < 7; i++) {
+      Key key = new Key(new Object[]{expectedIds[i]});
+      assertSame(resized.get(key), records.get(key));
+    }
+
+    assertEquals(Double.doubleToRawLongBits((double) records.get(new Key(new Object[]{0})).getValues()[1]),
+        Double.doubleToRawLongBits(firstNaN));
+    assertEquals(Double.doubleToRawLongBits((double) records.get(new Key(new Object[]{8})).getValues()[1]),
+        Double.doubleToRawLongBits(secondNaN));
+    assertEquals(Double.doubleToRawLongBits((double) records.get(new Key(new Object[]{4})).getValues()[1]),
+        Double.doubleToRawLongBits(-0.0));
+  }
+
+  @Test
+  public void testTopRecordsPreservesIntermediateAggregateStates() {
+    double[] averages = {30.0, 10.0, 20.0, 5.0, 40.0, 4.0, 50.0, 3.0, 60.0};
+    AvgPair[] states = new AvgPair[averages.length];
+    for (int i = 0; i < states.length; i++) {
+      states[i] = new AvgPair(averages[i] * (i + 1), i + 1);
+    }
+    Map<Key, Record> records = recordsWithMetrics((Object[]) states);
+    TableResizer resizer = new TableResizer(
+        new DataSchema(new String[]{"id", "avg(m)"}, new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.OBJECT}),
+        QueryContextConverterUtils.getQueryContext(
+            "SELECT id, AVG(m) FROM testTable GROUP BY id ORDER BY AVG(m) DESC, id"));
+
+    assertRecordOrder(resizer.getTopRecords(records, 3, false), records, 4, 6, 8);
+    assertRecordOrder(resizer.getTopRecords(records, 3, true), records, 8, 6, 4);
+    for (int i = 0; i < states.length; i++) {
+      assertSame(records.get(new Key(new Object[]{i})).getValues()[1], states[i]);
+      assertEquals(states[i].getSum(), averages[i] * (i + 1));
+      assertEquals(states[i].getCount(), (long) i + 1);
+    }
+  }
+
+  private static TableResizer sumResizer(String orderBy, boolean nullHandlingEnabled) {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT id, SUM(m) FROM testTable GROUP BY id ORDER BY " + orderBy);
+    queryContext.setNullHandlingEnabled(nullHandlingEnabled);
+    return new TableResizer(
+        new DataSchema(new String[]{"id", "sum(m)"}, new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.DOUBLE}),
+        queryContext);
+  }
+
+  private static Map<Key, Record> recordsWithMetrics(Object... metrics) {
+    Map<Key, Record> records = new LinkedHashMap<>();
+    for (int i = 0; i < metrics.length; i++) {
+      records.put(new Key(new Object[]{i}), new Record(new Object[]{i, metrics[i]}));
+    }
+    return records;
+  }
+
+  private static void assertRecordOrder(Collection<Record> actual, Map<Key, Record> records, int... expectedIds) {
+    assertEquals(actual.size(), expectedIds.length);
+    int index = 0;
+    for (Record record : actual) {
+      assertSame(record, records.get(new Key(new Object[]{expectedIds[index++]})));
     }
   }
 


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Reuses sort\-key array for rejected candidates, allocating new IntermediateRecord only upon admission\.

```mermaid
flowchart TD
  N0["Compare intermediateRecord with heap#91;0#93; #40;F1#41;"]:::stUnchanged
  N1["Admit candidate#58; replace heap#91;0#93; and downHeap #40;F1#41;"]:::stUnchanged
  N2["Rejected candidate#58; reuse values array #40;F1#41;"]:::stAdded
  N3["Inner loop#58; check mapEntryIterator#46;hasNext#40;#41; #40;F1#41;"]:::stAdded
  N4["Fetch next entry in inner loop #40;F1#41;"]:::stAdded
  N5["Extract orderBy values into reused array #40;F1#41;"]:::stAdded
  N6["Compare updated intermediateRecord with heap#91;0#93; #40;F1#41;"]:::stAdded
  N7["Admit new candidate#58; new IntermediateRecord#44; downHeap#44; break #40;F1#41;"]:::stAdded
  N0 -->|"if true"| N1
  N0 -->|"if false"| N2
  N2 -->|"sequential"| N3
  N3 -->|"while true"| N4
  N3 -->|"while false #40;exit inner loop#41;"| N0
  N4 -->|"sequential"| N5
  N5 -->|"sequential"| N6
  N6 -->|"if true"| N7
  N6 -->|"if false #40;continue inner loop#41;"| N3
  N7 -->|"break #45;#62; continue outer loop"| N0
  N1 -->|"after admit #45;#62; continue outer loop"| N0
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/data/table/TableResizer\.java — [before](https://github.com/apache/pinot/blob/5771d6acea60cd72738116835111cf7c49965373/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java) · [after](https://github.com/apache/pinot/blob/e597d093a71c3c3e2e1c11f2ed4ac94167d2d596/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjU3NzFkNmFjZWE2MGNkNzI3MzgxMTY4MzUxMTFjZjdjNDk5NjUzNzMiLCJjb250ZXh0X2hhc2giOiI2NWViYzNkYTM2MTQ0NGM3ODIyYTdmYmUyNDEwMGQ4YmY0OTEzY2IzMDk2YmYyZDEwYjQwMjY5YzVmNTAyMWE2IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NTIyNTgyLCJoZWFkX3NoYSI6ImU1OTdkMDkzYTcxYzNjM2UyZTFjMTFmMmVkNGFjOTQxNjdkMmQ1OTYiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI1NzcxZDZhY2VhNjBjZDcyNzM4MTE2ODM1MTExY2Y3YzQ5OTY1MzczIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 580f1f95a7e56732ef97c449a3a939bdd526749eda2a24cb6830d1ebc981fd71 -->
<!-- pinot-pr-flow:end -->

GROUP BY top-K trimming allocates sort-key arrays and intermediate wrappers for rejected candidates. Reuse that storage across consecutive rejections; create a wrapper with the current key/record when a candidate is admitted. Immediate admissions retain the existing path, including comparator, tie handling and output order. An admitted row's sort-key array is never subsequently overwritten.

### Reproduction and benchmark

Select top K from a deterministic prepared map of numeric group results. Small/large K retain 20/5,000 of 8,192 groups; the large-N case retains 5,000 of 100,000. Best-first rejects every later candidate; worst-first admits every later candidate. Full-sort/no-trim retain all 8,192 with/without sorting, and unsorted top-K retains 5,000 without ordering the output. Timing includes construction of `TableResizer`, ORDER BY extraction, heap maintenance and optional output sorting; it excludes input-map preparation, SQL parsing, scanning, aggregation, JNI and transport.

Measured against upstream `5771d6acea60cd72738116835111cf7c49965373` on an Apple M2 Max (12 cores, 32 GiB), macOS ARM64 and Temurin JDK 25. Three AB/BA/AB pairs, one fresh JMH fork per case/arm, one thread, 512 MiB heap, three 500 ms warmups and five 500 ms measurements, with GC profiling. Both arms use the same pinned runtime and measurement code; only the `TableResizer` class family differs. Sorted classpath order and runtime hashes were checked. The workstation was shared, with no task builds or other task benchmarks during timing.

### Results

Times and allocations are medians of three arm means. Ratios are medians of paired baseline/candidate time ratios; ranges retain all three pairs. Values above 1 favor the candidate.

| Scenario | Baseline us/op | Candidate us/op | Paired ratio | Pair range | Allocation B/op before -> after | Reduction |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| FULL_SORT | 1357.213 | 1348.913 | 1.002x | 0.968-1.019 | 491307 -> 491307 | 0.0% |
| LARGE_K_BEST_FIRST | 684.138 | 675.338 | 1.012x | 1.001-1.013 | 357073 -> 280489 | 21.4% |
| LARGE_K_RANDOM | 1456.872 | 1457.745 | 0.995x | 0.990-1.016 | 433692 -> 410004 | 5.5% |
| LARGE_K_WORST_FIRST | 1091.692 | 1080.635 | 1.010x | 0.997-1.053 | 433687 -> 433687 | 0.0% |
| LARGE_N_RANDOM | 7392.171 | 6354.504 | 1.160x | 1.156-1.163 | 4840558 -> 1234591 | 74.5% |
| NO_TRIM | 0.091 | 0.092 | 0.998x | 0.923-1.034 | 384 -> 384 | 0.0% |
| SMALL_K_BEST_FIRST | 78.667 | 63.169 | 1.245x | 1.158-1.316 | 197705 -> 1601 | 99.2% |
| SMALL_K_RANDOM | 188.672 | 84.294 | 2.259x | 2.217-2.310 | 393835 -> 10697 | 97.3% |
| SMALL_K_WORST_FIRST | 288.432 | 297.038 | 0.971x | 0.966-0.994 | 393836 -> 393836 | 0.0% |
| UNSORTED_TOP_K | 613.472 | 605.108 | 1.027x | 0.978-1.084 | 433681 -> 409992 | 5.5% |

The small-K all-admitted case is about 3% slower with unchanged allocation; large-K random has a 0.995× median ratio. The no-trim control includes a 0.923× individual pair despite its 0.998× median. These non-wins remain part of the result. This is a controlled component comparison, not packaged deployment throughput or proof that every query benefits.

### Validation

Recorded local validation: 81 tests passed—13 table-resizer, 9 indexed-table, 3 deterministic-indexed-table, 12 sorted-combine and 44 inter-segment GROUP BY tests. Regression coverage includes rejection runs, immediate admissions, exact identities/order, ties, both resize directions, nulls/NaN/signed zero and aggregate-state ownership. Every measurement fork validated complete result membership, uniqueness, ordering, record identity and input preservation against an independent oracle before timing.

Normal compilation/tests, Spotless, Checkstyle and license format/check passed. Independent correctness, testing and performance reviews found no actionable issues. Scoped lint reported no source warnings and four existing dependency-manifest path warnings. Full-reactor Xlint was not repeated after the same-base attempt failed in unchanged Zstandard code on a missing JetBrains annotation.
