### PR TITLE
init tracking commit

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java
@@ -64,7 +64,6 @@ public class DispatchablePlanContext {
   private int _leafStagesAssigned;
   private int _leafStagesEmpty;
 
-
   public DispatchablePlanContext(WorkerManager workerManager, long requestId, PlannerContext plannerContext,
       PairList<Integer, String> resultFields, Set<String> tableNames) {
     _workerManager = workerManager;
@@ -174,6 +173,10 @@ public class DispatchablePlanContext {
           dispatchablePlanMetadata.getWorkerIdToMailboxesMap();
       Preconditions.checkArgument(workerIdToSegmentsMap == null || workerIdToTableNameSegmentsMap == null,
           "Both workerIdToSegmentsMap and workerIdToTableNameSegmentsMap cannot be set at the same time");
+      Map<Integer, Map<String, List<String>>> workerIdToOptionalSegmentsMap =
+          dispatchablePlanMetadata.getWorkerIdToOptionalSegmentsMap();
+      Map<Integer, Map<String, List<String>>> workerIdToOptionalTableSegmentsMap =
+          dispatchablePlanMetadata.getWorkerIdToOptionalTableSegmentsMap();
       Map<QueryServerInstance, List<Integer>> serverInstanceToWorkerIdsMap = new HashMap<>();
       WorkerMetadata[] workerMetadataArray = new WorkerMetadata[workerIdToServerInstanceMap.size()];
       for (Map.Entry<Integer, QueryServerInstance> serverEntry : workerIdToServerInstanceMap.entrySet()) {
@@ -183,9 +186,21 @@ public class DispatchablePlanContext {
         WorkerMetadata workerMetadata = new WorkerMetadata(workerId, workerIdToMailboxesMap.get(workerId));
         if (workerIdToSegmentsMap != null) {
           workerMetadata.setTableSegmentsMap(workerIdToSegmentsMap.get(workerId));
+          if (workerIdToOptionalSegmentsMap != null) {
+            Map<String, List<String>> optionalForWorker = workerIdToOptionalSegmentsMap.get(workerId);
+            if (optionalForWorker != null && !optionalForWorker.isEmpty()) {
+              workerMetadata.setOptionalTableSegmentsMap(optionalForWorker);
+            }
+          }
         }
         if (workerIdToTableNameSegmentsMap != null) {
           workerMetadata.setLogicalTableSegmentsMap(workerIdToTableNameSegmentsMap.get(workerId));
+          if (workerIdToOptionalTableSegmentsMap != null) {
+            Map<String, List<String>> optionalLogical = workerIdToOptionalTableSegmentsMap.get(workerId);
+            if (optionalLogical != null && !optionalLogical.isEmpty()) {
+              workerMetadata.setOptionalTableSegmentsMap(optionalLogical);
+            }
+          }
         }
         workerMetadataArray[workerId] = workerMetadata;
       }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanMetadata.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanMetadata.java
@@ -82,6 +82,11 @@ public class DispatchablePlanMetadata implements Serializable {
   private Map<Integer, Map<String, List<String>>> _workerIdToTableSegmentsMap;
   private LogicalTableRouteInfo _logicalTableRouteInfo;
 
+  @Nullable
+  private Map<Integer, Map<String, List<String>>> _workerIdToOptionalSegmentsMap;
+  @Nullable
+  private Map<Integer, Map<String, List<String>>> _workerIdToOptionalTableSegmentsMap;
+
   public List<String> getScannedTables() {
     return _scannedTables;
   }
@@ -199,4 +204,25 @@ public class DispatchablePlanMetadata implements Serializable {
       Map<Integer, Map<String, List<String>>> workerIdToTableSegmentsMap) {
     _workerIdToTableSegmentsMap = workerIdToTableSegmentsMap;
   }
+
+  @Nullable
+  public Map<Integer, Map<String, List<String>>> getWorkerIdToOptionalSegmentsMap() {
+    return _workerIdToOptionalSegmentsMap;
+  }
+
+  public void setWorkerIdToOptionalSegmentsMap(
+      @Nullable Map<Integer, Map<String, List<String>>> workerIdToOptionalSegmentsMap) {
+    _workerIdToOptionalSegmentsMap = workerIdToOptionalSegmentsMap;
+  }
+
+  @Nullable
+  public Map<Integer, Map<String, List<String>>> getWorkerIdToOptionalTableSegmentsMap() {
+    return _workerIdToOptionalTableSegmentsMap;
+  }
+
+  public void setWorkerIdToOptionalTableSegmentsMap(
+      @Nullable Map<Integer, Map<String, List<String>>> workerIdToOptionalTableSegmentsMap) {
+    _workerIdToOptionalTableSegmentsMap = workerIdToOptionalTableSegmentsMap;
+  }
+
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -560,6 +561,8 @@ public class WorkerManager {
 
     // extract all the instances associated to each table type
     Map<ServerInstance, Map<String, List<String>>> serverInstanceToSegmentsMap = new HashMap<>();
+    Map<ServerInstance, Map<String, List<String>>> serverInstanceToOptionalSegmentsMap = new HashMap<>();
+
     for (Map.Entry<String, RoutingTable> routingEntry : routingTableMap.entrySet()) {
       String tableType = routingEntry.getKey();
       RoutingTable routingTable = routingEntry.getValue();
@@ -568,9 +571,13 @@ public class WorkerManager {
       for (Map.Entry<ServerInstance, SegmentsToQuery> serverEntry : segmentsMap.entrySet()) {
         Map<String, List<String>> tableTypeToSegmentListMap =
             serverInstanceToSegmentsMap.computeIfAbsent(serverEntry.getKey(), k -> new HashMap<>());
-        // TODO: support optional segments for multi-stage engine.
+        Map<String, List<String>> tableTypeToOptionalSegmentListMap =
+            serverInstanceToOptionalSegmentsMap.computeIfAbsent(serverEntry.getKey(), k -> new HashMap<>());
         Preconditions.checkState(tableTypeToSegmentListMap.put(tableType, serverEntry.getValue().getSegments()) == null,
             "Entry for server {} and table type: {} already exist!", serverEntry.getKey(), tableType);
+        Preconditions.checkState(
+            tableTypeToOptionalSegmentListMap.put(tableType, serverEntry.getValue().getOptionalSegments()) == null,
+            "Optional Segment Entry for server {} and table type: {} already exist!", serverEntry.getKey(), tableType);
       }
 
       // attach unavailable segments to metadata
@@ -580,6 +587,11 @@ public class WorkerManager {
       if (routingPinotQuery != null) {
         context.addNumSegmentsPrunedByBroker(routingTable.getNumPrunedSegments());
       }
+    }
+    if (serverInstanceToSegmentsMap.isEmpty()) {
+      assignWorkersForNonPartitionedLeafSegmentsWhenNoServersHaveSegments(metadata, tableName, routingTableMap, context,
+          metadata.getTimeBoundaryInfo());
+      return;
     }
     // Sort server instances to ensure deterministic worker ID assignment.
     // This is critical for pre-partitioned exchanges where worker ID N on one stage
@@ -592,19 +604,25 @@ public class WorkerManager {
     int numWorkers = sortedServerInstanceToSegmentsMap.size();
     Map<Integer, QueryServerInstance> workerIdToServerInstanceMap = Maps.newHashMapWithExpectedSize(numWorkers);
     Map<Integer, Map<String, List<String>>> workerIdToSegmentsMap = Maps.newHashMapWithExpectedSize(numWorkers);
+    Map<Integer, Map<String, List<String>>> workerIdToOptionalSegmentMap = Maps.newHashMapWithExpectedSize(numWorkers);
 
     for (int workerId = 0; workerId < numWorkers; workerId++) {
       Map.Entry<ServerInstance, Map<String, List<String>>> serverEntry =
           sortedServerInstanceToSegmentsMap.get(workerId);
       QueryServerInstance server = new QueryServerInstance(serverEntry.getKey());
       Map<String, List<String>> segmentsMap = serverEntry.getValue();
+      Map<String, List<String>> optionalSegmentMap = serverInstanceToOptionalSegmentsMap.get(serverEntry.getKey());
 
       workerIdToServerInstanceMap.put(workerId, server);
       workerIdToSegmentsMap.put(workerId, segmentsMap);
+      if (!MapUtils.isEmpty(optionalSegmentMap)) {
+        workerIdToOptionalSegmentMap.put(workerId, optionalSegmentMap);
+      }
     }
 
     metadata.setWorkerIdToServerInstanceMap(workerIdToServerInstanceMap);
     metadata.setWorkerIdToSegmentsMap(workerIdToSegmentsMap);
+    metadata.setWorkerIdToOptionalSegmentsMap(workerIdToOptionalSegmentMap);
   }
 
   /// Acquire routing table for items listed in [org.apache.pinot.query.planner.plannode.TableScanNode].
@@ -737,9 +755,17 @@ public class WorkerManager {
       }
     }
 
-    // TODO: Support unavailable segments and optional segments for replicated leaf stage
     metadata.setReplicatedSegments(segmentsMap);
     filterReplicatedLeafStageSegments(context, metadata);
+
+    Map<String, RoutingTable> routingTableMap =
+        getRoutingTable(tableName, context.getRequestId(), context.getPlannerContext().getOptions());
+    for (Map.Entry<String, RoutingTable> routingEntry : routingTableMap.entrySet()) {
+      RoutingTable routingTable = routingEntry.getValue();
+      if (!routingTable.getUnavailableSegments().isEmpty()) {
+        metadata.addUnavailableSegments(tableName, routingTable.getUnavailableSegments());
+      }
+    }
   }
 
   /// Extension point to filter the non-replicated leaf-stage per-worker segment assignment; no-op by default.
@@ -864,13 +890,16 @@ public class WorkerManager {
       DispatchablePlanMetadata metadata) {
     Map<ServerInstance, Map<String, List<String>>> serverInstanceToLogicalSegmentsMap =
         new HashMap<>();
+    Map<ServerInstance, Map<String, List<String>>> serverInstanceToLogicalOptionalSegmentsMap =
+        new HashMap<>();
 
     if (logicalTableRouteInfo.getOfflineTables() != null) {
       for (TableRouteInfo physicalTableRoute : logicalTableRouteInfo.getOfflineTables()) {
         // Routing table maybe null if no routing table is found OR there are no segments.
         if (physicalTableRoute.getOfflineRoutingTable() != null) {
           transferToServerInstanceLogicalSegmentsMap(physicalTableRoute.getOfflineTableName(),
-              physicalTableRoute.getOfflineRoutingTable(), serverInstanceToLogicalSegmentsMap);
+              physicalTableRoute.getOfflineRoutingTable(), serverInstanceToLogicalSegmentsMap,
+              serverInstanceToLogicalOptionalSegmentsMap);
         }
       }
     }
@@ -880,7 +909,8 @@ public class WorkerManager {
         // Routing table maybe null if no routing table is found OR there are no segments.
         if (physicalTableRoute.getRealtimeRoutingTable() != null) {
           transferToServerInstanceLogicalSegmentsMap(physicalTableRoute.getRealtimeTableName(),
-              physicalTableRoute.getRealtimeRoutingTable(), serverInstanceToLogicalSegmentsMap);
+              physicalTableRoute.getRealtimeRoutingTable(), serverInstanceToLogicalSegmentsMap,
+              serverInstanceToLogicalOptionalSegmentsMap);
         }
       }
     }
@@ -914,20 +944,25 @@ public class WorkerManager {
 
   private static void transferToServerInstanceLogicalSegmentsMap(String physicalTableName,
       Map<ServerInstance, SegmentsToQuery> segmentsMap,
-      Map<ServerInstance, Map<String, List<String>>> serverInstanceToLogicalSegmentsMap) {
+      Map<ServerInstance, Map<String, List<String>>> serverInstanceToLogicalSegmentsMap,
+      Map<ServerInstance, Map<String, List<String>>> serverInstanceToOptionalLogicalSegmentsMap) {
     for (Map.Entry<ServerInstance, SegmentsToQuery> serverEntry : segmentsMap.entrySet()) {
       Map<String, List<String>> tableNameToSegmentsMap =
           serverInstanceToLogicalSegmentsMap.computeIfAbsent(serverEntry.getKey(), k -> new HashMap<>());
-      // TODO: support optional segments for multi-stage engine.
       Preconditions.checkState(
           tableNameToSegmentsMap.put(physicalTableName, serverEntry.getValue().getSegments()) == null,
           "Entry for server {} and physical table: {} already exist!", serverEntry.getKey(), physicalTableName);
+      List<String> optionalSegments = serverEntry.getValue().getOptionalSegments();
+      if (CollectionUtils.isNotEmpty(optionalSegments)) {
+        serverInstanceToOptionalLogicalSegmentsMap.computeIfAbsent(serverEntry.getKey(), k -> new HashMap<>())
+            .put(physicalTableName, new ArrayList<>(optionalSegments));
+      }
     }
   }
 
   // --------------------------------------------------------------------------
-  // Partitioned leaf stage assignment
-  // --------------------------------------------------------------------------
+// Partitioned leaf stage assignment
+// --------------------------------------------------------------------------
   private void assignWorkersToPartitionedLeafFragment(DispatchablePlanMetadata metadata,
       DispatchablePlanContext context, String partitionKey, Map<String, String> tableOptions,
       @Nullable PinotQuery routingPinotQuery) {
@@ -1402,5 +1437,36 @@ public class WorkerManager {
       Preconditions.checkState(realtimeSegments != null, "Both offline and realtime segments are null");
       return Map.of(TableType.REALTIME.name(), realtimeSegments);
     }
+  }
+
+  private void assignWorkersForNonPartitionedLeafSegmentsWhenNoServersHaveSegments(DispatchablePlanMetadata metadata,
+      String tableName, Map<String, RoutingTable> routingTableMap, DispatchablePlanContext context,
+      @Nullable TimeBoundaryInfo timeBoundaryInfo) {
+    Set<String> serversRoutingToTable = _routingManager.getServingInstances(tableName);
+    if (CollectionUtils.isEmpty(serversRoutingToTable)) {
+      LOGGER.error("[RequestId: {}] No routable server for empty routing on table: {}", context.getRequestId(),
+          tableName);
+      throw new IllegalStateException("No routable server for empty routing on table: " + tableName);
+    }
+
+    Map<String, ServerInstance> serverInstanceMap = _routingManager.getRoutableServerInstanceMap();
+    ServerInstance serverInstance = serverInstanceMap.get(serversRoutingToTable.iterator().next());
+    Map<String, List<String>> emptySegmentsMap = new HashMap<>();
+    for (String tableType : routingTableMap.keySet()) {
+      emptySegmentsMap.put(tableType, List.of());
+    }
+    if (emptySegmentsMap.isEmpty()) {
+      TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
+      if (tableType != null) {
+        emptySegmentsMap.put(tableType.name(), List.of());
+      } else if (timeBoundaryInfo != null) {
+        emptySegmentsMap.put(TableType.OFFLINE.name(), List.of());
+        emptySegmentsMap.put(TableType.REALTIME.name(), List.of());
+      } else {
+        emptySegmentsMap.put(TableType.OFFLINE.name(), List.of());
+      }
+    }
+    metadata.setWorkerIdToServerInstanceMap(Map.of(0, new QueryServerInstance(serverInstance)));
+    metadata.setWorkerIdToSegmentsMap(Map.of(0, emptySegmentsMap));
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerMetadata.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerMetadata.java
@@ -41,6 +41,7 @@ import org.apache.pinot.spi.utils.JsonUtils;
 public class WorkerMetadata {
   public static final String TABLE_SEGMENTS_MAP_KEY = "tableSegmentsMap";
   public static final String LOGICAL_TABLE_SEGMENTS_MAP_KEY = "logicalTableSegmentsMap";
+  public static final String OPTIONAL_TABLE_SEGMENTS_MAP_KEY = "optionalTableSegmentsMap";
 
   private final int _workerId;
   private final Map<Integer, MailboxInfos> _mailboxInfosMap;
@@ -118,5 +119,20 @@ public class WorkerMetadata {
       throw new RuntimeException("Unable to serialize table segments map: " + logicalTableSegmentsMap, e);
     }
     _customProperties.put(LOGICAL_TABLE_SEGMENTS_MAP_KEY, logicalTableSegmentsMapStr);
+  }
+
+  @Nullable
+  public Map<String, List<String>> getOptionalTableSegmentsMap() {
+    return deserializeStringSegmentListMap(OPTIONAL_TABLE_SEGMENTS_MAP_KEY);
+  }
+
+  public void setOptionalTableSegmentsMap(Map<String, List<String>> optionalTableSegmentsMap) {
+    String json;
+    try {
+      json = JsonUtils.objectToString(optionalTableSegmentsMap);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Unable to serialize optional table segments map: " + optionalTableSegmentsMap, e);
+    }
+    _customProperties.put(OPTIONAL_TABLE_SEGMENTS_MAP_KEY, json);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -156,12 +157,15 @@ public class ServerPlanRequestUtils {
     String rawTableName = TableNameBuilder.extractRawTableName(stageMetadata.getTableName());
     Map<String, List<String>> tableSegmentsMap = executionContext.getWorkerMetadata().getTableSegmentsMap();
     assert tableSegmentsMap != null;
+    Map<String, List<String>> optionalSegmentsMap =
+        executionContext.getWorkerMetadata().getOptionalTableSegmentsMap();
     TimeBoundaryInfo timeBoundary = stageMetadata.getTimeBoundary();
     int numRequests = tableSegmentsMap.size();
     if (numRequests == 1) {
       Map.Entry<String, List<String>> entry = tableSegmentsMap.entrySet().iterator().next();
       String tableType = entry.getKey();
       List<String> segments = entry.getValue();
+      List<String> optionalSegments = optionalListOrNull(optionalSegmentsMap, tableType);
       if (tableType.equals(TableType.OFFLINE.name())) {
         String offlineTableName = TableNameBuilder.forType(TableType.OFFLINE).tableNameWithType(rawTableName);
         TableDataManager tableDataManager = instanceDataManager.getTableDataManager(offlineTableName);
@@ -170,7 +174,7 @@ public class ServerPlanRequestUtils {
         Pair<TableConfig, Schema> tableConfigAndSchema = tableDataManager.getCachedTableConfigAndSchema();
         return List.of(compileInstanceRequest(executionContext, pinotQuery, timeBoundary, TableType.OFFLINE,
             tableDataManager.getTableName(), tableConfigAndSchema.getLeft(), tableConfigAndSchema.getRight(), segments,
-            null));
+            null, optionalSegments));
       } else {
         assert tableType.equals(TableType.REALTIME.name());
         String realtimeTableName = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(rawTableName);
@@ -180,12 +184,14 @@ public class ServerPlanRequestUtils {
         Pair<TableConfig, Schema> tableConfigAndSchema = tableDataManager.getCachedTableConfigAndSchema();
         return List.of(compileInstanceRequest(executionContext, pinotQuery, timeBoundary, TableType.REALTIME,
             tableDataManager.getTableName(), tableConfigAndSchema.getLeft(), tableConfigAndSchema.getRight(), segments,
-            null));
+            null, optionalSegments));
       }
     } else {
       assert numRequests == 2;
       List<String> offlineSegments = tableSegmentsMap.get(TableType.OFFLINE.name());
       List<String> realtimeSegments = tableSegmentsMap.get(TableType.REALTIME.name());
+      List<String> offlineOptional = optionalListOrNull(optionalSegmentsMap, TableType.OFFLINE.name());
+      List<String> realtimeOptional = optionalListOrNull(optionalSegmentsMap, TableType.REALTIME.name());
       assert offlineSegments != null && realtimeSegments != null;
       String offlineTableName = TableNameBuilder.forType(TableType.OFFLINE).tableNameWithType(rawTableName);
       TableDataManager offlineTableDataManager = instanceDataManager.getTableDataManager(offlineTableName);
@@ -202,10 +208,10 @@ public class ServerPlanRequestUtils {
       return List.of(
           compileInstanceRequest(executionContext, new PinotQuery(pinotQuery), timeBoundary, TableType.OFFLINE,
               offlineTableDataManager.getTableName(), offlineTableConfigAndSchema.getLeft(),
-              offlineTableConfigAndSchema.getRight(), offlineSegments, null),
+              offlineTableConfigAndSchema.getRight(), offlineSegments, null, offlineOptional),
           compileInstanceRequest(executionContext, pinotQuery, timeBoundary, TableType.REALTIME,
               realtimeTableDataManager.getTableName(), realtimeTableConfigAndSchema.getLeft(),
-              realtimeTableConfigAndSchema.getRight(), realtimeSegments, null));
+              realtimeTableConfigAndSchema.getRight(), realtimeSegments, null, realtimeOptional));
     }
   }
 
@@ -213,7 +219,7 @@ public class ServerPlanRequestUtils {
   private static InstanceRequest compileInstanceRequest(OpChainExecutionContext executionContext, PinotQuery pinotQuery,
       @Nullable TimeBoundaryInfo timeBoundaryInfo, TableType tableType,
       String tableNameWithType, TableConfig tableConfig, Schema schema, @Nullable List<String> segmentList,
-      @Nullable List<TableSegmentsInfo> tableRouteInfoList) {
+      @Nullable List<TableSegmentsInfo> tableRouteInfoList, @Nullable List<String> optionalSegmentList) {
     Preconditions.checkArgument(segmentList == null || tableRouteInfoList == null,
         "Either segmentList OR tableRouteInfoList should be set");
 
@@ -257,6 +263,9 @@ public class ServerPlanRequestUtils {
       instanceRequest.setSearchSegments(segmentList);
     } else {
       instanceRequest.setTableSegmentsInfoList(tableRouteInfoList);
+    }
+    if (CollectionUtils.isNotEmpty(optionalSegmentList)) {
+      instanceRequest.setOptionalSegments(optionalSegmentList);
     }
     instanceRequest.setQuery(brokerRequest);
 
@@ -420,6 +429,8 @@ public class ServerPlanRequestUtils {
         executionContext.getWorkerMetadata().getLogicalTableSegmentsMap();
     List<TableSegmentsInfo> offlineTableRouteInfoList = new ArrayList<>();
     List<TableSegmentsInfo> realtimeTableRouteInfoList = new ArrayList<>();
+    Map<String, List<String>> optionalLogicalTableSegmentsMap =
+        executionContext.getWorkerMetadata().getOptionalTableSegmentsMap();
 
     Preconditions.checkNotNull(logicalTableSegmentsMap);
     for (Map.Entry<String, List<String>> entry : logicalTableSegmentsMap.entrySet()) {
@@ -428,6 +439,12 @@ public class ServerPlanRequestUtils {
       TableSegmentsInfo tableSegmentsInfo = new TableSegmentsInfo();
       tableSegmentsInfo.setTableName(physicalTableName);
       tableSegmentsInfo.setSegments(entry.getValue());
+      if (optionalLogicalTableSegmentsMap != null) {
+        List<String> optionalSegments = optionalLogicalTableSegmentsMap.get(physicalTableName);
+        if (CollectionUtils.isNotEmpty(optionalSegments)) {
+          tableSegmentsInfo.setOptionalSegments(new ArrayList<>(optionalSegments));
+        }
+      }
       if (tableType == TableType.REALTIME) {
         realtimeTableRouteInfoList.add(tableSegmentsInfo);
       } else {
@@ -447,14 +464,14 @@ public class ServerPlanRequestUtils {
         return List.of(
             compileInstanceRequest(executionContext, pinotQuery, timeBoundaryInfo, TableType.OFFLINE, offlineTableName,
                 logicalTableContext.getRefOfflineTableConfig(), logicalTableContext.getLogicalTableSchema(), null,
-                routeInfoList));
+                routeInfoList,null));
       } else {
         Preconditions.checkNotNull(logicalTableContext.getRefRealtimeTableConfig());
         String realtimeTableName = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(logicalTableName);
         return List.of(
             compileInstanceRequest(executionContext, pinotQuery, timeBoundaryInfo, TableType.REALTIME,
                 realtimeTableName, logicalTableContext.getRefRealtimeTableConfig(),
-                logicalTableContext.getLogicalTableSchema(), null, routeInfoList));
+                logicalTableContext.getLogicalTableSchema(), null, routeInfoList,null));
       }
     } else {
       Preconditions.checkNotNull(logicalTableContext.getRefOfflineTableConfig());
@@ -466,10 +483,20 @@ public class ServerPlanRequestUtils {
       return List.of(
           compileInstanceRequest(executionContext, offlinePinotQuery, timeBoundaryInfo, TableType.OFFLINE,
               offlineTableName, logicalTableContext.getRefOfflineTableConfig(),
-              logicalTableContext.getLogicalTableSchema(), null, offlineTableRouteInfoList),
+              logicalTableContext.getLogicalTableSchema(), null, offlineTableRouteInfoList,null),
           compileInstanceRequest(executionContext, realtimePinotQuery, timeBoundaryInfo, TableType.REALTIME,
               realtimeTableName, logicalTableContext.getRefRealtimeTableConfig(),
-              logicalTableContext.getLogicalTableSchema(), null, realtimeTableRouteInfoList));
+              logicalTableContext.getLogicalTableSchema(), null, realtimeTableRouteInfoList,null));
     }
+  }
+
+  @Nullable
+  private static List<String> optionalListOrNull(@Nullable Map<String, List<String>> optionalSegmentsMap,
+      String tableTypeKey) {
+    if (optionalSegmentsMap == null) {
+      return null;
+    }
+    List<String> list = optionalSegmentsMap.get(tableTypeKey);
+    return CollectionUtils.isEmpty(list) ? null : list;
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds optional segment handling from plan metadata through worker assignment to runtime request construction\.

```mermaid
flowchart TD
  N0["DispatchablePlanMetadata optional segments #40;F2#41;"]:::stAdded
  N1["DispatchablePlanContext build fragments #40;F1#41;"]:::stModified
  N2["WorkerManager assign workers #40;F3#41;"]:::stModified
  N3["WorkerMetadata optional table segments #40;F4#41;"]:::stModified
  N4["ServerPlanRequestUtils add optional segments #40;F5#41;"]:::stModified
  N2 -->|"sets optional segments map"| N0
  N0 -->|"reads optional segments map"| N1
  N1 -->|"sets worker optional table segments"| N3
  N3 -->|"reads optional table segments for request"| N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-query\-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext\.java — [before](https://github.com/apache/pinot/blob/bff2f5d607e61d05e8964848f7fed8c61161efbe/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java) · [after](https://github.com/apache/pinot/blob/59bdad5606c048a200a476c9c2ee5a7b6e486e11/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java)
- F2: pinot\-query\-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanMetadata\.java — [before](https://github.com/apache/pinot/blob/bff2f5d607e61d05e8964848f7fed8c61161efbe/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanMetadata.java) · [after](https://github.com/apache/pinot/blob/59bdad5606c048a200a476c9c2ee5a7b6e486e11/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanMetadata.java)
- F3: pinot\-query\-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager\.java — [before](https://github.com/apache/pinot/blob/bff2f5d607e61d05e8964848f7fed8c61161efbe/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java) · [after](https://github.com/apache/pinot/blob/59bdad5606c048a200a476c9c2ee5a7b6e486e11/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java)
- F4: pinot\-query\-planner/src/main/java/org/apache/pinot/query/routing/WorkerMetadata\.java — [before](https://github.com/apache/pinot/blob/bff2f5d607e61d05e8964848f7fed8c61161efbe/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerMetadata.java) · [after](https://github.com/apache/pinot/blob/59bdad5606c048a200a476c9c2ee5a7b6e486e11/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerMetadata.java)
- F5: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils\.java — [before](https://github.com/apache/pinot/blob/bff2f5d607e61d05e8964848f7fed8c61161efbe/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java) · [after](https://github.com/apache/pinot/blob/59bdad5606c048a200a476c9c2ee5a7b6e486e11/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImJmZjJmNWQ2MDdlNjFkMDVlODk2NDg0OGY3ZmVkOGM2MTE2MWVmYmUiLCJjb250ZXh0X2hhc2giOiJjZTkxNjkzZDdkYTc0ZmVhNzgxZTU1OGE0ODY2ZWI1MmRjZDg1YmY1ODYxYmVmNDFkYzQ2NjRkMjFjZDM4NmFhIiwiZ2VuZXJhdGVkX2F0IjoxNzg5OTkxMzQ0LCJoZWFkX3NoYSI6IjU5YmRhZDU2MDZjMDQ4YTIwMGE0NzZjOWMyZWU1YTdiNmU0ODZlMTEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI1NzcxZDZhY2VhNjBjZDcyNzM4MTE2ODM1MTExY2Y3YzQ5OTY1MzczIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature e7bde5ecd7ffdd21327a2a26c1bce51686da7b730f0d376cd76475bcd0809a48 -->
<!-- pinot-pr-flow:end -->

Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
