### PR TITLE
Batch match-all and sorted document-ID iteration

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/BlockDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/BlockDocIdIterator.java
@@ -18,6 +18,11 @@
  */
 package org.apache.pinot.core.common;
 
+import org.apache.pinot.segment.spi.Constants;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+
 /// The interface `BlockDocIdIterator` represents the iterator for `BlockDocIdSet`. The document
 /// ids returned from the iterator should be in ascending order.
 public interface BlockDocIdIterator extends AutoCloseable {
@@ -28,6 +33,29 @@ public interface BlockDocIdIterator extends AutoCloseable {
   /// NOTE: There should be no more calls to this method after it returns
   /// [org.apache.pinot.segment.spi.Constants#EOF].
   int next();
+
+  /// Writes up to `maxDocs` next matching document ids into the prefix of the caller-owned `output` array and returns
+  /// the number written. Requires `0 < maxDocs <= output.length`. Does not retain the array or modify its remaining
+  /// elements. A full batch does not consume another document to look ahead.
+  ///
+  /// A return value less than `maxDocs` means the iterator is exhausted. There must be no further calls to
+  /// [#next()], [#advance(int)], or this method after a short batch. Otherwise, these methods share the same cursor
+  /// and may be interleaved subject to the target constraint of [#advance(int)]. This method must not be called after
+  /// either scalar method returns [Constants#EOF].
+  ///
+  /// The default implementation preserves scalar iteration for existing implementations.
+  default int nextBatch(int[] output, int maxDocs) {
+    checkArgument(maxDocs > 0 && maxDocs <= output.length);
+    int size = 0;
+    while (size < maxDocs) {
+      int docId = next();
+      if (docId == Constants.EOF) {
+        break;
+      }
+      output[size++] = docId;
+    }
+    return size;
+  }
 
   /// Returns the first matching document whose id is greater than or equal to the given target document id, or
   /// [org.apache.pinot.segment.spi.Constants#EOF] if there is no such document.

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/DocIdSetOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/DocIdSetOperator.java
@@ -26,7 +26,6 @@ import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.DocIdSetBlock;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
-import org.apache.pinot.segment.spi.Constants;
 import org.apache.pinot.spi.query.QueryScanCostContext;
 import org.apache.pinot.spi.query.QueryThreadContext;
 
@@ -51,7 +50,7 @@ public class DocIdSetOperator extends BaseDocIdSetOperator {
 
   private BlockDocIdSet _blockDocIdSet;
   private BlockDocIdIterator _blockDocIdIterator;
-  private int _currentDocId = 0;
+  private boolean _exhausted;
   private long _lastReportedEntriesScanned = 0;
 
   public DocIdSetOperator(BaseFilterOperator filterOperator, int maxSizeOfDocIdSet) {
@@ -62,7 +61,7 @@ public class DocIdSetOperator extends BaseDocIdSetOperator {
 
   @Override
   protected DocIdSetBlock getNextBlock() {
-    if (_currentDocId == Constants.EOF) {
+    if (_exhausted) {
       return null;
     }
 
@@ -74,15 +73,10 @@ public class DocIdSetOperator extends BaseDocIdSetOperator {
 
     QueryThreadContext.sampleUsage();
 
-    int pos = 0;
     int[] docIds = THREAD_LOCAL_DOC_IDS.get();
-    for (int i = 0; i < _maxSizeOfDocIdSet; i++) {
-      _currentDocId = _blockDocIdIterator.next();
-      if (_currentDocId == Constants.EOF) {
-        break;
-      }
-      docIds[pos++] = _currentDocId;
-    }
+    int pos = _blockDocIdIterator.nextBatch(docIds, _maxSizeOfDocIdSet);
+    // A short batch has already consumed EOF in the scalar fallback. Do not call the iterator again.
+    _exhausted = pos < _maxSizeOfDocIdSet;
     if (pos > 0) {
       // Push scan cost delta for proactive query killing
       QueryScanCostContext scanCost = getScanCostContext();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MatchAllDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MatchAllDocIdIterator.java
@@ -21,6 +21,8 @@ package org.apache.pinot.core.operator.dociditerators;
 import org.apache.pinot.core.common.BlockDocIdIterator;
 import org.apache.pinot.segment.spi.Constants;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 
 /// The `MatchAllDocIdIterator` is the iterator for MatchAllDocIdSet where all documents are matching.
 public final class MatchAllDocIdIterator implements BlockDocIdIterator {
@@ -39,6 +41,21 @@ public final class MatchAllDocIdIterator implements BlockDocIdIterator {
     } else {
       return Constants.EOF;
     }
+  }
+
+  @Override
+  public int nextBatch(int[] output, int maxDocs) {
+    checkArgument(maxDocs > 0 && maxDocs <= output.length);
+    int nextDocId = _nextDocId;
+    if (nextDocId >= _numDocs) {
+      return 0;
+    }
+    int size = Math.min(maxDocs, _numDocs - nextDocId);
+    for (int i = 0; i < size; i++) {
+      output[i] = nextDocId + i;
+    }
+    _nextDocId += size;
+    return size;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SortedDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SortedDocIdIterator.java
@@ -23,6 +23,8 @@ import org.apache.pinot.core.common.BlockDocIdIterator;
 import org.apache.pinot.segment.spi.Constants;
 import org.apache.pinot.spi.utils.Pairs.IntPair;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 
 /// The `SortedDocIdIterator` is the iterator for SortedDocIdSet to iterate over a list of matching document id
 /// ranges from a sorted column.
@@ -58,6 +60,30 @@ public final class SortedDocIdIterator implements BlockDocIdIterator {
     } else {
       return Constants.EOF;
     }
+  }
+
+  @Override
+  public int nextBatch(int[] output, int maxDocs) {
+    checkArgument(maxDocs > 0 && maxDocs <= output.length);
+    int size = 0;
+    while (size < maxDocs) {
+      IntPair currentRange = _docIdRanges.get(_currentRangeId);
+      if (_nextDocId > currentRange.getRight()) {
+        if (_currentRangeId == _numRanges - 1) {
+          break;
+        }
+        currentRange = _docIdRanges.get(++_currentRangeId);
+        _nextDocId = currentRange.getLeft();
+      }
+      int nextDocId = _nextDocId;
+      int numDocs = Math.min(maxDocs - size, currentRange.getRight() - nextDocId + 1);
+      for (int i = 0; i < numDocs; i++) {
+        output[size + i] = nextDocId + i;
+      }
+      size += numDocs;
+      _nextDocId += numDocs;
+    }
+    return size;
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/DocIdSetOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/DocIdSetOperatorTest.java
@@ -1,0 +1,428 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.core.common.BlockDocIdIterator;
+import org.apache.pinot.core.common.BlockDocIdSet;
+import org.apache.pinot.core.operator.DocIdOrderedOperator.DocIdOrder;
+import org.apache.pinot.core.operator.blocks.DocIdSetBlock;
+import org.apache.pinot.core.operator.filter.BaseFilterOperator;
+import org.apache.pinot.core.operator.filter.MatchAllFilterOperator;
+import org.apache.pinot.segment.spi.Constants;
+import org.apache.pinot.spi.accounting.ThreadAccountant;
+import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.exception.TerminationException;
+import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryScanCostContext;
+import org.apache.pinot.spi.query.QueryThreadContext;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+
+/// Exercises document block boundaries, query accounting and scratch ownership through public operator pulls.
+/// Every test owns its query context and iterators; only the documented thread-local output buffer is shared.
+public class DocIdSetOperatorTest {
+  @DataProvider
+  public Object[][] blockBoundaries() {
+    return new Object[][]{{0, 2}, {1, 2}, {2, 2}, {3, 2}, {4, 2}, {5, 2}, {8, 3}};
+  }
+
+  @Test(dataProvider = "blockBoundaries")
+  public void testFullPartialAndEmptyTerminalBlocks(int numDocs, int batchSize) {
+    int[] expected = new int[numDocs];
+    for (int i = 0; i < numDocs; i++) {
+      expected[i] = i * 3;
+    }
+    StrictDocIdSet docIdSet = new StrictDocIdSet(expected);
+    FixedFilterOperator filter = new FixedFilterOperator(docIdSet);
+    DocIdSetOperator operator = new DocIdSetOperator(filter, batchSize);
+    ThreadAccountant accountant = mock(ThreadAccountant.class);
+    try (QueryThreadContext ignore = QueryThreadContext.open(QueryExecutionContext.forSseTest(), accountant)) {
+      int publicPulls = 0;
+      for (int offset = 0; offset < numDocs; offset += batchSize) {
+        int length = Math.min(batchSize, numDocs - offset);
+        assertDocIds(operator.nextBlock(), Arrays.copyOfRange(expected, offset, offset + length));
+        publicPulls++;
+        // A full block must not consume a match or EOF beyond its requested prefix.
+        int expectedCalls = offset + length + (length < batchSize ? 1 : 0);
+        assertEquals(docIdSet._nextCalls, expectedCalls);
+      }
+      assertNull(operator.nextBlock());
+      publicPulls++;
+      int activeAttempts = numDocs / batchSize + 1;
+      assertEquals(docIdSet._nextCalls, numDocs + 1);
+      assertEquals(docIdSet._batchCalls, activeAttempts);
+      assertEquals(docIdSet._iteratorCalls, 1);
+      assertEquals(filter._filterCalls, 1);
+
+      assertNull(operator.nextBlock());
+      assertNull(operator.nextBlock());
+      publicPulls += 2;
+      assertEquals(docIdSet._nextCalls, numDocs + 1, "Latched EOF must not call the iterator again");
+      assertEquals(docIdSet._batchCalls, activeAttempts);
+      verify(accountant, times(activeAttempts)).sampleUsage();
+      // Filter initialization has its own checkpoint; every public pull keeps its checkpoint even after EOF.
+      verify(accountant, times(publicPulls + 1)).waitIfPaused();
+    }
+  }
+
+  @Test
+  public void testStoppingAfterFullBlockDoesNotConsumeNextMatch() {
+    StrictDocIdSet docIdSet = new StrictDocIdSet(new int[]{1, 4, 9});
+    DocIdSetOperator operator = new DocIdSetOperator(new FixedFilterOperator(docIdSet), 2);
+    try (QueryThreadContext ignore = QueryThreadContext.openForSseTest()) {
+      assertDocIds(operator.nextBlock(), 1, 4);
+      assertEquals(docIdSet._nextCalls, 2);
+      assertEquals(docIdSet._batchCalls, 1);
+      assertEquals(docIdSet.next(), 9, "A selection limit can stop without discarding the next match");
+    }
+  }
+
+  @Test
+  public void testOperatorUsesIteratorBatchOverride() {
+    BulkOnlyDocIdSet docIdSet = new BulkOnlyDocIdSet();
+    DocIdSetOperator operator = new DocIdSetOperator(new FixedFilterOperator(docIdSet), 2);
+    try (QueryThreadContext ignore = QueryThreadContext.openForSseTest()) {
+      assertDocIds(operator.nextBlock(), 2, 6);
+      assertDocIds(operator.nextBlock(), 10);
+      assertNull(operator.nextBlock());
+      assertNull(operator.nextBlock());
+      assertEquals(docIdSet._batchCalls, 2);
+    }
+  }
+
+  @DataProvider
+  public Object[][] scanCostTails() {
+    return new Object[][]{
+        {new int[0], new long[]{20}, 0L},
+        {new int[]{2, 6}, new long[]{3, 7, 20}, 7L},
+        {new int[]{2, 6, 9}, new long[]{3, 7, 10, 20}, 20L}
+    };
+  }
+
+  @Test(dataProvider = "scanCostTails")
+  public void testScanCostPreservesUnmatchedTerminalTail(int[] docIds, long[] scanTotals, long expectedPushedCost) {
+    StrictDocIdSet docIdSet = new StrictDocIdSet(docIds, scanTotals);
+    DocIdSetOperator operator = new DocIdSetOperator(new FixedFilterOperator(docIdSet), 2);
+    QueryExecutionContext executionContext = QueryExecutionContext.forSseTest();
+    QueryScanCostContext scanCost = new QueryScanCostContext();
+    executionContext.setQueryScanCostContext(scanCost);
+    try (QueryThreadContext ignore = QueryThreadContext.open(executionContext, mock(ThreadAccountant.class))) {
+      assertEquals(operator.getExecutionStatistics().getNumEntriesScannedInFilter(), 0L);
+      while (operator.nextBlock() != null) {
+        // Consume the full stream, including any unmatched tail found while looking for EOF.
+      }
+      // Existing proactive accounting only publishes deltas with a nonempty block. Final statistics include all scans.
+      assertEquals(scanCost.getNumEntriesScannedInFilter(), expectedPushedCost);
+      ExecutionStatistics statistics = operator.getExecutionStatistics();
+      assertEquals(statistics.getNumEntriesScannedInFilter(), 20L);
+      assertEquals(statistics.getNumDocsScanned(), 0L);
+      assertEquals(statistics.getNumEntriesScannedPostFilter(), 0L);
+      assertEquals(statistics.getNumTotalDocs(), 0L);
+      assertNull(operator.nextBlock());
+      assertEquals(scanCost.getNumEntriesScannedInFilter(), expectedPushedCost);
+      assertEquals(docIdSet._nextCalls, docIds.length + 1);
+    }
+  }
+
+  @Test
+  public void testOnlyPositiveScanCostDeltasArePublished() {
+    long initialCost = (long) Integer.MAX_VALUE + 5;
+    StrictDocIdSet docIdSet = new StrictDocIdSet(new int[]{1, 3, 5, 7},
+        new long[]{initialCost, initialCost, initialCost - 2, initialCost + 3, initialCost + 6});
+    DocIdSetOperator operator = new DocIdSetOperator(new FixedFilterOperator(docIdSet), 1);
+    QueryExecutionContext executionContext = QueryExecutionContext.forSseTest();
+    QueryScanCostContext scanCost = new QueryScanCostContext();
+    executionContext.setQueryScanCostContext(scanCost);
+    try (QueryThreadContext ignore = QueryThreadContext.open(executionContext, mock(ThreadAccountant.class))) {
+      assertDocIds(operator.nextBlock(), 1);
+      assertEquals(scanCost.getNumEntriesScannedInFilter(), initialCost);
+      assertDocIds(operator.nextBlock(), 3);
+      assertEquals(scanCost.getNumEntriesScannedInFilter(), initialCost);
+      assertDocIds(operator.nextBlock(), 5);
+      assertEquals(scanCost.getNumEntriesScannedInFilter(), initialCost);
+      assertDocIds(operator.nextBlock(), 7);
+      assertEquals(scanCost.getNumEntriesScannedInFilter(), initialCost + 3);
+      assertNull(operator.nextBlock());
+      assertEquals(scanCost.getNumEntriesScannedInFilter(), initialCost + 3);
+      assertEquals(operator.getExecutionStatistics().getNumEntriesScannedInFilter(), initialCost + 6);
+    }
+  }
+
+  @DataProvider
+  public Object[][] cancellationStates() {
+    return new Object[][]{{new int[0]}, {new int[]{1}}, {new int[]{1, 3, 5}}};
+  }
+
+  @Test(dataProvider = "cancellationStates")
+  public void testCancellationBetweenPublicPullsIncludesLatchedEof(int[] docIds) {
+    StrictDocIdSet docIdSet = new StrictDocIdSet(docIds);
+    DocIdSetOperator operator = new DocIdSetOperator(new FixedFilterOperator(docIdSet), 2);
+    QueryExecutionContext executionContext = QueryExecutionContext.forSseTest();
+    ThreadAccountant accountant = mock(ThreadAccountant.class);
+    try (QueryThreadContext ignore = QueryThreadContext.open(executionContext, accountant)) {
+      DocIdSetBlock firstBlock = operator.nextBlock();
+      if (docIds.length == 0) {
+        assertNull(firstBlock);
+      } else {
+        assertDocIds(firstBlock, Arrays.copyOf(docIds, Math.min(docIds.length, 2)));
+      }
+      int nextCallsBeforeCancellation = docIdSet._nextCalls;
+      assertTrue(executionContext.terminate(QueryErrorCode.QUERY_CANCELLATION, "cancel between document blocks"));
+      TerminationException failure = expectThrows(TerminationException.class, operator::nextBlock);
+      assertSame(failure, executionContext.getTerminateException());
+      assertEquals(docIdSet._nextCalls, nextCallsBeforeCancellation);
+      assertEquals(docIdSet._batchCalls, 1);
+      verify(accountant).sampleUsage();
+    }
+  }
+
+  @Test
+  public void testCancellationBeforeFirstPullDoesNotInitializeFilter() {
+    StrictDocIdSet docIdSet = new StrictDocIdSet(new int[]{1});
+    FixedFilterOperator filter = new FixedFilterOperator(docIdSet);
+    DocIdSetOperator operator = new DocIdSetOperator(filter, 2);
+    QueryExecutionContext executionContext = QueryExecutionContext.forSseTest();
+    ThreadAccountant accountant = mock(ThreadAccountant.class);
+    try (QueryThreadContext ignore = QueryThreadContext.open(executionContext, accountant)) {
+      assertTrue(executionContext.terminate(QueryErrorCode.QUERY_CANCELLATION, "cancel before document blocks"));
+      TerminationException failure = expectThrows(TerminationException.class, operator::nextBlock);
+      assertSame(failure, executionContext.getTerminateException());
+      assertEquals(filter._filterCalls, 0);
+      assertEquals(docIdSet._iteratorCalls, 0);
+      assertEquals(docIdSet._batchCalls, 0);
+      verify(accountant, never()).sampleUsage();
+    }
+  }
+
+  @Test
+  public void testScratchRemainsSharedAcrossOperatorsOnOneThread() {
+    DocIdSetOperator first = new DocIdSetOperator(new MatchAllFilterOperator(5), 2);
+    DocIdSetOperator second = new DocIdSetOperator(new FixedFilterOperator(
+        new StrictDocIdSet(new int[]{10, 12, 14})), 2);
+    try (QueryThreadContext ignore = QueryThreadContext.openForSseTest()) {
+      DocIdSetBlock firstBlock = first.nextBlock();
+      assertDocIds(firstBlock, 0, 1);
+      int[] retainedCopy = Arrays.copyOf(firstBlock.getDocIds(), firstBlock.getLength());
+      DocIdSetBlock secondBlock = second.nextBlock();
+      assertDocIds(secondBlock, 10, 12);
+      assertSame(firstBlock.getDocIds(), secondBlock.getDocIds());
+      assertDocIds(firstBlock, 10, 12);
+      assertEquals(retainedCopy, new int[]{0, 1});
+
+      DocIdSetBlock nextFirstBlock = first.nextBlock();
+      assertDocIds(nextFirstBlock, 2, 3);
+      assertSame(nextFirstBlock.getDocIds(), firstBlock.getDocIds());
+      assertDocIds(secondBlock, 2, 3);
+      assertEquals(retainedCopy, new int[]{0, 1});
+    }
+  }
+
+  @Test
+  public void testScratchIsIsolatedBetweenThreads()
+      throws Exception {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try (QueryThreadContext ignore = QueryThreadContext.openForSseTest()) {
+      DocIdSetOperator operator = new DocIdSetOperator(new MatchAllFilterOperator(4), 2);
+      DocIdSetBlock localBlock = operator.nextBlock();
+      assertDocIds(localBlock, 0, 1);
+      DocIdSetBlock otherBlock = executor.submit(() -> {
+        try (QueryThreadContext otherContext = QueryThreadContext.openForSseTest()) {
+          return new DocIdSetOperator(new FixedFilterOperator(new StrictDocIdSet(new int[]{10, 12})), 2).nextBlock();
+        }
+      }).get(10, TimeUnit.SECONDS);
+      assertDocIds(otherBlock, 10, 12);
+      assertNotSame(localBlock.getDocIds(), otherBlock.getDocIds());
+      assertDocIds(operator.nextBlock(), 2, 3);
+      assertDocIds(otherBlock, 10, 12);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  public void testWithOrderKeepsReverseMaterialization() {
+    StrictDocIdSet docIdSet = new StrictDocIdSet(new int[]{2, 7, 8, 13, 21});
+    FixedFilterOperator filter = new FixedFilterOperator(docIdSet);
+    DocIdSetOperator ascending = new DocIdSetOperator(filter, 2);
+    assertTrue(ascending.isCompatibleWith(DocIdOrder.ASC));
+    assertFalse(ascending.isCompatibleWith(DocIdOrder.DESC));
+    assertSame(ascending.withOrder(DocIdOrder.ASC), ascending);
+    BaseDocIdSetOperator descending = ascending.withOrder(DocIdOrder.DESC);
+    assertTrue(descending instanceof ReverseDocIdSetOperator);
+    assertSame(descending.withOrder(DocIdOrder.DESC), descending);
+    assertTrue(descending.withOrder(DocIdOrder.ASC) instanceof DocIdSetOperator);
+    assertEquals(ascending.getChildOperators(), List.of(filter));
+    assertEquals(descending.getChildOperators(), List.of(filter));
+    try (QueryThreadContext ignore = QueryThreadContext.openForSseTest()) {
+      assertDocIds(descending.nextBlock(), 21, 13);
+      assertDocIds(descending.nextBlock(), 8, 7);
+      assertDocIds(descending.nextBlock(), 2);
+      assertNull(descending.nextBlock());
+      assertNull(descending.nextBlock());
+      assertEquals(docIdSet._nextCalls, 6);
+      assertEquals(docIdSet._batchCalls, 0, "Reverse bitmap materialization retains its existing scalar path");
+      assertEquals(filter._filterCalls, 1);
+    }
+  }
+
+  private static void assertDocIds(DocIdSetBlock block, int... expected) {
+    assertNotNull(block);
+    assertEquals(block.getLength(), expected.length);
+    assertEquals(Arrays.copyOf(block.getDocIds(), block.getLength()), expected);
+  }
+
+  /// A filter with an observable one-time initialization and the real public operator checkpoint.
+  private static final class FixedFilterOperator extends BaseFilterOperator {
+    private final BlockDocIdSet _docIdSet;
+    private int _filterCalls;
+
+    private FixedFilterOperator(BlockDocIdSet docIdSet) {
+      super(32, false);
+      _docIdSet = docIdSet;
+    }
+
+    @Override
+    protected BlockDocIdSet getTrues() {
+      _filterCalls++;
+      return _docIdSet;
+    }
+
+    @Override
+    public String toExplainString() {
+      return "TEST_FILTER";
+    }
+
+    @Override
+    public List<BaseFilterOperator> getChildOperators() {
+      return List.of();
+    }
+  }
+
+  /// Scalar-backed fixture that rejects all iterator operations after its first terminal result.
+  private static final class StrictDocIdSet implements BlockDocIdSet, BlockDocIdIterator {
+    private final int[] _docIds;
+    private final long[] _scanTotals;
+    private int _iteratorCalls;
+    private int _nextCalls;
+    private int _batchCalls;
+    private boolean _exhausted;
+
+    private StrictDocIdSet(int[] docIds) {
+      this(docIds, new long[docIds.length + 1]);
+    }
+
+    private StrictDocIdSet(int[] docIds, long[] scanTotals) {
+      _docIds = docIds;
+      _scanTotals = scanTotals;
+    }
+
+    @Override
+    public BlockDocIdIterator iterator() {
+      assertEquals(++_iteratorCalls, 1, "The filter iterator must only be acquired once");
+      return this;
+    }
+
+    @Override
+    public int next() {
+      assertFalse(_exhausted, "Iterator called after terminal EOF");
+      int position = _nextCalls++;
+      if (position == _docIds.length) {
+        _exhausted = true;
+        return Constants.EOF;
+      }
+      return _docIds[position];
+    }
+
+    @Override
+    public int nextBatch(int[] output, int maxDocs) {
+      assertFalse(_exhausted, "Batch called after terminal EOF");
+      _batchCalls++;
+      return BlockDocIdIterator.super.nextBatch(output, maxDocs);
+    }
+
+    @Override
+    public int advance(int targetDocId) {
+      throw new AssertionError("Document block pulls must not advance the iterator");
+    }
+
+    @Override
+    public long getNumEntriesScannedInFilter() {
+      return _nextCalls == 0 ? 0 : _scanTotals[_nextCalls - 1];
+    }
+  }
+
+  /// An optimized batch source whose scalar APIs are deliberately unavailable to the operator.
+  private static final class BulkOnlyDocIdSet implements BlockDocIdSet, BlockDocIdIterator {
+    private final int[] _docIds = {2, 6, 10};
+    private int _position;
+    private int _batchCalls;
+    private boolean _exhausted;
+
+    @Override
+    public BlockDocIdIterator iterator() {
+      return this;
+    }
+
+    @Override
+    public int nextBatch(int[] output, int maxDocs) {
+      assertFalse(_exhausted, "Batch called after terminal EOF");
+      assertEquals(maxDocs, 2, "The operator must pass its configured block size");
+      _batchCalls++;
+      int length = Math.min(maxDocs, _docIds.length - _position);
+      System.arraycopy(_docIds, _position, output, 0, length);
+      _position += length;
+      _exhausted = length < maxDocs;
+      return length;
+    }
+
+    @Override
+    public int next() {
+      throw new AssertionError("Operator bypassed the batch override");
+    }
+
+    @Override
+    public int advance(int targetDocId) {
+      throw new AssertionError("Operator unexpectedly advanced a batch iterator");
+    }
+
+    @Override
+    public long getNumEntriesScannedInFilter() {
+      return 0;
+    }
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/dociditerators/DocIdIteratorBatchTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/dociditerators/DocIdIteratorBatchTest.java
@@ -1,0 +1,253 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.dociditerators;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import org.apache.pinot.core.common.BlockDocIdIterator;
+import org.apache.pinot.segment.spi.Constants;
+import org.apache.pinot.spi.utils.Pairs.IntPair;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.expectThrows;
+
+
+/// Exercises the shared cursor, caller-owned output and terminal-batch contract of document-id iterators.
+/// Each test uses its own mutable iterator and may run independently.
+public class DocIdIteratorBatchTest {
+  private static final int UNWRITTEN = -123456;
+
+  @DataProvider
+  public Object[][] batchBoundaries() {
+    List<Object[]> cases = new ArrayList<>();
+    for (int capacity : new int[]{1, 255, 256, 257, 10000}) {
+      for (int numDocs : new int[]{0, 1, capacity - 1, capacity, capacity + 1}) {
+        cases.add(new Object[]{capacity, numDocs});
+      }
+    }
+    return cases.toArray(new Object[0][]);
+  }
+
+  @Test(dataProvider = "batchBoundaries")
+  public void testBatchBoundaries(int capacity, int numDocs) {
+    int[] expected = IntStream.range(0, numDocs).toArray();
+    assertBatches(new MatchAllDocIdIterator(numDocs), capacity, expected);
+    assertBatches(new ScalarIterator(expected), capacity, expected);
+    if (numDocs > 0) {
+      assertBatches(new SortedDocIdIterator(List.of(new IntPair(0, numDocs - 1))), capacity, expected);
+    } else {
+      assertBatches(EmptyDocIdIterator.getInstance(), capacity, expected);
+    }
+  }
+
+  @DataProvider
+  public Object[][] sortedRanges() {
+    return new Object[][]{
+        {List.of(new IntPair(7, 7)), new int[]{7}},
+        {List.of(new IntPair(1, 2), new IntPair(3, 3), new IntPair(4, 6)), new int[]{1, 2, 3, 4, 5, 6}},
+        {List.of(new IntPair(1, 3), new IntPair(8, 11), new IntPair(18, 20)),
+            new int[]{1, 2, 3, 8, 9, 10, 11, 18, 19, 20}},
+        {List.of(new IntPair(Integer.MAX_VALUE - 8, Integer.MAX_VALUE - 7),
+            new IntPair(Integer.MAX_VALUE - 4, Integer.MAX_VALUE - 1)),
+            new int[]{Integer.MAX_VALUE - 8, Integer.MAX_VALUE - 7, Integer.MAX_VALUE - 4,
+                Integer.MAX_VALUE - 3, Integer.MAX_VALUE - 2, Integer.MAX_VALUE - 1}}
+    };
+  }
+
+  @Test(dataProvider = "sortedRanges")
+  public void testSortedRangeTransitions(List<IntPair> ranges, int[] expected) {
+    for (int capacity : new int[]{1, 2, 3, 4, 256}) {
+      assertBatches(new SortedDocIdIterator(ranges), capacity, expected);
+    }
+  }
+
+  @Test
+  public void testSortedScalarAdvanceAndBatchShareCursor() {
+    BlockDocIdIterator iterator = new SortedDocIdIterator(
+        List.of(new IntPair(1, 3), new IntPair(8, 11), new IntPair(18, 20)));
+    assertEquals(iterator.next(), 1);
+    assertBatch(iterator, 2, 2, 3);
+    assertEquals(iterator.advance(5), 8);
+    assertBatch(iterator, 2, 9, 10);
+    assertEquals(iterator.next(), 11);
+    assertBatch(iterator, 1, 18);
+    assertEquals(iterator.advance(20), 20);
+    assertBatch(iterator, 2);
+  }
+
+  @Test
+  public void testMatchAllScalarAdvanceAndBatchShareCursor() {
+    BlockDocIdIterator iterator = new MatchAllDocIdIterator(13);
+    assertEquals(iterator.next(), 0);
+    assertBatch(iterator, 3, 1, 2, 3);
+    assertEquals(iterator.advance(7), 7);
+    assertBatch(iterator, 2, 8, 9);
+    assertEquals(iterator.next(), 10);
+    assertBatch(iterator, 3, 11, 12);
+  }
+
+  @Test
+  public void testMatchAllNearMaximumDocumentId() {
+    BlockDocIdIterator iterator = new MatchAllDocIdIterator(Integer.MAX_VALUE);
+    assertEquals(iterator.advance(Integer.MAX_VALUE - 4), Integer.MAX_VALUE - 4);
+    assertBatch(iterator, 4, Integer.MAX_VALUE - 3, Integer.MAX_VALUE - 2, Integer.MAX_VALUE - 1);
+  }
+
+  @Test
+  public void testDefaultDoesNotLookAheadOrRetainOutput() {
+    ScalarIterator iterator = new ScalarIterator(new int[]{1, 2, 3, 8, 9});
+    int[] output = new int[2];
+    assertEquals(iterator.nextBatch(output, 2), 2);
+    assertEquals(output, new int[]{1, 2});
+    assertEquals(iterator._numNextCalls, 2);
+    // Changing caller-owned storage cannot change the iterator's next result.
+    Arrays.fill(output, UNWRITTEN);
+    assertEquals(iterator.next(), 3);
+    assertEquals(iterator.advance(8), 8);
+    assertBatch(iterator, 2, 9);
+    assertEquals(iterator._numNextCalls, 6);
+  }
+
+  @Test
+  public void testInvalidCapacityDoesNotConsumeOrWrite() {
+    for (BlockDocIdIterator iterator : List.of(new MatchAllDocIdIterator(3),
+        new SortedDocIdIterator(List.of(new IntPair(0, 2))), new ScalarIterator(new int[]{0, 1, 2}))) {
+      int[] output = {UNWRITTEN, UNWRITTEN};
+      expectThrows(IllegalArgumentException.class, () -> iterator.nextBatch(output, 0));
+      expectThrows(IllegalArgumentException.class, () -> iterator.nextBatch(output, -1));
+      expectThrows(IllegalArgumentException.class, () -> iterator.nextBatch(output, 3));
+      expectThrows(IllegalArgumentException.class, () -> iterator.nextBatch(new int[0], 1));
+      assertEquals(output, new int[]{UNWRITTEN, UNWRITTEN});
+      assertEquals(iterator.next(), 0);
+    }
+  }
+
+  @DataProvider
+  public Object[][] fallbackIterators() {
+    Supplier<BlockDocIdIterator> bitmap = () -> bitmap(1, 2, 3, 8, 9, 10, 11, 18, 19, 20);
+    Supplier<BlockDocIdIterator> and = () -> new AndDocIdIterator(new BlockDocIdIterator[]{
+        bitmap(1, 2, 3, 8, 9, 10, 18, 19, 20), bitmap(0, 2, 3, 4, 9, 10, 11, 19, 20)});
+    Supplier<BlockDocIdIterator> or = () -> new OrDocIdIterator(new BlockDocIdIterator[]{
+        bitmap(1, 3, 8, 9, 18, 20), bitmap(2, 3, 10, 11, 19, 20)});
+    Supplier<BlockDocIdIterator> not = () -> new NotDocIdIterator(bitmap(0, 3, 7, 9), 12);
+    Supplier<BlockDocIdIterator> notOverOr = () -> new NotDocIdIterator(new OrDocIdIterator(
+        new BlockDocIdIterator[]{bitmap(0, 3, 7, 9), bitmap(1, 3, 8, 10)}), 12);
+    Supplier<BlockDocIdIterator> fullExclusion = () -> new NotDocIdIterator(bitmap(0, 1, 2, 3), 4);
+    return new Object[][]{
+        {bitmap, new int[]{1, 2, 3, 8, 9, 10, 11, 18, 19, 20}},
+        {and, new int[]{2, 3, 9, 10, 19, 20}},
+        {or, new int[]{1, 2, 3, 8, 9, 10, 11, 18, 19, 20}},
+        {not, new int[]{1, 2, 4, 5, 6, 8, 10, 11}},
+        {notOverOr, new int[]{2, 4, 5, 6, 11}},
+        {fullExclusion, new int[0]}
+    };
+  }
+
+  @Test(dataProvider = "fallbackIterators")
+  public void testDefaultFallbacks(Supplier<BlockDocIdIterator> factory, int[] expected) {
+    for (int capacity : new int[]{1, 2, 3, 256}) {
+      assertBatches(factory.get(), capacity, expected);
+    }
+    BlockDocIdIterator scalar = factory.get();
+    for (int docId : expected) {
+      assertEquals(scalar.next(), docId);
+    }
+    assertEquals(scalar.next(), Constants.EOF);
+
+    // Compare scalar and batched progress while alternately skipping and requesting documents.
+    if (expected.length > 5) {
+      BlockDocIdIterator mixed = factory.get();
+      scalar = factory.get();
+      assertEquals(mixed.next(), scalar.next());
+      assertEquals(mixed.advance(expected[2]), scalar.advance(expected[2]));
+      assertBatch(mixed, 2, scalar.next(), scalar.next());
+      assertEquals(mixed.advance(expected[expected.length - 1]), scalar.advance(expected[expected.length - 1]));
+      assertBatch(mixed, 2);
+      assertEquals(scalar.next(), Constants.EOF);
+    }
+  }
+
+  private static BitmapDocIdIterator bitmap(int... docIds) {
+    MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+    bitmap.add(docIds);
+    return new BitmapDocIdIterator(bitmap, 32);
+  }
+
+  private static void assertBatches(BlockDocIdIterator iterator, int capacity, int[] expected) {
+    int offset = 0;
+    while (true) {
+      int size = Math.min(capacity, expected.length - offset);
+      assertBatch(iterator, capacity, Arrays.copyOfRange(expected, offset, offset + size));
+      offset += size;
+      if (size < capacity) {
+        break;
+      }
+    }
+    assertEquals(offset, expected.length);
+  }
+
+  private static void assertBatch(BlockDocIdIterator iterator, int capacity, int... expected) {
+    int[] output = new int[capacity + 2];
+    Arrays.fill(output, UNWRITTEN);
+    assertEquals(iterator.nextBatch(output, capacity), expected.length);
+    assertEquals(Arrays.copyOf(output, expected.length), expected);
+    for (int i = expected.length; i < output.length; i++) {
+      assertEquals(output[i], UNWRITTEN);
+    }
+  }
+
+  /// Models the public scalar contract, including its prohibition on post-EOF calls.
+  private static final class ScalarIterator implements BlockDocIdIterator {
+    private final int[] _docIds;
+    private int _position;
+    private int _numNextCalls;
+    private boolean _exhausted;
+
+    private ScalarIterator(int[] docIds) {
+      _docIds = docIds;
+    }
+
+    @Override
+    public int next() {
+      if (_exhausted) {
+        throw new IllegalStateException("Iterator called after EOF");
+      }
+      _numNextCalls++;
+      if (_position == _docIds.length) {
+        _exhausted = true;
+        return Constants.EOF;
+      }
+      return _docIds[_position++];
+    }
+
+    @Override
+    public int advance(int targetDocId) {
+      while (_position < _docIds.length && _docIds[_position] < targetDocId) {
+        _position++;
+      }
+      return next();
+    }
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DocIdBatchNullQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DocIdBatchNullQueriesTest.java
@@ -1,0 +1,275 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.IntPredicate;
+import java.util.stream.IntStream;
+import javax.annotation.Nullable;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.common.BlockDocIdIterator;
+import org.apache.pinot.core.operator.DocIdSetOperator;
+import org.apache.pinot.core.operator.blocks.DocIdSetBlock;
+import org.apache.pinot.core.operator.dociditerators.EmptyDocIdIterator;
+import org.apache.pinot.core.operator.dociditerators.MatchAllDocIdIterator;
+import org.apache.pinot.core.operator.dociditerators.SortedDocIdIterator;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.core.plan.FilterPlanNode;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.creator.SegmentVersion;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.query.QueryThreadContext;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+/// Verifies nullable group aggregation across full and tail doc-id blocks and separately executed server responses.
+/// The fixture belongs to this test instance; it has no shared mutable state with other query tests.
+public class DocIdBatchNullQueriesTest extends BaseQueriesTest {
+  private static final String TABLE = "DocIdBatchNullQueriesTest";
+  private static final int FIRST_ROWS = 10017;
+  private static final int TOTAL_ROWS = FIRST_ROWS + 3;
+  private static final Map<String, String> OPTIONS = Map.of("enableNullHandling", "true", "skipStarTree", "true",
+      "maxExecutionThreads", "1", "numGroupsLimit", "100");
+
+  private final List<IndexSegment> _segments = new ArrayList<>(2);
+  private File _directory;
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    _directory = Files.createTempDirectory("doc-id-batch-null-queries").toFile();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE).setSortedColumn("s")
+        .setNoDictionaryColumns(List.of("m")).build();
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE).addSingleValueDimension("s", DataType.INT)
+        .addSingleValueDimension("g", DataType.INT).addMetric("m", DataType.DOUBLE).build();
+    for (int segmentId = 0; segmentId < 2; segmentId++) {
+      int start = segmentId == 0 ? 0 : FIRST_ROWS;
+      int end = segmentId == 0 ? FIRST_ROWS : TOTAL_ROWS;
+      List<GenericRow> rows = new ArrayList<>(end - start);
+      for (int id = start; id < end; id++) {
+        GenericRow row = new GenericRow();
+        row.putValue("s", id);
+        row.putValue("g", group(id));
+        row.putValue("m", metric(id));
+        rows.add(row);
+      }
+      String segmentName = "segment-" + segmentId;
+      SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+      config.setOutDir(_directory.getPath());
+      config.setSegmentName(segmentName);
+      config.setSegmentVersion(SegmentVersion.v3);
+      config.setDefaultNullHandlingEnabled(true);
+      SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+      try (GenericRowRecordReader reader = new GenericRowRecordReader(rows)) {
+        driver.init(config, reader);
+        driver.build();
+      }
+      IndexSegment segment = ImmutableSegmentLoader.load(new File(_directory, segmentName), ReadMode.mmap);
+      _segments.add(segment);
+      assertTrue(segment.getDataSource("s").getDataSourceMetadata().isSorted());
+      assertNotNull(segment.getDataSource("s").getDictionary());
+      assertNull(segment.getDataSource("m").getDictionary());
+      assertNotNull(segment.getDataSource("m").getNullValueVector());
+      assertTrue(segment.getStarTrees() == null || segment.getStarTrees().isEmpty());
+    }
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void tearDown()
+      throws Exception {
+    for (IndexSegment segment : _segments) {
+      segment.destroy();
+    }
+    if (_directory != null) {
+      FileUtils.deleteDirectory(_directory);
+    }
+  }
+
+  @Override
+  protected String getFilter() {
+    return "";
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _segments.get(0);
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _segments;
+  }
+
+  @Override
+  protected List<List<IndexSegment>> getDistinctInstances() {
+    return List.of(List.of(_segments.get(0)), List.of(_segments.get(1)));
+  }
+
+  @DataProvider
+  public Object[][] filters() {
+    IntPredicate all = id -> true;
+    IntPredicate range = id -> id >= 5;
+    IntPredicate gaps = id -> id != 7 && id != 10000;
+    IntPredicate tail = id -> id >= 10015;
+    IntPredicate allNull = id -> id == 3;
+    IntPredicate empty = id -> id > 20000;
+    return new Object[][]{
+        {"", all}, {" WHERE s >= 5", range}, {" WHERE s NOT IN (7, 10000)", gaps},
+        {" WHERE s >= 10015", tail}, {" WHERE s = 3", allNull}, {" WHERE s > 20000", empty}
+    };
+  }
+
+  @Test(dataProvider = "filters")
+  public void testNullableGroupByAcrossBatches(String filter, IntPredicate matches) {
+    String query = "SELECT g AS group_key, SUM(m) AS total_value, AVG(m) AS average_value,"
+        + " COUNT(*) AS row_count, COUNT(m) AS value_count FROM " + TABLE + filter
+        + " GROUP BY g ORDER BY g NULLS FIRST LIMIT 100";
+    verifyDocIdBlocks(query, matches);
+
+    Map<Integer, ExpectedGroup> groups = new TreeMap<>(Comparator.nullsFirst(Comparator.naturalOrder()));
+    long numDocs = 0;
+    for (int id = 0; id < TOTAL_ROWS; id++) {
+      if (matches.test(id)) {
+        numDocs++;
+        ExpectedGroup expected = groups.computeIfAbsent(group(id), ignored -> new ExpectedGroup());
+        expected._numRows++;
+        Double metric = metric(id);
+        if (metric != null) {
+          expected._sum += metric;
+          expected._numValues++;
+        }
+      }
+    }
+    List<Object[]> expectedRows = new ArrayList<>(groups.size());
+    groups.forEach((key, values) -> expectedRows.add(new Object[]{key,
+        values._numValues == 0 ? null : values._sum,
+        values._numValues == 0 ? null : values._sum / values._numValues, values._numRows, values._numValues}));
+
+    BrokerResponseNative response = getBrokerResponse(query, OPTIONS);
+    assertFalse(response.isPartialResult(), response.getExceptions().toString());
+    assertEquals(response.getTotalDocs(), TOTAL_ROWS);
+    assertEquals(response.getNumDocsScanned(), numDocs);
+    assertEquals(response.getNumEntriesScannedInFilter(), 0L);
+    assertEquals(response.getNumEntriesScannedPostFilter(), numDocs * 2);
+    ResultTable result = response.getResultTable();
+    assertNotNull(result);
+    assertEquals(result.getDataSchema().getColumnNames(),
+        new String[]{"group_key", "total_value", "average_value", "row_count", "value_count"});
+    assertEquals(result.getDataSchema().getColumnDataTypes(), new ColumnDataType[]{ColumnDataType.INT,
+        ColumnDataType.DOUBLE, ColumnDataType.DOUBLE, ColumnDataType.LONG, ColumnDataType.LONG});
+    assertEquals(result.getRows().size(), expectedRows.size());
+    for (int row = 0; row < expectedRows.size(); row++) {
+      assertEquals(result.getRows().get(row), expectedRows.get(row), "Row " + row + " for " + query);
+    }
+  }
+
+  private void verifyDocIdBlocks(String query, IntPredicate matches) {
+    try (QueryThreadContext ignored = QueryThreadContext.openForSseTest()) {
+      for (int segmentId = 0; segmentId < _segments.size(); segmentId++) {
+        int start = segmentId == 0 ? 0 : FIRST_ROWS;
+        int end = segmentId == 0 ? FIRST_ROWS : TOTAL_ROWS;
+        int[] expected = IntStream.range(start, end).filter(matches).map(id -> id - start).toArray();
+        IndexSegment segment = _segments.get(segmentId);
+        try (BlockDocIdIterator iterator = new FilterPlanNode(new SegmentContext(segment), context(query)).run()
+            .nextBlock().getBlockDocIdSet().iterator()) {
+          if (expected.length == 0) {
+            assertTrue(iterator instanceof EmptyDocIdIterator);
+          } else if (expected.length == end - start) {
+            assertTrue(iterator instanceof MatchAllDocIdIterator);
+          } else {
+            assertTrue(iterator instanceof SortedDocIdIterator);
+          }
+        }
+        DocIdSetOperator operator = new DocIdSetOperator(
+            new FilterPlanNode(new SegmentContext(segment), context(query)).run(), DocIdSetPlanNode.MAX_DOC_PER_CALL);
+        int offset = 0;
+        DocIdSetBlock block;
+        while ((block = operator.nextBlock()) != null) {
+          int expectedSize = Math.min(DocIdSetPlanNode.MAX_DOC_PER_CALL, expected.length - offset);
+          assertEquals(block.getLength(), expectedSize);
+          for (int i = 0; i < expectedSize; i++) {
+            assertEquals(block.getDocIds()[i], expected[offset++]);
+          }
+        }
+        assertEquals(offset, expected.length);
+        assertNull(operator.nextBlock());
+      }
+    }
+  }
+
+  private static QueryContext context(String sql) {
+    PinotQuery query = CalciteSqlParser.compileToPinotQuery(sql);
+    query.setQueryOptions(new HashMap<>(OPTIONS));
+    QueryContext context = QueryContextConverterUtils.getQueryContext(query);
+    context.setEndTimeMs(System.currentTimeMillis() + 60_000);
+    return context;
+  }
+
+  @Nullable
+  private static Integer group(int id) {
+    return id % 11 == 0 ? null : id % 4;
+  }
+
+  @Nullable
+  private static Double metric(int id) {
+    // Group 3 has only null metrics; other groups mix null and non-null values.
+    return id % 4 == 3 || id % 7 == 0 ? null : (id % 17 - 8) * 0.25;
+  }
+
+  /// Independent exact-quarter arithmetic oracle, including rows excluded by COUNT(metric).
+  private static final class ExpectedGroup {
+    private double _sum;
+    private long _numRows;
+    private long _numValues;
+  }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

DocIdSetOperator uses BlockDocIdIterator\.nextBatch, overridden by MatchAll and Sorted iterators for fast batch paths\.

```mermaid
flowchart TD
  N0["BlockDocIdIterator #40;F1#41;"]:::stAdded
  N1["MatchAllDocIdIterator #40;F3#41;"]:::stAdded
  N2["SortedDocIdIterator #40;F4#41;"]:::stAdded
  N3["DocIdSetOperator #40;F2#41;"]:::stModified
  N3 -->|"calls nextBatch"| N0
  N0 -->|"overrides"| N1
  N0 -->|"overrides"| N2
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/common/BlockDocIdIterator\.java — [before](https://github.com/apache/pinot/blob/5771d6acea60cd72738116835111cf7c49965373/pinot-core/src/main/java/org/apache/pinot/core/common/BlockDocIdIterator.java) · [after](https://github.com/apache/pinot/blob/d538aed249148563a02a0be50a836b76c1d8a3b0/pinot-core/src/main/java/org/apache/pinot/core/common/BlockDocIdIterator.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/operator/DocIdSetOperator\.java — [before](https://github.com/apache/pinot/blob/5771d6acea60cd72738116835111cf7c49965373/pinot-core/src/main/java/org/apache/pinot/core/operator/DocIdSetOperator.java) · [after](https://github.com/apache/pinot/blob/d538aed249148563a02a0be50a836b76c1d8a3b0/pinot-core/src/main/java/org/apache/pinot/core/operator/DocIdSetOperator.java)
- F3: pinot\-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MatchAllDocIdIterator\.java — [before](https://github.com/apache/pinot/blob/5771d6acea60cd72738116835111cf7c49965373/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MatchAllDocIdIterator.java) · [after](https://github.com/apache/pinot/blob/d538aed249148563a02a0be50a836b76c1d8a3b0/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MatchAllDocIdIterator.java)
- F4: pinot\-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SortedDocIdIterator\.java — [before](https://github.com/apache/pinot/blob/5771d6acea60cd72738116835111cf7c49965373/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SortedDocIdIterator.java) · [after](https://github.com/apache/pinot/blob/d538aed249148563a02a0be50a836b76c1d8a3b0/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SortedDocIdIterator.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjU3NzFkNmFjZWE2MGNkNzI3MzgxMTY4MzUxMTFjZjdjNDk5NjUzNzMiLCJjb250ZXh0X2hhc2giOiIwYWJiMGFkZWUxZjg5OGMxMDBkYmYwNjBkYzg3NDliN2ZiM2JiYTkxY2UxOTMwYzJlYjg5NWUwMzQwZTY3ODAyIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NTIyNjk2LCJoZWFkX3NoYSI6ImQ1MzhhZWQyNDkxNDg1NjNhMDJhMGJlNTBhODM2Yjc2YzFkOGEzYjAiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI1NzcxZDZhY2VhNjBjZDcyNzM4MTE2ODM1MTExY2Y3YzQ5OTY1MzczIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature c79bce5694f8dc08cd92bfc0c36508fb49e623be2dbedee9d8b14f633290073a -->
<!-- pinot-pr-flow:end -->

Match-all and sorted-range queries fill document blocks through one `next()` call per row. Add `BlockDocIdIterator.nextBatch` with a compatible scalar default and contiguous fast paths, then use it from `DocIdSetOperator` with its existing scratch array. A short batch latches exhaustion; EOF, checkpoints, cancellation and scan accounting are preserved. Predicate/bitmap iterators retain the default path, and reverse iteration is unchanged.

### Reproduction and benchmark

Query two immutable v3 MMAP segments containing 2,000,000 and 1,000,017 rows with star-tree disabled. Global row ID determines four columns: sorted dictionary `s=floor(id*100/3000017)`, dictionary group key `g=id%32`, unsorted inverted-index `b=id%100`, and raw PASS_THROUGH DOUBLE `m=(id%127-63)*0.25+(id<2000000?0:0.5)`. Exercise match-all SUM/AVG, contiguous/multiple/excluded sorted ranges, full 32-group SUM/AVG/COUNT, bitmap/predicate controls, metadata COUNT and LIMIT 1.

Timing includes SQL preparation, sequential server plan construction/execution on the two distinct segments, separate response serialization, wire decoding and broker reduction. Server execution and broker reduction limits are one worker each; the owned executor has two backing threads. Data is warmed by validation before timing. Fixture generation, ingestion, HTTP/network, admission queues, concurrent-server capacity and metric publication are excluded.

Measured against upstream `5771d6acea60cd72738116835111cf7c49965373` on an Apple M2 Max (12 cores, 32 GiB), macOS ARM64 and Temurin JDK 25. Three AB/BA/AB pairs, one fresh JMH fork per case/arm, one benchmark thread, 512 MiB initial/1 GiB maximum heap, three 500 ms warmups and five 500 ms measurements, with GC profiling. Both arms use identical measurement code and pinned runtimes; only four production classes differ. Source, runtime and fixture hashes were checked before/after each arm. Ordinary shared-host activity remained; no task builds or other task benchmarks ran during timing.

### Results

Times and bytes are medians of three arm means; ratios are medians of paired baseline/candidate times. Values above 1 favor the candidate. Allocation reduction is the median of paired percentage reductions, so it need not equal the reduction calculated from displayed median bytes.

| Scenario | Baseline us/op | Candidate us/op | Paired ratio | All pair ratios | Allocation B/op before -> after | Reduction |
| --- | ---: | ---: | ---: | --- | ---: | ---: |
| BITMAP_CONTROL | 2388.549 | 2119.116 | 1.128x | 1.077, 1.128, 1.129 | 806129 -> 806035 | 0.0% |
| BITMAP_SCAN_CONTROL | 3180.026 | 3149.215 | 1.010x | 1.010, 1.024, 0.998 | 2317570 -> 2317493 | 0.0% |
| GROUP_MATCH_ALL | 9813.154 | 8771.338 | 1.119x | 1.114, 1.129, 1.119 | 570686 -> 570348 | 0.1% |
| MATCH_ALL | 7793.917 | 6791.657 | 1.126x | 1.104, 1.126, 1.159 | 355977 -> 355688 | 0.1% |
| METADATA_CONTROL | 64.927 | 65.517 | 1.007x | 1.007, 0.985, 1.020 | 141090 -> 141158 | -0.0% |
| RAW_SCAN_CONTROL | 10283.779 | 10186.739 | 1.005x | 1.005, 0.995, 1.020 | 347736 -> 347726 | -0.0% |
| SORTED_GAPS | 12716.417 | 7056.726 | 1.802x | 1.746, 1.802, 1.814 | 404597 -> 396846 | 1.9% |
| SORTED_RANGE | 6390.525 | 3695.951 | 1.729x | 1.678, 1.734, 1.729 | 342191 -> 341062 | 0.3% |
| SORTED_RANGES | 1431.947 | 892.460 | 1.650x | 1.650, 1.714, 1.600 | 333240 -> 332073 | 0.4% |
| TINY_SELECTION | 53.437 | 52.917 | 1.003x | 1.003, 0.994, 1.037 | 143411 -> 143330 | 0.0% |

Allocation is mostly unchanged. Controls retain mixed individual outcomes: the largest individual slowdown was 1.508%, in metadata COUNT. These are bounded in-process query results, not deployment goodput, equal-p99 capacity, universal all-query improvement or a 10× result.

### Validation

Recorded local validation: 148 tests across 19 classes passed with no failures/errors/skips. Coverage includes scalar/batch/advance interleaving, terminal boundaries, scratch ownership, cancellation/checkpoints, scan accounting, bitmap/AND/OR/NOT/scan defaults, real nullable scalar/GROUP BY aggregation and selection. Every measurement fork checked physical iterator/operator paths, all result cells and schema, total documents and exact scan counters twice before warmup.

The fixture owns and closes its executor/reducer; all ten cases also passed while reusing one state in one JVM on each arm, and a separate JMH smoke fork exited cleanly. An initial harness pilot leaked inherited executor threads and timed out during shutdown; no complete pair was accepted, and none of its values are included above.

Standard compilation/package, Spotless, Checkstyle, license format/check and Apache RAT passed. Independent source, lifecycle and measurement reviews found no remaining issues. Compiler checks retain four existing dependency-manifest path warnings, an existing raw `Operator` generic warning and intentional scope-lifetime try warnings; this is not a warning-free claim. A prior full-reactor Xlint attempt failed in unchanged Zstandard code on a missing JetBrains annotation and remains separate from the successful standard compiler checks.
